### PR TITLE
Add in-repo planning and reference documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing
 
+## Before you start
+
+Read these documents before writing code. They are the source of truth
+for what is done, what is next, and which design decisions are locked.
+
+- [PLAN.md](PLAN.md) for current state, the single in-flight task, and invariants.
+- [docs/PHYSICS.md](docs/PHYSICS.md) for equations, scaling conventions, and boundary conditions.
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the layered design and the imports-allowed rules per layer.
+- [docs/adr/](docs/adr/) for accepted architecture decisions. If your change conflicts with any invariant in PLAN.md, open an ADR first.
+
 This is an early-stage evaluation project. If you want to run it or extend it:
 
 ## Development setup

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,198 @@
+# PLAN
+
+Authoritative planning document for kronos-semi. Human and AI contributors
+should read this file before writing any code.
+
+## How to use this document
+
+- **Read before writing code.** The "Current state" and "Next task" sections
+  are the ground truth for what is done and what to work on next. Do not
+  duplicate finished work.
+- **Check invariants before architectural changes.** Anything in "Invariants"
+  is locked. To change an invariant, open an ADR under `docs/adr/` first,
+  get it accepted, and then update this file.
+- **Update on completion.** When a task in "Next task" is finished, move its
+  summary line to "Completed work log" (append, never delete), replace
+  "Current state" with the new reality, and set "Next task" to the following
+  item from the roadmap.
+- **Never delete history.** The completed work log is append-only.
+- **Keep it short.** Target under 300 lines. If a section grows, move the
+  detail to `docs/ROADMAP.md` or an ADR and leave a one-line summary here.
+
+## Project one-liner
+
+A JSON-driven finite-element semiconductor device simulator built on
+FEniCSx (dolfinx 0.10), solving Poisson-coupled drift-diffusion with SRH
+recombination for 1D/2D/3D devices.
+
+## Repository
+
+- URL: https://github.com/rwalkerlewis/kronos-semi
+- License: MIT
+- Primary branch: `main`
+- Active dev branch: `dev/docker-day1-fix` (Day 1 complete, pending merge)
+- Docs branch: `docs/planning-scaffolding` (this change)
+
+## Current state
+
+### What works (verified in Docker)
+
+- Docker dev environment on `ghcr.io/fenics/dolfinx/dolfinx:stable`
+  (dolfinx 0.10). `docker compose run --rm test` runs 36/36 pytest.
+- Pure-Python core: constants, materials (Si, Ge, GaAs, SiO2, HfO2, Si3N4),
+  nondimensional scaling, doping profiles (uniform/step/gaussian), JSON
+  schema with validate/load. 36/36 pytest passing.
+- JSON input schema (jsonschema Draft-07) with defaults.
+- Builtin mesh generation (interval/rectangle/box) with region and facet
+  tagging from axis-aligned boxes and planes.
+- Equilibrium Poisson under Boltzmann statistics, solved via PETSc SNES
+  through `dolfinx.fem.petsc.NonlinearProblem`. Quadratic Newton
+  convergence observed (5 iterations, residual 1.5e-6 to 8.1e-15).
+- Benchmark runner CLI (`scripts/run_benchmark.py`) producing plots and
+  running registered physical verifiers. `pn_1d` benchmark passes all
+  six checks:
+
+  | Check                                      | Sim                 | Theory             | Rel err |
+  |--------------------------------------------|--------------------:|-------------------:|--------:|
+  | Built-in voltage V_bi                      | 0.8334 V            | 0.8334 V           | 0.00%   |
+  | Peak \|E\|                                 | 104.84 kV/cm        | 113.53 kV/cm       | 7.65%   |
+  | p-side bulk hole density                   | 1.00e23 m^-3        | N_A = 1.00e23      | ratio 1.00 |
+  | n-side bulk electron density               | 1.00e23 m^-3        | N_D = 1.00e23      | ratio 1.00 |
+  | Mass action n*p in p-side bulk             | 1.000e32            | n_i^2 = 1.000e32   | 0.00%   |
+  | Mass action n*p in n-side bulk             | 1.000e32            | n_i^2 = 1.000e32   | 0.00%   |
+
+### What does not work / not yet built
+
+- Drift-diffusion under applied bias (Day 2 target).
+- Slotboom variable formulation (Day 2).
+- SRH recombination kernel (Day 2).
+- Coupled block Newton for (psi, Phi_n, Phi_p) (Day 2).
+- Bias ramping continuation (Day 3).
+- Forward-bias IV curve verification against Shockley diode equation
+  (Day 3).
+- 2D MOS capacitor benchmark (Day 5).
+- 3D doped resistor benchmark (Day 6).
+- Gmsh `.msh` mesh loader (stubbed, raises `NotImplementedError`).
+- Gate contacts (`type: "gate"`), Schottky contacts.
+- Field-dependent mobility, Auger/radiative recombination, Fermi-Dirac
+  statistics (see Non-goals).
+
+## Next task
+
+**Day 2: Slotboom drift-diffusion and bias support.**
+
+- **Branch:** `dev/day2-drift-diffusion` (to be created off `main` after
+  `dev/docker-day1-fix` merges).
+- **Preconditions:**
+  - `dev/docker-day1-fix` is merged to `main`.
+  - `docker compose run --rm benchmark pn_1d` exits 0 on the fresh `main`.
+  - `docker compose run --rm test` is 36/36 green on the fresh `main`.
+- **Scope, in:**
+  - Implement Slotboom quasi-Fermi variables (Phi_n, Phi_p) with
+    Boltzmann carrier expressions `n = n_i exp((psi - Phi_n) / V_t)`,
+    `p = n_i exp((Phi_p - psi) / V_t)`.
+  - Add SRH recombination term with tau_n, tau_p from JSON.
+  - Build a coupled (psi, Phi_n, Phi_p) block residual using dolfinx
+    0.10 blocked function space support
+    (`NonlinearProblem(..., kind="nest")` or equivalent).
+  - Extend the schema with optional `recombination` (SRH parameters) and
+    per-contact applied bias sweeps.
+  - Add a bias ramping driver that reuses the previous solution as the
+    initial guess.
+  - New benchmark `benchmarks/pn_1d_bias/` with a forward-bias IV sweep.
+  - New verifier: Shockley diode equation `J = J_0 (exp(V/V_t) - 1)`
+    matched within 10% over V in [0.2, 0.6] V at 0.05 V steps.
+  - Unit tests for Slotboom math and the SRH kernel.
+- **Scope, out:**
+  - Reverse bias / breakdown.
+  - Field-dependent mobility or Caughey-Thomas.
+  - AC small-signal.
+  - 2D and higher (stays Day 5+).
+  - Notebook updates (deferred to after the code runs clean in Docker).
+- **Acceptance criteria:**
+  - `docker compose run --rm benchmark pn_1d` still green (no
+    regression on Day 1).
+  - `docker compose run --rm benchmark pn_1d_bias` exits 0 with IV
+    curve within 10% of Shockley across the specified bias range.
+  - pytest green with new Slotboom and SRH tests (target: at least 10
+    new tests).
+  - No em dashes in any new prose.
+  - No new non-dolfinx imports in the pure-Python core.
+- **Estimated effort:** one focused work day in Docker.
+
+## Roadmap
+
+| Day | Milestone                                                    | Status  | Notes                                                                 |
+|----:|--------------------------------------------------------------|---------|-----------------------------------------------------------------------|
+| 1   | Equilibrium Poisson, 1D pn junction, Docker env              | Done    | 6/6 verifier checks pass; PR `dev/docker-day1-fix`                    |
+| 2   | Slotboom drift-diffusion, coupled Newton, bias sweep         | Planned | Target benchmark `pn_1d_bias` vs Shockley                             |
+| 3   | Bias ramping continuation, Shockley IV verifier hardening    | Planned | Tighten tolerance, add reverse bias (saturation region)               |
+| 4   | Refactor pass, expanded test coverage, physics docs updates  | Planned | Ruff-clean, coverage target, ADR review                               |
+| 5   | 2D MOS capacitor (oxide + silicon multi-region)              | Planned | Uses submesh for carriers; verify C-V curve                           |
+| 6   | 3D doped resistor                                            | Planned | Framework extension; verify Ohmic V-I linearity                       |
+| 7   | Final polish, submission packaging                           | Planned | Regenerate notebooks, tag release                                     |
+
+See `docs/ROADMAP.md` for the full per-day breakdown.
+
+## Invariants
+
+These decisions are locked. Changing any of them requires an accepted ADR
+under `docs/adr/`.
+
+1. **JSON is the only supported input format.** No Python DSL, no TOML,
+   no YAML. See `docs/adr/0001-json-as-input-format.md`.
+2. **Nondimensionalization is mandatory.** The raw equations have a
+   Jacobian condition number exceeding 10^30 and Newton fails. See
+   `docs/adr/0002-nondimensionalization-mandatory.md`.
+3. **Mesh coordinates stay in meters.** Only psi, densities, and
+   quasi-Fermi potentials are scaled. The scaled Poisson coefficient is
+   therefore `L_D^2 * eps_r`, not `lambda2 * eps_r`. See `docs/PHYSICS.md`
+   and ADR 0002.
+4. **Pure-Python core must not depend on dolfinx.** The modules
+   `constants`, `materials`, `scaling`, `doping`, `schema` must import
+   without dolfinx so CI and users can run them standalone. See
+   `docs/ARCHITECTURE.md`.
+5. **Target dolfinx 0.10 API only.** Use `dolfinx.fem.petsc.NonlinearProblem`
+   with `petsc_options_prefix`. The `dolfinx.nls.petsc.NewtonSolver` class
+   is deprecated and must not be introduced. See
+   `docs/adr/0003-dolfinx-0-10-api.md`.
+6. **Slotboom variables for drift-diffusion.** No SUPG or streamline
+   diffusion stabilization of raw continuity equations. See
+   `docs/adr/0004-slotboom-variables-for-dd.md`.
+7. **Physics-style variable names are allowed and expected.** `N_A`,
+   `V_t`, `psi_L`, `eps_Si`, etc. Ruff is configured to accept them
+   (N rules disabled). Do not rename to PEP 8.
+8. **No em dashes in prose anywhere in the repo.** Use commas, periods,
+   or parentheses.
+9. **Docker for dev, conda/FEM-on-Colab for users.** The supported dev
+   path is `docker compose`. See
+   `docs/adr/0005-docker-for-dev-conda-fem-on-colab-for-users.md`.
+
+## Non-goals
+
+The following are explicitly out of scope for the evaluation submission.
+They may be added after submission as stretch goals (see
+`docs/ROADMAP.md`, "Post-submission" section).
+
+- Field-dependent mobility (Caughey-Thomas, Canali, saturation velocity).
+- Auger and radiative recombination.
+- Fermi-Dirac statistics.
+- Heterojunctions (multiple semiconductor materials with different band
+  alignments in the same device).
+- Incomplete ionization of dopants.
+- AC small-signal analysis.
+- Band-to-band or trap-assisted tunneling.
+- Transient (time-dependent) solver.
+- Full MOSFET with source/drain/gate/body contacts. **Post-submission stretch goal only.**
+- FinFET or any 3D transistor geometry. **Post-submission stretch goal only.**
+- GUI or web frontend.
+
+## Completed work log
+
+Append-only. Newest entries on top.
+
+- **Day 1 (2026-04-20):** equilibrium Poisson, 1D pn junction benchmark,
+  Docker dev environment, benchmark runner CLI, physics coefficient fix
+  (scaled Poisson LHS uses `L_D^2 = lambda2 * L_0^2`, not `lambda2`, since
+  the mesh is in physical meters). All 6 `pn_1d` verifier checks pass.
+  PR: `dev/docker-day1-fix`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 A JSON-driven finite-element semiconductor device simulator built on [FEniCSx](https://fenicsproject.org/) (dolfinx 0.10+), targeting the workflow of the COMSOL Semiconductor Module — Poisson-coupled drift-diffusion with SRH recombination, multi-region support, ohmic/gate/insulating boundary conditions — in a clean, extensible Python package.
 
+## Planning documents
+
+Before contributing (human or AI), read these in order:
+
+- [PLAN.md](PLAN.md): authoritative current state, next task, invariants, and non-goals.
+- [docs/PHYSICS.md](docs/PHYSICS.md): governing equations, nondimensionalization, and boundary-condition conventions.
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md): five-layer component design and dependency rules.
+- [docs/adr/](docs/adr/): architecture decision records; open a new ADR before changing any invariant.
+- [docs/ROADMAP.md](docs/ROADMAP.md): full per-day deliverables and verification criteria.
+
 ## Status
 
 **Early development.** Day 1 deliverable is the equilibrium Poisson solve, verified against the depletion-approximation of a 1D pn junction. Drift-diffusion under bias, 2D MOS capacitor, and 3D benchmarks are on the roadmap; see [Roadmap](#roadmap) below.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,143 @@
+# Architecture
+
+kronos-semi is organized as five layers. Higher layers depend on lower
+layers; lower layers must never import from higher layers. The
+pure-Python core (Layer 3) has an additional constraint: it must not
+import dolfinx, so that schema, material, and doping logic can be
+tested in a lightweight CI environment and used standalone.
+
+## Layer diagram
+
+```
++-----------------------------------------------------------------------+
+| Layer 5 : Delivery surface                                            |
+|   benchmarks/  scripts/  notebooks/  tests/  Dockerfile               |
+|   docker-compose.yml  .devcontainer/  .github/workflows/              |
++-----------------------------^-----------------------------------------+
+                              |
++-----------------------------+-----------------------------------------+
+| Layer 4 : FEM                                                         |
+|   semi/mesh.py   semi/physics/*   semi/solver.py   semi/run.py        |
+|   depends on: dolfinx 0.10, petsc4py, ufl, mpi4py + Layer 3           |
++-----------------------------^-----------------------------------------+
+                              |
++-----------------------------+-----------------------------------------+
+| Layer 3 : Pure-Python core                                            |
+|   semi/constants.py   semi/materials.py   semi/scaling.py             |
+|   semi/doping.py                                                      |
+|   depends on: numpy only                                              |
++-----------------------------^-----------------------------------------+
+                              |
++-----------------------------+-----------------------------------------+
+| Layer 2 : Schema                                                      |
+|   semi/schema.py                                                      |
+|   depends on: jsonschema, Layer 3 (for defaults)                      |
++-----------------------------^-----------------------------------------+
+                              |
++-----------------------------+-----------------------------------------+
+| Layer 1 : JSON input                                                  |
+|   benchmarks/*/*.json, user-provided files                            |
+|   depends on: nothing                                                 |
++-----------------------------------------------------------------------+
+```
+
+## Layer-by-layer
+
+### Layer 1: JSON input
+
+- **Provides:** a declarative device specification (mesh, regions,
+  doping, contacts, physics options, solver options, output).
+- **Depends on:** nothing. JSON is a data format, not code.
+- **Must never depend on:** Python, imports, or side effects. A JSON
+  file must be consumable by non-Python tooling (UI, JS, other
+  solvers' converters).
+
+### Layer 2: Schema (`semi.schema`)
+
+- **Provides:** `validate(cfg)` and `load(path)` that produce a
+  normalized config dict with defaults filled in and unknown keys
+  rejected.
+- **Depends on:** jsonschema, Layer 3 constants for unit conversions
+  used in defaults.
+- **Must never depend on:** dolfinx, petsc4py, matplotlib, numpy for
+  numerics (only numpy types are fine, but no heavy computation).
+
+### Layer 3: Pure-Python core
+
+Modules: `semi.constants`, `semi.materials`, `semi.scaling`,
+`semi.doping`.
+
+- **Provides:**
+  - `constants`: SI physical constants and cm/m conversion helpers.
+  - `materials`: material parameter database (Si, Ge, GaAs, SiO2,
+    HfO2, Si3N4) as `Material` dataclasses.
+  - `scaling`: `Scaling` class with `L0`, `C0`, `V0`, `lambda2`,
+    `debye_length`, etc. Derives scales from the config.
+  - `doping`: callable doping-profile evaluators
+    (uniform, step, gaussian) that take an `(dim, N)` array and return
+    net doping in $\mathrm{m}^{-3}$.
+- **Depends on:** numpy only.
+- **Must never depend on:** dolfinx, petsc4py, mpi4py, ufl, basix,
+  matplotlib, jupyter. These imports are lazy in Layer 4 specifically
+  so that Layer 3 can be imported and unit-tested in a plain Python
+  environment.
+
+Rationale: fast CI, no Docker required for schema/materials
+development, and users with only the pure-Python install can still
+drive the schema and material DB.
+
+### Layer 4: FEM
+
+Modules: `semi.mesh`, `semi.physics.*`, `semi.solver`, `semi.run`.
+
+- **Provides:**
+  - `mesh`: builtin interval/rectangle/box mesh construction plus
+    region and facet tagging.
+  - `physics.poisson`: equilibrium Poisson UFL residual builder.
+  - Future `physics.drift_diffusion`: Slotboom continuity forms (Day 2).
+  - `solver`: `solve_nonlinear` wrapping `dolfinx.fem.petsc.NonlinearProblem`.
+  - `run`: top-level `run(cfg) -> SimulationResult` orchestrator.
+- **Depends on:** dolfinx 0.10, petsc4py, mpi4py, ufl, basix, plus
+  Layers 1-3.
+- **Must never depend on:** matplotlib, jupyter, IPython. Plotting and
+  notebook concerns live in Layer 5.
+
+### Layer 5: Delivery surface
+
+- **Provides:**
+  - `benchmarks/`: self-contained JSON inputs with a README per benchmark.
+  - `scripts/run_benchmark.py`: CLI that loads a benchmark, runs it, and
+    verifies it.
+  - `notebooks/`: thin Colab drivers that clone the repo and import the
+    package.
+  - `tests/`: pytest suite covering Layer 2-3 (offline) and Layer 4
+    (in-Docker).
+  - `Dockerfile`, `docker-compose.yml`, `.devcontainer/`: reproducible
+    dev environment.
+  - `.github/workflows/ci.yml`: lint and test the pure-Python layers on
+    Python 3.10 / 3.11 / 3.12 (no dolfinx required).
+- **Depends on:** everything below.
+- **Must never depend on:** nothing depends on Layer 5; it is the leaf.
+
+## Test matrix
+
+- **Offline (GitHub Actions, no dolfinx):** Layers 2-3 with the
+  full 36-test pytest suite, plus ruff lint.
+- **In-Docker (manual or GHA with dolfinx image):** full suite plus
+  `docker compose run --rm benchmark <name>` for each benchmark
+  directory. This exercises Layer 4 end to end.
+
+## Module boundaries at a glance
+
+| Concern              | Where it lives         | Forbidden imports                       |
+|----------------------|------------------------|------------------------------------------|
+| Unit conversions     | `semi.constants`       | everything except stdlib                 |
+| Material DB          | `semi.materials`       | dolfinx                                  |
+| Scaling              | `semi.scaling`         | dolfinx                                  |
+| Doping profiles      | `semi.doping`          | dolfinx                                  |
+| JSON schema          | `semi.schema`          | dolfinx, matplotlib                      |
+| Mesh assembly        | `semi.mesh`            | matplotlib                               |
+| UFL residuals        | `semi.physics.*`       | matplotlib                               |
+| SNES driver          | `semi.solver`          | matplotlib                               |
+| Top-level runner     | `semi.run`             | matplotlib (plotting is Layer 5)         |
+| Plotting             | `scripts/run_benchmark.py`, notebooks | ...                        |

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -1,0 +1,243 @@
+# Physics reference
+
+Stable reference for the governing equations, nondimensionalization, and
+boundary conditions used throughout kronos-semi. This document changes
+only when the physics content of the code changes. When adding a new
+physics module, verify it uses the conventions here.
+
+## 1. Governing equations (dimensional, SI)
+
+Internal units are SI: potentials in V, lengths in m, densities in
+$\mathrm{m}^{-3}$, current density in $\mathrm{A\,m^{-2}}$. JSON input
+uses $\mathrm{cm}^{-3}$ for densities and $\mathrm{cm^2\,V^{-1}\,s^{-1}}$
+for mobility; those are converted at ingest by helpers in
+`semi/constants.py`.
+
+### 1.1 Poisson equation
+
+$$
+-\nabla \cdot \bigl( \varepsilon_0 \varepsilon_r(\mathbf{x})\, \nabla \psi \bigr)
+    = q\,\bigl( p - n + N_D^+ - N_A^- \bigr)
+$$
+
+For Day 1 scope (equilibrium, complete ionization) we take
+$N_D^+ = N_D$ and $N_A^- = N_A$.
+
+### 1.2 Carrier statistics (Boltzmann)
+
+Under Boltzmann statistics, carrier densities are expressed in terms of
+the electrostatic potential $\psi$ and the quasi-Fermi potentials
+$\Phi_n$ (electrons) and $\Phi_p$ (holes):
+
+$$
+n = n_i \exp\!\left( \frac{\psi - \Phi_n}{V_t} \right), \qquad
+p = n_i \exp\!\left( \frac{\Phi_p - \psi}{V_t} \right).
+$$
+
+At thermal equilibrium $\Phi_n = \Phi_p = 0$ and the product
+$n p = n_i^2$ identically, which is the mass-action law verified in the
+`pn_1d` benchmark.
+
+### 1.3 Continuity equations (Slotboom current form)
+
+Starting from the drift-diffusion currents
+$\mathbf{J}_n = q \mu_n n \mathbf{E} + q D_n \nabla n$ (with Einstein
+relation $D_n = \mu_n V_t$) and substituting the Boltzmann expression for
+$n$, the electron current simplifies to
+
+$$
+\mathbf{J}_n = q\, \mu_n\, n_i \exp\!\left(\frac{\psi - \Phi_n}{V_t}\right)\, \nabla \Phi_n
+    \;\equiv\; -q\, \mu_n\, n\, \nabla \Phi_n.
+$$
+
+That is, the current is a pure gradient of the electron quasi-Fermi
+potential times an exponential coefficient. The hole current is
+symmetric:
+
+$$
+\mathbf{J}_p = -q\, \mu_p\, p\, \nabla \Phi_p.
+$$
+
+The steady-state continuity equations are then
+
+$$
+\nabla \cdot \mathbf{J}_n = \phantom{-}q\, R(n, p), \qquad
+\nabla \cdot \mathbf{J}_p = -q\, R(n, p),
+$$
+
+where $R$ is net recombination.
+
+### 1.4 SRH recombination kernel
+
+Shockley-Read-Hall recombination through a single mid-gap trap level:
+
+$$
+R_\mathrm{SRH}(n, p) = \frac{n p - n_i^2}{\tau_p (n + n_1) + \tau_n (p + p_1)}
+$$
+
+with $n_1 = n_i \exp(E_t / V_t)$, $p_1 = n_i \exp(-E_t / V_t)$, and
+$E_t$ the trap energy referenced to the intrinsic level (zero for a
+mid-gap trap).
+
+## 2. Nondimensionalization
+
+### 2.1 Scales
+
+| Quantity                | Symbol        | Scale                                           | Scaled name    |
+|-------------------------|---------------|-------------------------------------------------|----------------|
+| Spatial coordinate      | $x$           | none (kept in meters)                           | $x$            |
+| Electrostatic potential | $\psi$        | $V_0 = V_t = k_B T / q$                         | $\hat\psi$     |
+| Quasi-Fermi potentials  | $\Phi_n, \Phi_p$ | $V_0 = V_t$                                  | $\hat\Phi_n$, $\hat\Phi_p$ |
+| Carrier densities       | $n, p$        | $C_0 = \max\|N\|$ across profiles, floored at $10^{16}\,\mathrm{cm}^{-3}$ | $\hat n$, $\hat p$ |
+| Doping                  | $N_D - N_A$   | $C_0$                                           | $\hat N$       |
+| Intrinsic density       | $n_i$         | $C_0$                                           | $\hat n_i$     |
+
+See `semi/scaling.py` for the implementation.
+
+### 2.2 Scaled Poisson
+
+Substituting $\psi = V_t \hat\psi$ and $n, p, N \to C_0 \hat n$, etc. into
+the Poisson equation, **keeping the spatial coordinate in meters**:
+
+$$
+-\nabla \cdot \bigl( \varepsilon_0 \varepsilon_r\, V_t\, \nabla \hat\psi \bigr)
+    = q\, C_0 \bigl( \hat p - \hat n + \hat N \bigr).
+$$
+
+Divide both sides by $q C_0$:
+
+$$
+-\nabla \cdot \bigl( L_D^2\, \varepsilon_r\, \nabla \hat\psi \bigr)
+    = \hat p - \hat n + \hat N,
+\qquad
+\boxed{\; L_D^2 \;\equiv\; \frac{\varepsilon_0 V_t}{q C_0} \;}
+$$
+
+where $L_D$ is the extrinsic Debye length at the reference density
+$C_0$. This is the coefficient used in `semi/physics/poisson.py`.
+
+### 2.3 Relationship to `lambda2`
+
+`Scaling.lambda2` returns the **dimensionless** ratio
+
+$$
+\lambda^2 = \frac{\varepsilon_0 V_t}{q C_0 L_0^2} \;=\; \frac{L_D^2}{L_0^2}.
+$$
+
+That is, $L_D^2 = \lambda^2 L_0^2$. `lambda2` is only the correct
+stiffness coefficient if the spatial coordinate is itself scaled by
+$L_0$.
+
+> **Cautionary note (Day 1 bug).** An earlier version of
+> `semi/physics/poisson.py` used `sc.lambda2` directly as the Laplacian
+> coefficient. Because the mesh is in physical meters (not in units of
+> $L_0$), this suppressed diffusion by a factor of $L_0^2$ (of order
+> $10^{-12}$ for a micron-scale device) and Newton converged on the
+> Laplace solution instead of the nonlinear Poisson one. V_bi came out
+> right by coincidence (it is set entirely by the Dirichlet BCs), but
+> peak $|E|$ was off by more than 20x. The fix was to use
+> $L_D^2 = \lambda^2 L_0^2$. Any future scaled forms must follow the
+> same convention.
+
+### 2.4 Scaled continuity (for Day 2)
+
+Under the same scaling, with the time scale $t_0 = L_0^2 / D_0$ and
+$D_0 = V_t \mu_0$ (Einstein for the reference mobility), the steady-state
+electron continuity equation becomes
+
+$$
+-\nabla \cdot \bigl( \mu_n V_t\, n_i \exp(\hat\psi - \hat\Phi_n) \nabla \hat\Phi_n \bigr)
+    = q\, R(n, p).
+$$
+
+The current-scale becomes $J_0 = q D_0 C_0 / L_0$. Details of the Day 2
+scaled forms will be fixed when the code lands.
+
+## 3. Boundary conditions
+
+### 3.1 Ohmic contacts
+
+At an ohmic contact the carrier densities equal their majority-side
+equilibrium values and the semiconductor is locally in quasi-neutral
+charge balance. In terms of $\psi$, this gives the Dirichlet value
+
+$$
+\psi = V_t\, \operatorname{asinh}\!\left( \frac{N_D - N_A}{2 n_i} \right) \;+\; V_\mathrm{applied}.
+$$
+
+For the coupled system, the quasi-Fermi potentials at the contact equal
+the applied bias:
+
+$$
+\Phi_n = \Phi_p = V_\mathrm{applied}.
+$$
+
+See `_build_ohmic_bcs` in `semi/run.py`.
+
+### 3.2 Gate contacts
+
+At a gate over an oxide, the applied potential is specified as a
+Dirichlet condition on $\psi$, offset by the metal-semiconductor work
+function difference $\phi_{ms}$ (ignored for ideal gates):
+
+$$
+\psi_\mathrm{gate} = V_g - \phi_{ms}.
+$$
+
+No carriers are defined in the oxide; continuity equations are solved
+only in semiconductor regions. The normal component of
+$\varepsilon \nabla \psi$ is continuous across the oxide/semiconductor
+interface (natural in the Galerkin form). Gate BCs are deferred to the
+Day 5 MOS benchmark.
+
+### 3.3 Insulating boundaries
+
+Homogeneous Neumann on every field:
+
+$$
+\nabla \psi \cdot \hat{\mathbf{n}} = 0, \qquad
+\nabla \Phi_n \cdot \hat{\mathbf{n}} = 0, \qquad
+\nabla \Phi_p \cdot \hat{\mathbf{n}} = 0.
+$$
+
+This is the natural condition and requires no explicit code.
+
+## 4. Reference values
+
+All values are room temperature ($T = 300\,\mathrm{K}$) unless noted.
+Source of truth for material parameters: `semi/materials.py`.
+
+### 4.1 Universal
+
+| Symbol     | Value                                          | Notes                                  |
+|------------|------------------------------------------------|----------------------------------------|
+| $q$        | $1.602176634 \times 10^{-19}$ C                | 2019 SI redefinition exact             |
+| $k_B$      | $1.380649 \times 10^{-23}$ J/K                 | 2019 SI redefinition exact             |
+| $\varepsilon_0$ | $8.8541878128 \times 10^{-12}$ F/m        |                                        |
+| $V_t(300\,\mathrm{K})$ | $25.852\,\mathrm{mV}$              | $= k_B T / q$                          |
+
+### 4.2 Silicon
+
+| Symbol        | Value                               | Notes                                               |
+|---------------|-------------------------------------|-----------------------------------------------------|
+| $\varepsilon_r$ | $11.7$                             |                                                     |
+| $E_g$         | $1.12$ eV                           |                                                     |
+| $\chi$        | $4.05$ eV                           | Electron affinity                                   |
+| $N_c$         | $2.86 \times 10^{19}\,\mathrm{cm}^{-3}$ | Sze, 3rd ed. Table 7                            |
+| $N_v$         | $3.10 \times 10^{19}\,\mathrm{cm}^{-3}$ |                                                 |
+| $n_i$         | $1.0 \times 10^{10}\,\mathrm{cm}^{-3}$ | Altermatt 2003 consensus                         |
+| $\mu_n$       | $1400\,\mathrm{cm^2\,V^{-1}\,s^{-1}}$ | Undoped, 300 K                                   |
+| $\mu_p$       | $450\,\mathrm{cm^2\,V^{-1}\,s^{-1}}$  |                                                  |
+
+> **Note on $n_i$.** The older textbook value $1.45 \times 10^{10}\,\mathrm{cm}^{-3}$
+> is superseded; modern TCAD tools (Sentaurus, Atlas, etc.) use values close
+> to $1.0 \times 10^{10}$ following Altermatt's 2003 reassessment. We match
+> the modern convention. If you compare against a hand calculation that
+> uses 1.45e10, expect built-in voltage offsets of order $V_t \ln(1.45^2)
+> \approx 19\,\mathrm{mV}$.
+
+### 4.3 Other semiconductors
+
+See `semi/materials.py` for Ge, GaAs. Insulators (SiO2 $\varepsilon_r = 3.9$,
+HfO2 $\varepsilon_r = 25.0$, Si3N4 $\varepsilon_r = 7.5$) carry only a relative
+permittivity; semiconductor-specific fields are zero on them.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,189 @@
+# Roadmap
+
+Full day-by-day plan for the kronos-semi evaluation submission. This
+expands on the roadmap table in `PLAN.md`. Each day lists a goal,
+concrete deliverables, verification criteria (the commands you run to
+prove it is done), and dependencies on prior days.
+
+Read `PLAN.md` for the short version and the current in-flight task.
+
+## Day 1. Equilibrium Poisson, 1D pn junction, Docker env
+
+- **Status:** Done (2026-04-20). PR `dev/docker-day1-fix`.
+- **Goal:** prove the end-to-end pipeline works for a known analytical
+  test case.
+- **Deliverables:**
+  - `Dockerfile`, `docker-compose.yml`, `.devcontainer/devcontainer.json`,
+    `.dockerignore`.
+  - `semi/constants.py`, `semi/materials.py`, `semi/scaling.py`,
+    `semi/doping.py`, `semi/schema.py`.
+  - `semi/mesh.py`, `semi/physics/poisson.py`, `semi/solver.py`,
+    `semi/run.py`.
+  - `benchmarks/pn_1d/pn_junction.json`.
+  - `scripts/run_benchmark.py` with a `pn_1d` verifier.
+  - 36 pytest tests covering the pure-Python core.
+- **Verification:**
+  - `docker compose run --rm test` exits 0 with 36/36 pass.
+  - `docker compose run --rm benchmark pn_1d` exits 0 with all six
+    verifier checks green.
+- **Dependencies:** none.
+
+## Day 2. Slotboom drift-diffusion, coupled Newton, bias sweep
+
+- **Status:** Planned. Branch `dev/day2-drift-diffusion` (to be created
+  after `dev/docker-day1-fix` merges).
+- **Goal:** solve the full coupled (psi, Phi_n, Phi_p) system with SRH
+  recombination under forward bias, and verify against the Shockley
+  diode equation.
+- **Deliverables:**
+  - `semi/physics/drift_diffusion.py` with Slotboom continuity forms
+    (electron and hole continuity as separate form builders, plus a
+    combined block residual).
+  - `semi/physics/recombination.py` with the SRH kernel as a UFL
+    expression builder.
+  - Extension of `semi/solver.py` to dispatch between scalar and
+    blocked `NonlinearProblem` via the `kind` argument.
+  - Update `semi/run.py` to build the coupled system when the config's
+    `solver.type` is `"drift_diffusion"` or `"bias_sweep"`.
+  - Schema extension: `recombination` block (tau_n, tau_p, E_t),
+    `contacts[*].voltage_sweep` for bias ramping.
+  - `benchmarks/pn_1d_bias/pn_junction_bias.json` with a forward-bias
+    IV sweep from 0.0 to 0.6 V in 0.05 V increments.
+  - `pn_1d_bias` verifier in `scripts/run_benchmark.py` checking IV vs
+    Shockley `J = J_0 (exp(V/V_t) - 1)` with the saturation current
+    $J_0$ computed from $D_n, D_p, \tau_n, \tau_p, N_A, N_D, n_i$.
+  - At least 10 new unit tests: Slotboom math round-trip (n, p
+    recovery), SRH kernel limits (R = 0 at equilibrium, R > 0 under
+    bias, correct saturation behavior).
+- **Verification:**
+  - `docker compose run --rm benchmark pn_1d` still green (Day 1
+    regression).
+  - `docker compose run --rm benchmark pn_1d_bias` exits 0 with IV
+    curve within 10% of Shockley over V in [0.2, 0.6] V. Below 0.2 V
+    the current is dominated by numerical noise and Shockley is not a
+    meaningful target.
+  - `docker compose run --rm test` green with the new tests.
+  - ruff clean.
+- **Dependencies:** Day 1 merged to `main`.
+
+## Day 3. Bias ramping hardening, Shockley IV polish
+
+- **Status:** Planned.
+- **Goal:** make the bias sweep robust, add reverse-bias saturation
+  verification, document the ramp-continuation logic.
+- **Deliverables:**
+  - Adaptive step-size control in the bias ramp: if SNES fails to
+    converge, halve the step and retry; fail the run after a
+    configurable number of halvings.
+  - Reverse-bias sweep from 0 to -2 V verifying saturation current
+    within 20% of $J_0$ (saturation tolerance is looser because real
+    $J_0$ is very small and relative error is noisy).
+  - IV curve plot with theory overlay written to `results/pn_1d_bias/`.
+  - Short writeup in `benchmarks/pn_1d_bias/README.md`.
+- **Verification:**
+  - `benchmark pn_1d_bias` exits 0 with forward and reverse checks
+    both passing.
+  - Plot file exists and has expected title and labels.
+- **Dependencies:** Day 2.
+
+## Day 4. Refactor, expanded test coverage, docs pass
+
+- **Status:** Planned.
+- **Goal:** pay down technical debt accumulated across Days 1-3 and
+  expand coverage before moving to higher dimensions.
+- **Deliverables:**
+  - Break `semi/run.py` into `run_equilibrium` and `run_bias_sweep`
+    functions with a thin `run(cfg)` dispatcher.
+  - Factor BC construction into `semi/bcs.py` so ohmic, gate, and
+    future Schottky contacts share a common interface.
+  - Raise pure-Python coverage to 95%+; add integration tests for
+    `run` itself that can be parameterized over small in-memory
+    configs.
+  - Update `docs/PHYSICS.md` with the scaled drift-diffusion
+    derivation now that it is implemented.
+  - Add `docs/adr/0006-bc-construction-interface.md` if the BC refactor
+    introduces a new decision.
+- **Verification:**
+  - `pytest --cov=semi --cov-report=term-missing` shows core coverage
+    at or above 95%.
+  - No behavioral regressions in `pn_1d` or `pn_1d_bias`.
+- **Dependencies:** Days 2 and 3.
+
+## Day 5. 2D MOS capacitor
+
+- **Status:** Planned.
+- **Goal:** extend to 2D and multi-region (oxide plus silicon).
+- **Deliverables:**
+  - `benchmarks/mos_2d/mos_cap.json` with a gate, oxide, silicon
+    substrate, and body contact.
+  - Submesh handling in `semi/mesh.py` so carriers live only on the
+    semiconductor region.
+  - Gate boundary condition (Dirichlet on psi, no continuity
+    equations in oxide).
+  - C-V curve verifier: depletion C-V should match MOS theory within
+    10% across the depletion-to-inversion transition.
+- **Verification:**
+  - `benchmark mos_2d` exits 0.
+  - 2D plots rendered (psi contour, |E| contour, n and p contours).
+- **Dependencies:** Day 4 refactor.
+
+## Day 6. 3D doped resistor
+
+- **Status:** Planned.
+- **Goal:** confirm the framework extends to 3D unstructured meshes
+  with no physics changes.
+- **Deliverables:**
+  - `benchmarks/resistor_3d/resistor.json` with a doped bar.
+  - Gmsh `.msh` loading via `dolfinx.io.gmshio` (currently stubbed
+    out in `semi/mesh.py`).
+  - Ohmic V-I linearity verifier: current scales linearly with
+    applied voltage to within 1% over a small voltage range.
+- **Verification:**
+  - `benchmark resistor_3d` exits 0.
+  - At least two 3D slice plots (current density magnitude, potential).
+- **Dependencies:** Day 4.
+
+## Day 7. Final polish and submission packaging
+
+- **Status:** Planned.
+- **Goal:** make the submission presentation-ready.
+- **Deliverables:**
+  - Regenerate `notebooks/01_pn_junction_1d.ipynb` using
+    `scripts/build_notebook_01.py` after all Docker tests pass.
+  - Add `notebooks/02_pn_junction_bias.ipynb` for the Day 2-3 content.
+  - Update `README.md` status section with the final capability
+    matrix.
+  - Tag release `v0.2.0` (or similar) on `main` after final review.
+  - Update `CHANGELOG.md`.
+- **Verification:**
+  - Both notebooks execute top-to-bottom on Colab with no errors.
+  - README and CHANGELOG accurately describe final state.
+- **Dependencies:** Days 5 and 6.
+
+## Post-submission (stretch goals)
+
+Explicitly out of scope for the evaluation submission. Listed here so
+contributors and reviewers know the intended direction.
+
+- **Field-dependent mobility:** Caughey-Thomas parameterization with
+  saturation velocity, needed for any quantitatively accurate
+  high-field device simulation.
+- **Auger and radiative recombination:** becomes important in heavily
+  doped regions and direct-gap materials.
+- **Fermi-Dirac statistics:** needed for degeneracy in source/drain
+  regions and for wide-gap materials at low temperature.
+- **Incomplete dopant ionization:** freeze-out effects at low T.
+- **AC small-signal:** linearized frequency response around a DC
+  operating point; enables impedance and C-V analysis.
+- **Transient solver:** time-dependent drift-diffusion for
+  switching analysis.
+- **Band-to-band and trap-assisted tunneling:** breakdown and gate
+  leakage.
+- **Heterojunctions:** multi-semiconductor stacks (GaAs/AlGaAs,
+  Si/SiGe).
+- **Full MOSFET:** source/drain/gate/body with submesh for carriers
+  and proper work-function handling.
+- **FinFET and 3D transistor geometries:** geometry generation and
+  meshing, plus whatever new physics the above stretch goals bring.
+- **GUI or web frontend:** a JavaScript SPA that builds the JSON
+  input interactively and streams results back.

--- a/docs/adr/0001-json-as-input-format.md
+++ b/docs/adr/0001-json-as-input-format.md
@@ -1,0 +1,59 @@
+# 0001. JSON as input format
+
+- Status: Accepted
+- Date: 2026-04-20
+
+## Context
+
+kronos-semi needs a way for users to specify a device: mesh, regions,
+doping profiles, contacts, physics options, solver options, and output
+preferences. Candidate formats are:
+
+- JSON
+- TOML
+- YAML
+- A Python DSL (the user writes `Device(...)` calls in Python)
+
+The audience is mixed: TCAD engineers who may not know Python well, AI
+coding assistants that benefit from a schema-validatable format, and
+automated test harnesses.
+
+## Decision
+
+Use JSON as the only supported input format. Validate inputs against a
+jsonschema Draft-07 schema defined in `semi/schema.py`.
+
+## Consequences
+
+Easier:
+
+- Schema validation catches malformed inputs at the boundary with
+  precise error messages, before any FEM code runs.
+- JSON round-trips cleanly through web APIs, UIs, JavaScript tooling,
+  and test fixtures.
+- AI agents and human reviewers can inspect a device spec statically
+  without executing any code.
+- Cases are reproducible: a JSON file plus a package version fully
+  determines the simulation.
+
+Harder:
+
+- Deeply nested configurations are verbose compared to a Python DSL.
+- No comments in JSON proper; we rely on descriptive `name` and
+  `description` fields to document intent.
+- Default values must be maintained in two places (the schema and any
+  downstream code that reads the config); schema tests guard against
+  drift.
+
+Rejected alternatives:
+
+- **TOML:** elegant for shallow configs, but the schema has nested
+  arrays of objects (doping entries inside regions, facets-by-plane
+  inside mesh) where TOML's array-of-tables syntax becomes awkward.
+- **YAML:** whitespace-significant parsing is fragile, and YAML's
+  implicit type coercion has known foot-guns (for example, `1e17`
+  parsing as a string in some parsers, or `no` parsing as boolean).
+- **Python DSL:** running arbitrary Python to define a case is a
+  security and reproducibility problem (a case description should not
+  require executing code), prevents static analysis by AI assistants,
+  and cannot be produced by a JS frontend.

--- a/docs/adr/0002-nondimensionalization-mandatory.md
+++ b/docs/adr/0002-nondimensionalization-mandatory.md
@@ -1,0 +1,72 @@
+# 0002. Nondimensionalization is mandatory
+
+- Status: Accepted
+- Date: 2026-04-20
+
+## Context
+
+The raw semiconductor device equations combine quantities that span more
+than 40 orders of magnitude:
+
+| Quantity            | Typical value               |
+|---------------------|-----------------------------|
+| $q$                 | $1.6 \times 10^{-19}$ C     |
+| $\varepsilon_0$     | $8.85 \times 10^{-12}$ F/m  |
+| $n_i$ (Si, 300 K)   | $1 \times 10^{16}$ m$^{-3}$ |
+| $N$ (typical)       | $1 \times 10^{23}$ m$^{-3}$ |
+| $\psi$              | $\sim 1$ V                  |
+| $L$ (device)        | $\sim 10^{-6}$ m            |
+
+Feeding these directly into Newton gives a Jacobian with condition
+number in excess of $10^{30}$. The linear solve at each Newton step is
+numerically meaningless at that conditioning, and SNES fails to
+converge (residuals stagnate or explode).
+
+This applies equally to Poisson alone and to the coupled
+Poisson-continuity system.
+
+## Decision
+
+All FEM forms operate on nondimensional unknowns:
+
+- $\hat\psi = \psi / V_t$
+- $\hat n, \hat p, \hat N = \{n, p, N\} / C_0$
+- $\hat\Phi_n, \hat\Phi_p = \{\Phi_n, \Phi_p\} / V_t$
+
+The **spatial coordinate is deliberately kept in meters** so that mesh
+extents and facet locations in the JSON remain in SI. This is an
+asymmetric scaling: fields scaled, geometry not.
+
+The consequence for the scaled Poisson LHS coefficient is
+
+$$
+L_D^2 \varepsilon_r = \frac{\varepsilon_0 V_t}{q C_0}\, \varepsilon_r
+     = \lambda^2 L_0^2 \varepsilon_r,
+$$
+
+not $\lambda^2 \varepsilon_r$. This is spelled out in `docs/PHYSICS.md`
+Section 2.
+
+## Consequences
+
+Easier:
+
+- Newton converges quadratically on well-posed problems.
+- Boundary conditions simplify ($\hat\psi_\mathrm{BC} =
+  \operatorname{asinh}(\hat N / 2 \hat n_i) + V_\mathrm{applied} / V_t$).
+- The small parameter $\lambda^2 L_0^2 / L_\mathrm{feature}^2$ makes the
+  depletion regime explicit as a singular perturbation.
+
+Harder:
+
+- Every new physics form must be written in scaled variables from the
+  start. Mixing scaled and unscaled quantities is a source of bugs.
+- The asymmetric scaling choice (fields scaled, x not) is unusual and
+  caused the Day 1 coefficient bug (see `docs/PHYSICS.md` Section 2.3).
+  All new physics modules must reference that section and use $L_D^2$,
+  not $\lambda^2$, when the coordinate is in meters.
+
+## Related
+
+- `docs/PHYSICS.md` Section 2 for the derivation.
+- Invariant 2 and 3 in `PLAN.md`.

--- a/docs/adr/0003-dolfinx-0-10-api.md
+++ b/docs/adr/0003-dolfinx-0-10-api.md
@@ -1,0 +1,57 @@
+# 0003. Target dolfinx 0.10 API only
+
+- Status: Accepted
+- Date: 2026-04-20
+
+## Context
+
+FEniCSx has a rapidly evolving API. The relevant API surface for this
+project is the nonlinear solver interface:
+
+- **dolfinx 0.9 and earlier:** `dolfinx.nls.petsc.NewtonSolver` held a
+  hand-rolled Newton loop. Setting PETSc options required either
+  manipulating global `PETSc.Options()` or reaching through the solver
+  object. Block/nested systems required extra plumbing in user code.
+- **dolfinx 0.10:** `dolfinx.fem.petsc.NonlinearProblem` wraps PETSc
+  SNES directly. It takes a `petsc_options_prefix` and a dict of PETSc
+  options, giving clean per-problem configuration. It also supports
+  blocked and nested function spaces via `kind="blocked"` or
+  `kind="nest"`, which the coupled (psi, Phi_n, Phi_p) system will
+  need for Day 2.
+
+The Day 2 coupled block Newton implementation needs the 0.10 blocked
+support. Supporting both APIs simultaneously would fork the solver
+driver and double the test matrix.
+
+## Decision
+
+Target `dolfinx >= 0.10, < 0.11` as the only supported version. Use
+`dolfinx.fem.petsc.NonlinearProblem` with `petsc_options_prefix` and
+`petsc_options` (see `semi/solver.py`). Do not introduce or import
+`dolfinx.nls.petsc.NewtonSolver`; the class is deprecated in 0.10 and
+will be removed.
+
+## Consequences
+
+Easier:
+
+- Single solver driver, single set of PETSc option semantics.
+- Block-Newton (Day 2) uses the same `NonlinearProblem` API as
+  scalar Newton, with an additional `kind` argument.
+- SNES line search (`snes_linesearch_type`) and advanced convergence
+  criteria are available out of the box.
+
+Harder:
+
+- Users on older dolfinx environments (for example, stale conda
+  environments, legacy FEM-on-Colab kernels) cannot run the FEM layer.
+  The Docker image in the repo pins to
+  `ghcr.io/fenics/dolfinx/dolfinx:stable`, which currently resolves to
+  0.10, so the supported path is unambiguous.
+- When dolfinx 0.11 lands, every form and driver will need to be
+  retested. We accept that cost rather than hedging.
+
+## Related
+
+- `semi/solver.py`, the single use site for `NonlinearProblem`.
+- Invariant 5 in `PLAN.md`.

--- a/docs/adr/0004-slotboom-variables-for-dd.md
+++ b/docs/adr/0004-slotboom-variables-for-dd.md
@@ -1,0 +1,76 @@
+# 0004. Slotboom variables for drift-diffusion
+
+- Status: Accepted
+- Date: 2026-04-20
+
+## Context
+
+The drift-diffusion currents
+
+$$
+\mathbf{J}_n = q \mu_n n \mathbf{E} + q D_n \nabla n,
+\qquad
+\mathbf{J}_p = q \mu_p p \mathbf{E} - q D_p \nabla p
+$$
+
+have a mixed advective-diffusive structure. The local Peclet number is
+$\mathrm{Pe} = |\mathbf{E}| L_\mathrm{element} / (2 V_t)$. In any
+realistic semiconductor device under bias, $|\mathbf{E}|$ at the
+junction or in the channel is in the range $10^4$ to $10^6$ V/cm, which
+gives $\mathrm{Pe} \gg 1$ for any mesh resolution short of atomistic.
+
+Standard Galerkin FEM is known to be unstable (oscillatory) in the
+drift-dominant regime. The textbook fixes are:
+
+- **SUPG / streamline diffusion:** add stabilization terms tuned to
+  $\mathrm{Pe}$. Requires careful parameter selection; mass
+  conservation becomes approximate; coupling to Poisson is more
+  complex.
+- **Scharfetter-Gummel box integration:** exact exponential fitting on
+  a dual mesh. Excellent for finite volumes, but not a natural fit for
+  high-order FEM spaces and does not generalize cleanly to 3D
+  unstructured meshes.
+- **Slotboom variables (quasi-Fermi potentials):** rewrite $n$ and $p$
+  in terms of $\Phi_n$ and $\Phi_p$ using Boltzmann relations. The
+  resulting current is a pure gradient,
+  $\mathbf{J}_n = -q \mu_n n \nabla \Phi_n$, with a positive
+  coefficient. Standard Galerkin on $\Phi_n$ is coercive and stable
+  without any stabilization terms.
+
+## Decision
+
+Use Slotboom variables $\Phi_n, \Phi_p$ as the primary continuity
+unknowns. The coupled block unknown is $(\hat\psi, \hat\Phi_n,
+\hat\Phi_p)$. Electron and hole densities are recovered pointwise from
+the Boltzmann relations in `docs/PHYSICS.md` Section 1.2.
+
+## Consequences
+
+Easier:
+
+- No SUPG parameters to tune; no stabilization terms to maintain across
+  elements or dimensions.
+- Conservation is exact (the continuity equations are in divergence
+  form of a pure gradient).
+- Ohmic and gate BCs on $\Phi_n$ and $\Phi_p$ are natural (they equal
+  the applied bias at contacts).
+
+Harder:
+
+- The coefficient $n = n_i \exp((\hat\psi - \hat\Phi_n)/V_t)$ can
+  underflow in deep depletion (large negative argument), or overflow in
+  heavy accumulation. The coupled system is stiff. Bias ramping
+  continuation (Day 3) is mandatory; jumping from zero to high forward
+  bias will not converge.
+- Reverse bias near breakdown pushes the exponent large negative; we
+  rely on PETSc SNES line search and bias ramping to stay in the
+  feasible region.
+- Users familiar with the raw $(n, p)$ formulation have to translate
+  when reading the code.
+
+## Related
+
+- `docs/PHYSICS.md` Sections 1.2 and 1.3.
+- Invariant 6 in `PLAN.md`.
+- Future ADR if we ever need SUPG for a non-Slotboom subsystem (for
+  example, hot-carrier transport).

--- a/docs/adr/0005-docker-for-dev-conda-fem-on-colab-for-users.md
+++ b/docs/adr/0005-docker-for-dev-conda-fem-on-colab-for-users.md
@@ -1,0 +1,79 @@
+# 0005. Docker for dev, conda and FEM-on-Colab for users
+
+- Status: Accepted
+- Date: 2026-04-20
+
+## Context
+
+FEniCSx is not pip-installable from PyPI in any practical sense: it
+depends on PETSc, MPI, Basix (C++ core), and FFCx compiled against
+specific library versions. Users and contributors need a reliable
+install path, and the right path differs by audience:
+
+- **Development:** primary author plus any future contributors need
+  a tight edit-test loop with deterministic dolfinx behavior and no
+  risk of environment drift.
+- **Evaluation reviewers:** want to run the benchmarks with zero setup
+  cost.
+- **Local users on their own machines:** mix of Linux, macOS, and WSL,
+  some with conda preferences, some without.
+
+Candidate install paths considered:
+
+- Docker image (official `ghcr.io/fenics/dolfinx/dolfinx:stable`).
+- conda-forge (`fenics-dolfinx` package).
+- FEM-on-Colab install script (precompiled wheels + deb packages,
+  Colab-specific).
+- Building dolfinx from source via pip.
+- System packages (apt, brew): available but versions lag.
+
+## Decision
+
+Three supported install paths, in this order:
+
+1. **Docker** is the primary development environment. The repo ships a
+   `Dockerfile` layered on `ghcr.io/fenics/dolfinx/dolfinx:stable`, with
+   `docker-compose.yml` services for interactive dev, test, benchmark,
+   and Jupyter. This is what CI and the primary author use.
+2. **conda-forge** is the alternative local install for contributors
+   who prefer conda or need native performance (no container
+   overhead). Instructions in README.
+3. **FEM-on-Colab** is the zero-setup path for evaluation reviewers:
+   the Colab notebook includes a first cell that runs the
+   FEM-on-Colab install script and then clones the repo. Reviewers
+   click the Colab badge, wait roughly 30 seconds, and run cells.
+
+Do not attempt to support a "pip install dolfinx" path.
+
+## Consequences
+
+Easier:
+
+- Three clearly documented install paths, each validated by the
+  project: Docker (CI), conda (README), Colab (notebook).
+- Docker is bit-exact reproducible for development; conda is fast on
+  native hardware; Colab is accessible with no local tooling at all.
+- When dolfinx 0.11 lands, we update one base image, bump the Colab
+  install URL, and update the conda channel spec.
+
+Harder:
+
+- Three install paths is more documentation surface than one.
+- The Docker-on-Apple-Silicon path is slow (dolfinx base image is
+  x86_64; on M-series Macs it runs under emulation). Contributors on
+  Apple Silicon are encouraged to use conda-forge instead.
+- First-time Docker build pulls several GB of base image.
+
+Rejected alternatives:
+
+- **pip-from-source dolfinx:** multi-hour build, brittle dependence on
+  the user's PETSc, MPI, and compiler versions, breaks silently on
+  PETSc major version bumps.
+- **apt / brew / pacman system packages:** version lag makes the API
+  drift documented in ADR 0003 unworkable.
+
+## Related
+
+- `Dockerfile`, `docker-compose.yml` at repo root.
+- Invariant 9 in `PLAN.md`.
+- README's "Quick start on Colab" and "Docker" sections.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,69 @@
+# Architecture Decision Records
+
+This directory holds the Architecture Decision Records (ADRs) for
+kronos-semi. An ADR captures a single significant decision: its context,
+the decision itself, and its consequences. Once accepted, an ADR is
+immutable. To change an accepted decision, write a new ADR that
+supersedes the old one and mark the old one as Superseded.
+
+## When to add an ADR
+
+Add an ADR for any change that:
+
+- Modifies an item listed under "Invariants" in `PLAN.md`.
+- Introduces a new external dependency or removes one.
+- Changes the target version of a core tool (dolfinx, PETSc, Python).
+- Alters the input format or breaks backward compatibility of the JSON
+  schema.
+- Picks between multiple defensible technical approaches where the
+  choice is visible to users or future maintainers.
+
+Do **not** add ADRs for routine code changes, bug fixes, or internal
+refactors that do not cross an invariant.
+
+## Format
+
+Each ADR is a separate markdown file named
+`NNNN-short-slug.md`, numbered sequentially from 0001. Each file follows
+this skeleton:
+
+```markdown
+# NNNN. Short title
+
+- Status: Proposed | Accepted | Deprecated | Superseded by ADR-XXXX
+- Date: YYYY-MM-DD
+
+## Context
+
+What problem are we solving? What forces are at play?
+
+## Decision
+
+What did we decide to do? State it plainly.
+
+## Consequences
+
+What becomes easier, harder, or impossible as a result? Note any
+follow-up ADRs that might be needed.
+```
+
+## Status values
+
+- **Proposed:** under discussion; not binding.
+- **Accepted:** in effect; code must conform.
+- **Deprecated:** no longer applies but kept for historical context; no
+  replacement needed.
+- **Superseded by ADR-XXXX:** replaced; see the linked ADR for the
+  current decision.
+
+## Reference
+
+Template and background: <https://github.com/joelparkerhenderson/architecture-decision-record>.
+
+## Index
+
+- [0001 JSON as input format](0001-json-as-input-format.md)
+- [0002 Nondimensionalization is mandatory](0002-nondimensionalization-mandatory.md)
+- [0003 Target dolfinx 0.10 API only](0003-dolfinx-0-10-api.md)
+- [0004 Slotboom variables for drift-diffusion](0004-slotboom-variables-for-dd.md)
+- [0005 Docker for dev, conda and FEM-on-Colab for users](0005-docker-for-dev-conda-fem-on-colab-for-users.md)


### PR DESCRIPTION
## Summary

Adds in-repo planning and reference documents so future AI agents and
human contributors have an authoritative source of truth for what is
built, what is next, and which design decisions are locked.

**No code changes.** Docs only.

This PR is stacked on `dev/docker-day1-fix` (Day 1). It targets that
branch as its base so the diff view stays clean. After the Day 1 PR
merges to `main`, this one can be retargeted to `main` and rebased.

## Files added

- `PLAN.md` (root): authoritative current state, next task, invariants,
  non-goals, and append-only completed work log. Kept under 300 lines.
- `docs/PHYSICS.md`: governing equations (Poisson, Slotboom continuity,
  SRH), nondimensionalization derivation with the explicit
  $L_D^2 = \lambda^2 L_0^2$ note (cautionary reference to the Day 1
  coefficient bug), boundary conditions, reference values cross-linked
  to `semi/materials.py`.
- `docs/ARCHITECTURE.md`: five-layer design with per-layer
  provides / depends-on / must-not-depend-on rules.
- `docs/adr/README.md` + five initial ADRs:
  - 0001 JSON as input format
  - 0002 Nondimensionalization mandatory
  - 0003 Target dolfinx 0.10 API only
  - 0004 Slotboom variables for drift-diffusion
  - 0005 Docker for dev, conda and FEM-on-Colab for users
- `docs/ROADMAP.md`: per-day breakdown with deliverables, verification
  commands, and dependencies.

## Files modified

- `README.md`: new Planning documents section between the badge and
  Status.
- `CONTRIBUTING.md`: Before you start callout pointing at PLAN.md,
  docs/PHYSICS.md, docs/ARCHITECTURE.md, and docs/adr/.

## Commits

1. docs: add PLAN.md as authoritative planning document
2. docs: add PHYSICS.md and ARCHITECTURE.md
3. docs: add architecture decision records
4. docs: add ROADMAP.md with per-day deliverables and verification
5. docs: point README and CONTRIBUTING at the new planning docs

## Ground-rules check

- No em dashes in any new prose (`grep -P '[\x{2013}\x{2014}]'` on new
  files returns nothing). Pre-existing em dashes in README and
  CONTRIBUTING were not touched; per the invariant they should be
  cleaned up in a separate pass.
- No new code, no existing code reorganized.
- Physics and reference values were cross-checked against
  `semi/materials.py`, `semi/scaling.py`, and `semi/physics/poisson.py`.
- LaTeX math used throughout `docs/PHYSICS.md`.

## Not self-merging

Per the workflow in the brief, this PR is left for human review.