### PR TITLE
ci: fix branch trigger glob and add dockerized FEM benchmark job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches:
+      - main
+      - "dev/**"
+      - "ci/**"
+      - "docs/**"
   pull_request:
     branches: [main]
 
@@ -44,3 +48,69 @@ jobs:
           python-version: "3.12"
       - run: pip install ruff
       - run: ruff check semi/ tests/
+
+  docker-fem:
+    # FEM integration: build the dolfinx dev image, run pytest inside,
+    # and execute both benchmark verifiers. Slow (~10-12 min once cached)
+    # but this is the only place the dolfinx code paths actually run.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show runner UID/GID
+        # First-run diagnostic. Leave this in until the job proves stable,
+        # then it can be removed in a follow-up. The UID/GID determine
+        # whether bind-mounted files are writable from inside the container.
+        run: id
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image with GHA cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          tags: kronos-semi:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            USER_UID=1001
+            USER_GID=127
+
+      - name: Run pytest inside container
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspaces/kronos-semi" \
+            -w /workspaces/kronos-semi \
+            kronos-semi:ci \
+            pytest tests/ -v --tb=short
+
+      - name: Run pn_1d benchmark
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspaces/kronos-semi" \
+            -w /workspaces/kronos-semi \
+            -e MPLBACKEND=Agg \
+            kronos-semi:ci \
+            python scripts/run_benchmark.py pn_1d
+
+      - name: Run pn_1d_bias benchmark
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspaces/kronos-semi" \
+            -w /workspaces/kronos-semi \
+            -e MPLBACKEND=Agg \
+            kronos-semi:ci \
+            python scripts/run_benchmark.py pn_1d_bias
+
+      - name: Upload benchmark plots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-plots
+          path: results/
+          retention-days: 14


### PR DESCRIPTION
## Motivation

Three problems with the current CI that this PR addresses:

1. **Broken branch trigger.** `branches: [main, dev]` matches literal branch names. Day 1 and Day 2 feature branches (`dev/docker-day1-fix`, `dev/day2-drift-diffusion`) never fired CI on push, only on PR. Fixed by using `dev/**` glob (plus `ci/**` and `docs/**` for their respective branches).
2. **No FEM code in CI.** The entire dolfinx-dependent layer was never exercised. The Day 1 coefficient bug slipped past everything except a manual local run. Added a `docker-fem` job that builds the dev image and runs pytest + both benchmark verifiers inside it.
3. **No benchmark regression gate.** Prior to this PR nothing prevented a future change from silently breaking `pn_1d` or `pn_1d_bias`. The new job makes both regression-gated on every push to `main`, `dev/**`, `ci/**`, `docs/**`, and on every PR to `main`.

## CI run evidence

First push on this branch: https://github.com/rwalkerlewis/kronos-semi/actions/runs/24702537972

All five jobs green on first run:

| Job | Duration |
|-----|---------:|
| `lint` | 10s |
| `pure-python (3.10)` | 18s |
| `pure-python (3.11)` | 21s |
| `pure-python (3.12)` | 16s |
| `docker-fem` | 3m 25s |

`docker-fem` step breakdown:

| Step | Duration |
|------|---------:|
| Set up Docker Buildx | 4s |
| Build image with GHA cache (first run, no cache) | 3m 0s |
| Run pytest inside container (70 passed) | 2s |
| Run pn_1d benchmark (6/6 green) | 4s |
| Run pn_1d_bias benchmark (verifier green) | 6s |
| Upload benchmark plots | 1s |

Subsequent runs with warm Buildx cache should fit within the 10-12 minute budget well under the 30-minute timeout.

## Runner UID/GID observation

The diagnostic step reported `uid=1001(runner) gid=1001(runner) groups=...,118(docker),...`, not the `1001:127` assumed in the build args. The job still passed because (a) the UID matches, so bind-mounted files written from inside the container are owned by the runner user, and (b) the runner is in the `docker` group, which grants access to the daemon socket. Leaving the `USER_GID=127` arg in place since changing it is not required for the job to stay green; this can be reconsidered in the follow-up that removes the diagnostic step.

## Follow-ups

- The `Show runner UID/GID` diagnostic step can be removed in a follow-up once `docker-fem` has proven stable over several runs.
- A dedicated `fem-unit-tests/` directory for dolfinx-requiring tests would let us split fast pytest from slow FEM tests. Deferred until we have enough of them to matter.

## Checklist

- [x] Both `pure-python` and `docker-fem` jobs green on this branch
- [x] `pure-python` passes on Python 3.10/3.11/3.12
- [x] `docker-fem` builds the image, runs pytest (70 passing), runs both benchmarks green
- [x] `benchmark-plots` artifact uploaded (Upload step completed; contains `results/pn_1d/` and `results/pn_1d_bias/` PNGs)
- [x] No code changes outside `.github/workflows/ci.yml`