### PR TITLE
Day 4: Verification and Validation suite (MMS-Poisson + MMS-DD + mesh convergence + conservation checks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,11 @@ jobs:
 
   docker-fem:
     # FEM integration: build the dolfinx dev image, run pytest inside,
-    # and execute both benchmark verifiers. Slow (~10-12 min once cached)
-    # but this is the only place the dolfinx code paths actually run.
+    # and execute the benchmark verifiers plus the full V&V suite. The
+    # job stays inside a 15-minute budget once the image is cached.
+    # This is the only place the dolfinx code paths actually run.
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -116,10 +117,19 @@ jobs:
             kronos-semi:ci \
             python scripts/run_benchmark.py pn_1d_bias_reverse
 
-      - name: Upload benchmark plots
+      - name: Run V&V suite (MMS Poisson, mesh convergence, conservation, MMS DD)
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspaces/kronos-semi" \
+            -w /workspaces/kronos-semi \
+            -e MPLBACKEND=Agg \
+            kronos-semi:ci \
+            python scripts/run_verification.py all
+
+      - name: Upload results (benchmarks + V&V artifacts)
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-plots
+          name: fem-results
           path: results/
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [0.4.0] - Day 4
+
+### Added
+- Verification & Validation suite under `semi/verification/`, driven
+  by `scripts/run_verification.py` with subcommands `mms_poisson`,
+  `mesh_convergence`, `conservation`, `mms_dd`, and `all`:
+  - `mms_poisson`: 1D linear, 1D nonlinear, 2D triangles + 2D quad
+    smoke. Finest-pair rates at theoretical L^2 = 2.000,
+    H^1 = 0.999-1.000; quad/triangle ratio 0.394.
+  - `mesh_convergence`: `pn_1d` sweep over
+    N in [50, 100, 200, 400, 800, 1600] with Cauchy self-convergence
+    reported as the primary convergence metric (depletion-approximation
+    errors plateau because the reference is itself approximate; this
+    is honest-flagged in runner output and in `docs/PHYSICS.md`).
+    Cauchy ratios >= 1.99x per doubling on E_peak and W over the
+    first four levels.
+  - `conservation`: charge conservation on `pn_1d` equilibrium
+    (|Q_net|/Q_ref = 1.5e-17 vs. 1e-10 threshold) and current
+    continuity on `pn_1d_bias` forward (5% tol) and
+    `pn_1d_bias_reverse` (15% tol); worst max_rel 1.91% / 0.020%.
+  - `mms_dd`: three variants (psi-only, full coupling no R, full
+    coupling with SRH) x three grids (1D default, 1D nonlinear, 2D).
+    Every gated block rate >= 1.99 L^2 and >= 0.996 H^1.
+- Derivation artifact `docs/mms_dd_derivation.md` (gate-first:
+  approved before any MMS-DD code landed). Amended with the
+  implementation-time SNES tolerance fix: `atol = 0.0` with
+  `stol = 1e-12` (the originally-proposed `atol = 1e-16` was below
+  the 2D continuity-block initial residual and terminated Newton
+  prematurely).
+- New ADR `docs/adr/0006-verification-and-validation-strategy.md`
+  recording the four-phase V&V choice and rejected alternatives
+  (devsim code-to-code, single-MMS-for-everything).
+- New "Verification & Validation" section in `docs/PHYSICS.md`
+  (Section 5) with current finest-pair rates and honest flags.
+- CI `docker-fem` job now runs
+  `python scripts/run_verification.py all` inside the dolfinx
+  container; timeout tightened from 30 to 15 minutes.
+
+### Changed
+- `benchmark-plots` CI artifact renamed to `fem-results`; path
+  stays `results/` and now covers benchmarks + V&V together.
+- Day-4 scope re-purposed: the originally-planned refactor pass is
+  pushed to Day 5 to make room for the V&V work (see
+  `docs/adr/0006-*.md` context).
+
 ## [0.3.0] - Day 3
 
 ### Added

--- a/PLAN.md
+++ b/PLAN.md
@@ -30,14 +30,17 @@ recombination for 1D/2D/3D devices.
 - URL: https://github.com/rwalkerlewis/kronos-semi
 - License: MIT
 - Primary branch: `main`
-- Active dev branch: `dev/day4-refactor` (Day 4 to be cut after Day 3 PR merges)
+- Active dev branch: `dev/day4-vnv` (Day 4 V&V suite in flight)
 
 ## Current state
 
-Day 1 and Day 2 are merged into `main`. CI hardening (branch glob plus
-Dockerized FEM job) merged on `ci/docker-benchmark-matrix`. Day 3
-(adaptive bias continuation, Sah-Noyce-Shockley verifier, reverse-bias
-check) is in flight on `dev/day3-bias-hardening`.
+Day 1, Day 2, and Day 3 are merged into `main`. CI hardening (branch
+glob plus Dockerized FEM job) merged on `ci/docker-benchmark-matrix`.
+Day 3 (adaptive bias continuation, Sah-Noyce-Shockley verifier,
+reverse-bias generation check) merged via PR #5 from
+`dev/day3-bias-hardening`. Day 4 has been re-scoped from a refactor pass
+to a Verification & Validation suite (MMS, mesh convergence,
+conservation checks); the original refactor is pushed to Day 5.
 
 ### What works (verified in Docker on current `main`)
 
@@ -64,18 +67,25 @@ check) is in flight on `dev/day3-bias-hardening`.
 - `pn_1d` benchmark (equilibrium): V_bi, peak |E|, bulk densities, mass
   action, all within 5-10% of depletion-approximation theory.
 - `pn_1d_bias` benchmark (forward bias): J at V = 0.6 V within 10% of
-  Shockley long-diode theory. Low-bias behaviour is qualitative in Day 2
-  because depletion-region SRH recombination raises ideality toward 2;
-  Day 3 will make that regime quantitative by adding the Sah-Noyce-
-  Shockley term.
+  Shockley long-diode theory; J_sim within 15% of the Sah-Noyce-Shockley
+  total (J_diff + J_rec, with the Sze f = 2 V_t/(V_bi - V) correction)
+  on V in [0.15, 0.55] V. The original Day 2 "qualitative below 0.5 V"
+  caveat was retired by the Day 3 SNS verifier.
+- `pn_1d_bias_reverse` benchmark (reverse bias): |J| within 20% of the
+  net SRH generation current (q n_i / 2 tau_eff)(W(V) - W(0)) on V in
+  [-2, -0.5] V.
 - GitHub Actions runs pure-Python tests on 3.10/3.11/3.12, ruff, and a
   Dockerized FEM job that runs pytest plus both benchmark verifiers on
   every push to `main`, `dev/**`, `ci/**`, `docs/**`.
 
 ### What does not work / not yet built
 
-- 2D MOS capacitor benchmark (Day 5).
-- 3D doped resistor benchmark (Day 6).
+- Verification & Validation suite (Day 4, in flight on
+  `dev/day4-vnv`): MMS for Poisson and DD, mesh convergence study,
+  current/charge conservation checks, CI integration.
+- Refactor of `semi/run.py` and BC construction (Day 5).
+- 2D MOS capacitor benchmark (Day 6).
+- 3D doped resistor benchmark (Day 7).
 - Gmsh `.msh` mesh loader (stubbed, raises `NotImplementedError`).
 - Gate contacts (`type: "gate"`), Schottky contacts.
 - Field-dependent mobility, Auger/radiative recombination, Fermi-Dirac
@@ -83,37 +93,68 @@ check) is in flight on `dev/day3-bias-hardening`.
 
 ## Next task
 
-**Day 4: Refactor, expanded test coverage, physics docs updates.**
-Planned.
+**Day 4: Verification & Validation suite.** In flight on
+`dev/day4-vnv`. Replaces the originally-planned refactor pass; the
+refactor is pushed to Day 5.
 
-- **Branch:** `dev/day4-refactor` (to be cut from `main` after the
-  Day 3 PR merges).
-- **Scope, in (per `docs/ROADMAP.md` Day 4):**
-  - Break `semi/run.py` into `run_equilibrium` and `run_bias_sweep`
-    modules with a thin `run(cfg)` dispatcher (partially done; extract
-    BC construction into `semi/bcs.py`).
-  - Raise pure-Python coverage to 95%+; add in-memory integration
-    tests for `run` itself.
-  - Update `docs/PHYSICS.md` with the scaled drift-diffusion
-    derivation now that all Day 2/3 terms are implemented.
-  - Add `docs/adr/0006-bc-construction-interface.md` if the BC refactor
-    introduces a new decision.
+- **Branch:** `dev/day4-vnv` (cut from `main` after PR #5 merged).
+- **Rationale:** the existing `pn_1d` / `pn_1d_bias` /
+  `pn_1d_bias_reverse` "verifiers" are single-point physical sanity
+  tests, not verification in the Roache / Oberkampf-Roy sense. We have
+  no mesh convergence evidence, no manufactured solutions, and no
+  conservation checks. Closing this gap is a higher-value use of Day 4
+  than refactoring.
+- **Scope, in (five phases):**
+  - **Phase 1: MMS for Poisson.** New module
+    `semi/verification/mms_poisson.py` with 1D and 2D smooth
+    manufactured solutions, observed L^2 / H^1 convergence rate
+    measurement, CSV+PNG output under `results/mms_poisson/`. Tests in
+    `tests/fem/test_mms_poisson.py` (skipped when dolfinx missing).
+    Acceptance: L^2 rate >= 1.85 on the finest mesh pair.
+  - **Phase 2: Mesh convergence on `pn_1d`.** New module
+    `semi/verification/mesh_convergence.py`. Sweep N in
+    [50, 100, 200, 400, 800, 1600], record V_bi / peak |E| /
+    depletion-width error, Newton iterations, solve time. Acceptance:
+    monotone error reduction; documented convergence order.
+  - **Phase 3: Conservation checks.** Current continuity check
+    (J_n + J_p constant in space, +-5% forward / +-15% reverse) added
+    to `pn_1d_bias` and `pn_1d_bias_reverse` verifiers; charge
+    conservation check (integrated rho == 0 to solver tolerance) added
+    to `pn_1d`.
+  - **Phase 4: MMS for coupled drift-diffusion.** New module
+    `semi/verification/mms_dd.py`. Three tests: psi-only with frozen
+    quasi-Fermis, full three-block coupling, full coupling with SRH.
+    Acceptance: L^2 rate >= 1.75 on each field on the finest pair.
+  - **Phase 5: CI integration.** Add `run_verification.py all` to the
+    `docker-fem` job; upload `results/mms_*` and
+    `results/mesh_convergence/` as workflow artifacts.
+  - **Phase 6 (Final): Documentation.** New "Verification & Validation"
+    section in `docs/PHYSICS.md`, new ADR
+    `0006-verification-and-validation-strategy.md`, CHANGELOG update.
 - **Scope, out:**
-  - 2D or 3D benchmarks (Days 5-6).
+  - Refactor of `run.py` / BC extraction (Day 5).
+  - 2D MOS capacitor (Day 6) and 3D resistor (Day 7).
   - Colab notebook updates.
-- **Preconditions:** Day 3 PR merged into `main`.
+  - `devsim` code-to-code comparison (post-submission).
+- **Preconditions:** Day 3 (PR #5) merged into `main`. Done.
+- **Hard invariants for this PR:** mesh stays in meters with
+  L_D^2 = lambda2 * L_0^2 on Poisson LHS; pure-Python core stays
+  dolfinx-free (`semi/verification/` may import dolfinx); dolfinx 0.10
+  API only; Slotboom variables for DD; no em dashes in new prose;
+  no Colab work.
 
 ## Roadmap
 
-| Day | Milestone                                                    | Status  | Notes                                                                 |
-|----:|--------------------------------------------------------------|---------|-----------------------------------------------------------------------|
-| 1   | Equilibrium Poisson, 1D pn junction, Docker env              | Done    | 6/6 verifier checks pass; PR `dev/docker-day1-fix`                    |
-| 2   | Slotboom drift-diffusion, coupled Newton, bias sweep         | Done    | 6/6 `pn_1d_bias` checks pass; PR `dev/day2-drift-diffusion`           |
-| 3   | Bias ramping continuation, Shockley IV verifier hardening    | Done    | Adaptive ramp (-26.2% iters), SNS verifier, reverse-bias gen check    |
-| 4   | Refactor pass, expanded test coverage, physics docs updates  | Planned | Ruff-clean, coverage target, ADR review                               |
-| 5   | 2D MOS capacitor (oxide + silicon multi-region)              | Planned | Uses submesh for carriers; verify C-V curve                           |
-| 6   | 3D doped resistor                                            | Planned | Framework extension; verify Ohmic V-I linearity                       |
-| 7   | Final polish, submission packaging                           | Planned | Regenerate notebooks, tag release                                     |
+| Day | Milestone                                                    | Status     | Notes                                                                 |
+|----:|--------------------------------------------------------------|------------|-----------------------------------------------------------------------|
+| 1   | Equilibrium Poisson, 1D pn junction, Docker env              | Done       | 6/6 verifier checks pass; PR `dev/docker-day1-fix`                    |
+| 2   | Slotboom drift-diffusion, coupled Newton, bias sweep         | Done       | 6/6 `pn_1d_bias` checks pass; PR `dev/day2-drift-diffusion`           |
+| 3   | Bias ramping continuation, Shockley IV verifier hardening    | Done       | Adaptive ramp (-26.2% iters), SNS verifier, reverse-bias gen check    |
+| 4   | Verification & Validation suite (MMS, conv, conservation)    | In flight  | `dev/day4-vnv`; replaces refactor; MMS-Poisson, MMS-DD, mesh, CI      |
+| 5   | Refactor pass, expanded test coverage, physics docs updates  | Planned    | Ruff-clean, coverage target, ADR review (was Day 4)                   |
+| 6   | 2D MOS capacitor (oxide + silicon multi-region)              | Planned    | Uses submesh for carriers; verify C-V curve (was Day 5)               |
+| 7   | 3D doped resistor                                            | Planned    | Framework extension; verify Ohmic V-I linearity (was Day 6)           |
+| 8   | Final polish, submission packaging                           | Planned    | Regenerate notebooks, tag release (was Day 7)                         |
 
 See `docs/ROADMAP.md` for the full per-day breakdown.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -30,17 +30,19 @@ recombination for 1D/2D/3D devices.
 - URL: https://github.com/rwalkerlewis/kronos-semi
 - License: MIT
 - Primary branch: `main`
-- Active dev branch: `dev/day4-vnv` (Day 4 V&V suite in flight)
+- Active dev branch: `dev/day4-vnv` (Day 4 V&V suite complete, PR pending)
 
 ## Current state
 
-Day 1, Day 2, and Day 3 are merged into `main`. CI hardening (branch
-glob plus Dockerized FEM job) merged on `ci/docker-benchmark-matrix`.
-Day 3 (adaptive bias continuation, Sah-Noyce-Shockley verifier,
-reverse-bias generation check) merged via PR #5 from
-`dev/day3-bias-hardening`. Day 4 has been re-scoped from a refactor pass
-to a Verification & Validation suite (MMS, mesh convergence,
-conservation checks); the original refactor is pushed to Day 5.
+Day 1, Day 2, Day 3, and Day 4 are delivered. Day 1-3 are merged into
+`main`. CI hardening (branch glob plus Dockerized FEM job) merged on
+`ci/docker-benchmark-matrix`. Day 3 (adaptive bias continuation,
+Sah-Noyce-Shockley verifier, reverse-bias generation check) merged via
+PR #5 from `dev/day3-bias-hardening`. Day 4 (Verification & Validation
+suite: MMS-Poisson, mesh convergence, discrete conservation, MMS for
+coupled drift-diffusion, CI integration, documentation) is complete on
+`dev/day4-vnv` and awaiting PR. The original Day-4 refactor pass is
+pushed to Day 5.
 
 ### What works (verified in Docker on current `main`)
 
@@ -75,14 +77,19 @@ conservation checks); the original refactor is pushed to Day 5.
   net SRH generation current (q n_i / 2 tau_eff)(W(V) - W(0)) on V in
   [-2, -0.5] V.
 - GitHub Actions runs pure-Python tests on 3.10/3.11/3.12, ruff, and a
-  Dockerized FEM job that runs pytest plus both benchmark verifiers on
-  every push to `main`, `dev/**`, `ci/**`, `docs/**`.
+  Dockerized FEM job that runs pytest, three benchmark verifiers, and
+  the full V&V suite on every push to `main`, `dev/**`, `ci/**`,
+  `docs/**`. Job timeout is 15 minutes once the dolfinx image is cached.
+- Verification & Validation suite (Day 4): MMS for Poisson (1D linear,
+  1D nonlinear, 2D triangles, 2D quad smoke) with finest-pair rates at
+  theoretical 2.0/1.0; mesh convergence on `pn_1d` with Cauchy ratios
+  >= 1.99x per doubling; discrete conservation (charge on `pn_1d`
+  equilibrium at relative 1.5e-17; current continuity on forward and
+  reverse bias sweeps); MMS for coupled drift-diffusion (three variants
+  x three grids) with all gated block rates >= 1.99.
 
 ### What does not work / not yet built
 
-- Verification & Validation suite (Day 4, in flight on
-  `dev/day4-vnv`): MMS for Poisson and DD, mesh convergence study,
-  current/charge conservation checks, CI integration.
 - Refactor of `semi/run.py` and BC construction (Day 5).
 - 2D MOS capacitor benchmark (Day 6).
 - 3D doped resistor benchmark (Day 7).
@@ -93,55 +100,30 @@ conservation checks); the original refactor is pushed to Day 5.
 
 ## Next task
 
-**Day 4: Verification & Validation suite.** In flight on
-`dev/day4-vnv`. Replaces the originally-planned refactor pass; the
-refactor is pushed to Day 5.
+**Day 5: Refactor pass, expanded coverage, docs update.** Ready to
+start once Day 4 merges.
 
-- **Branch:** `dev/day4-vnv` (cut from `main` after PR #5 merged).
-- **Rationale:** the existing `pn_1d` / `pn_1d_bias` /
-  `pn_1d_bias_reverse` "verifiers" are single-point physical sanity
-  tests, not verification in the Roache / Oberkampf-Roy sense. We have
-  no mesh convergence evidence, no manufactured solutions, and no
-  conservation checks. Closing this gap is a higher-value use of Day 4
-  than refactoring.
-- **Scope, in (five phases):**
-  - **Phase 1: MMS for Poisson.** New module
-    `semi/verification/mms_poisson.py` with 1D and 2D smooth
-    manufactured solutions, observed L^2 / H^1 convergence rate
-    measurement, CSV+PNG output under `results/mms_poisson/`. Tests in
-    `tests/fem/test_mms_poisson.py` (skipped when dolfinx missing).
-    Acceptance: L^2 rate >= 1.85 on the finest mesh pair.
-  - **Phase 2: Mesh convergence on `pn_1d`.** New module
-    `semi/verification/mesh_convergence.py`. Sweep N in
-    [50, 100, 200, 400, 800, 1600], record V_bi / peak |E| /
-    depletion-width error, Newton iterations, solve time. Acceptance:
-    monotone error reduction; documented convergence order.
-  - **Phase 3: Conservation checks.** Current continuity check
-    (J_n + J_p constant in space, +-5% forward / +-15% reverse) added
-    to `pn_1d_bias` and `pn_1d_bias_reverse` verifiers; charge
-    conservation check (integrated rho == 0 to solver tolerance) added
-    to `pn_1d`.
-  - **Phase 4: MMS for coupled drift-diffusion.** New module
-    `semi/verification/mms_dd.py`. Three tests: psi-only with frozen
-    quasi-Fermis, full three-block coupling, full coupling with SRH.
-    Acceptance: L^2 rate >= 1.75 on each field on the finest pair.
-  - **Phase 5: CI integration.** Add `run_verification.py all` to the
-    `docker-fem` job; upload `results/mms_*` and
-    `results/mesh_convergence/` as workflow artifacts.
-  - **Phase 6 (Final): Documentation.** New "Verification & Validation"
-    section in `docs/PHYSICS.md`, new ADR
-    `0006-verification-and-validation-strategy.md`, CHANGELOG update.
+- **Branch:** to be cut from `main` after `dev/day4-vnv` merges.
+- **Goal:** pay down accumulated technical debt before moving to 2D/3D
+  (Days 6-7). Break `semi/run.py` into `run_equilibrium` and
+  `run_bias_sweep` functions behind a thin `run(cfg)` dispatcher;
+  factor BC construction into `semi/bcs.py` so ohmic, gate, and
+  future Schottky contacts share a common interface.
+- **Scope, in:**
+  - `semi/run.py` split with no behavioral change to `pn_1d`,
+    `pn_1d_bias`, `pn_1d_bias_reverse`.
+  - `semi/bcs.py` extraction from `_build_ohmic_bcs` and bias-contact
+    plumbing.
+  - Pure-Python coverage target: 95%+ per `pytest --cov=semi`.
+  - `docs/PHYSICS.md` scaled drift-diffusion derivation completed
+    (Section 2.5 is still a placeholder).
+  - Any ADR the refactor requires (ADR 0007 is free).
 - **Scope, out:**
-  - Refactor of `run.py` / BC extraction (Day 5).
   - 2D MOS capacitor (Day 6) and 3D resistor (Day 7).
-  - Colab notebook updates.
-  - `devsim` code-to-code comparison (post-submission).
-- **Preconditions:** Day 3 (PR #5) merged into `main`. Done.
-- **Hard invariants for this PR:** mesh stays in meters with
-  L_D^2 = lambda2 * L_0^2 on Poisson LHS; pure-Python core stays
-  dolfinx-free (`semi/verification/` may import dolfinx); dolfinx 0.10
-  API only; Slotboom variables for DD; no em dashes in new prose;
-  no Colab work.
+  - Field-dependent mobility, Auger, Fermi-Dirac (Non-goals).
+- **Preconditions:** Day 4 V&V suite merged into `main`.
+- **Hard invariants for this PR:** see "Invariants" below; Day-4 V&V
+  gates must stay green through the refactor.
 
 ## Roadmap
 
@@ -150,8 +132,8 @@ refactor is pushed to Day 5.
 | 1   | Equilibrium Poisson, 1D pn junction, Docker env              | Done       | 6/6 verifier checks pass; PR `dev/docker-day1-fix`                    |
 | 2   | Slotboom drift-diffusion, coupled Newton, bias sweep         | Done       | 6/6 `pn_1d_bias` checks pass; PR `dev/day2-drift-diffusion`           |
 | 3   | Bias ramping continuation, Shockley IV verifier hardening    | Done       | Adaptive ramp (-26.2% iters), SNS verifier, reverse-bias gen check    |
-| 4   | Verification & Validation suite (MMS, conv, conservation)    | In flight  | `dev/day4-vnv`; replaces refactor; MMS-Poisson, MMS-DD, mesh, CI      |
-| 5   | Refactor pass, expanded test coverage, physics docs updates  | Planned    | Ruff-clean, coverage target, ADR review (was Day 4)                   |
+| 4   | Verification & Validation suite (MMS, conv, conservation)    | Done       | `dev/day4-vnv`; all four phases green, CI V&V step within 15 min      |
+| 5   | Refactor pass, expanded test coverage, physics docs updates  | Queued     | Ruff-clean, coverage target, ADR review (was Day 4)                   |
 | 6   | 2D MOS capacitor (oxide + silicon multi-region)              | Planned    | Uses submesh for carriers; verify C-V curve (was Day 5)               |
 | 7   | 3D doped resistor                                            | Planned    | Framework extension; verify Ohmic V-I linearity (was Day 6)           |
 | 8   | Final polish, submission packaging                           | Planned    | Regenerate notebooks, tag release (was Day 7)                         |
@@ -214,6 +196,46 @@ They may be added after submission as stretch goals (see
 ## Completed work log
 
 Append-only. Newest entries on top.
+
+- **Day 4 (2026-04-21):** Verification & Validation suite. Replaces
+  the originally-planned refactor (pushed to Day 5) with four
+  verification activities, each gated in CI via
+  `scripts/run_verification.py`:
+  - **MMS for equilibrium Poisson** (`semi/verification/mms_poisson.py`):
+    1D linear, 1D nonlinear, 2D triangles sweep with UFL weak-form
+    forcing. Finest-pair L^2 rates at theoretical 2.000, H^1 at
+    0.999-1.000. `2d_quad_smoke` sanity ratio 0.394.
+  - **Mesh convergence on `pn_1d`** (`semi/verification/mesh_convergence.py`):
+    N in [50..1600] sweep; Cauchy self-convergence >= 1.99x per
+    doubling on E_peak and W over the first four levels; honest-flag
+    plateau documented because the depletion-approximation reference
+    is itself approximate.
+  - **Conservation** (`semi/verification/conservation.py`): charge
+    conservation on `pn_1d` equilibrium at rel 1.5e-17; current
+    continuity on `pn_1d_bias` (V in {0.30, 0.45, 0.60} V) and
+    `pn_1d_bias_reverse` (V in {-0.50, -1.00, -2.00} V) with worst
+    max_rel 1.91% forward / 0.020% reverse, inside the 5% / 15% tols.
+  - **MMS for coupled drift-diffusion** (`semi/verification/mms_dd.py`):
+    three variants (psi-only / full coupling no R / full coupling with
+    SRH) x three grids (1D default, 1D nonlinear, 2D); every gated
+    block rate >= 1.99 L^2 and >= 0.996 H^1. Derivation artifact:
+    `docs/mms_dd_derivation.md`. Implementation-time amendment to the
+    derivation: SNES `atol = 0.0`, `stol = 1e-12` (the originally-
+    proposed `atol = 1e-16` was below the 2D continuity-block initial
+    residual and terminated Newton prematurely).
+  - **CLI driver** `scripts/run_verification.py` with subcommands
+    `mms_poisson`, `mesh_convergence`, `conservation`, `mms_dd`, `all`.
+  - **CI integration:** `docker-fem` job adds a V&V step running
+    `run_verification.py all` inside the dolfinx image; timeout
+    tightened from 30 to 15 minutes; `benchmark-plots` artifact
+    renamed `fem-results` and keeps uploading the full `results/`
+    tree.
+  - **Documentation:** new "Verification & Validation" section in
+    `docs/PHYSICS.md` with current finest-pair rates and honest flags
+    (depletion plateau, Variant A scope, block residual scale
+    disparity); new ADR
+    `docs/adr/0006-verification-and-validation-strategy.md`. PR:
+    `dev/day4-vnv`.
 
 - **Day 3 (2026-04-21):** adaptive bias continuation, Sah-Noyce-
   Shockley recombination in the forward verifier, and a dedicated

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -304,3 +304,159 @@ Source of truth for material parameters: `semi/materials.py`.
 See `semi/materials.py` for Ge, GaAs. Insulators (SiO2 $\varepsilon_r = 3.9$,
 HfO2 $\varepsilon_r = 25.0$, Si3N4 $\varepsilon_r = 7.5$) carry only a relative
 permittivity; semiconductor-specific fields are zero on them.
+
+## 5. Verification & Validation
+
+This section documents the Day-4 V&V suite and its results. The code
+lives under `semi/verification/`, the runner is
+`scripts/run_verification.py`, artifacts land under
+`results/mms_poisson/`, `results/mesh_convergence/`,
+`results/conservation/`, and `results/mms_dd/`. CI runs
+`python scripts/run_verification.py all` inside the `docker-fem` job on
+every push and uploads the full `results/` tree.
+
+The distinction followed here is the Roache / Oberkampf-Roy one.
+**Verification** asks "did we solve the equations we wrote down
+correctly?"; it is a property of the code and its discretization.
+**Validation** asks "are those equations the right model for the
+device?"; it compares the code to experiment or to an accepted
+reference model. The four activities below are all verification
+activities. The earlier single-point benchmark verifiers (`pn_1d`,
+`pn_1d_bias`, `pn_1d_bias_reverse`) stand as validation against
+depletion-approximation and Shockley / SNS analytics; they remain in
+CI unchanged.
+
+### 5.1 MMS for equilibrium Poisson (Phase 1)
+
+Module: `semi/verification/mms_poisson.py`. Subcommand:
+`run_verification.py mms_poisson`.
+
+Manufactured smooth exact solutions (1D sin, 2D sin-sin with distinct
+wavenumbers) are injected into the equilibrium Poisson form with UFL
+weak-form forcing. The mesh is refined over several levels; the
+observed L^2 and H^1 rates are measured on each refinement pair. The
+finest-pair rate is gated at L^2 >= 1.85 and H^1 >= 0.85, with
+monotone error reduction required across the sweep.
+
+Finest-pair rates on the latest run (N = 320 for 1D, N = 128 for 2D):
+
+| Study          | L^2 rate | H^1 rate |
+|----------------|----------|----------|
+| 1D linear      | 2.000    | 1.000    |
+| 1D nonlinear   | 2.000    | 1.000    |
+| 2D triangles   | 1.998    | 0.999    |
+
+The `2d_quad_smoke` sanity check confirms the quad-element L^2 error
+is within an order of magnitude of the triangle error at N = 64
+(ratio ~0.39, well inside the [0.1, 10] acceptance band).
+
+### 5.2 Mesh convergence on `pn_1d` (Phase 2)
+
+Module: `semi/verification/mesh_convergence.py`. Subcommand:
+`run_verification.py mesh_convergence`.
+
+A mesh sweep over N in [50, 100, 200, 400, 800, 1600] on the Day-1
+equilibrium pn junction reports V_bi, peak |E|, depletion width W,
+Newton iterations, and solve time. Errors are recorded in two ways:
+against the depletion-approximation reference (which is itself an
+approximation), and as Cauchy self-convergence ratios (consecutive
+mesh differences, which isolate pure FE discretization error).
+
+**Honest flag.** The depletion approximation is a model, not the
+truth. The FEM solver converges to the full Poisson-Boltzmann
+solution, so relative errors against the depletion references
+plateau on fine meshes at the physics-model gap, not at zero.
+Monotone reduction is therefore gated only over the first four
+refinements (N up to 400), before the plateau; the Cauchy ratios
+are gated across the same range at >= 1.8x per doubling, which is
+the mathematically meaningful convergence indicator. V_bi is set
+exactly by the Ohmic BCs and is mesh-independent to machine
+epsilon (reported only, not gated).
+
+Latest run, consecutive Cauchy ratios (N = 100/50, 200/100, 400/200):
+
+| Quantity  | Ratio 100/50 | Ratio 200/100 | Ratio 400/200 |
+|-----------|--------------|---------------|---------------|
+| E_peak    | 1.99         | 2.10          | 2.31          |
+| W         | 2.01         | 4.10          | 4.21          |
+
+All >= 1.8x as required. Residual error vs. depletion at the finest
+level (N = 1600): E_peak 4.3% gap, W 3.2% gap, consistent with the
+expected physics-model offset.
+
+### 5.3 Conservation checks (Phase 3)
+
+Module: `semi/verification/conservation.py`. Subcommand:
+`run_verification.py conservation`.
+
+- **Charge conservation** on `pn_1d` equilibrium. Integrates
+  q * (p - n + N_D - N_A) over the device and asserts
+  |Q_net| < 1e-10 * Q_ref with
+  Q_ref = q * max|N_net| * L_device. Latest run:
+  Q_net = 4.8e-19 C/m^2 vs. threshold 3.2e-9 C/m^2 (rel 1.5e-17).
+
+- **Current continuity** on `pn_1d_bias` forward and
+  `pn_1d_bias_reverse`. At each target bias the total current
+  J_total = J_n + J_p is sampled on ten interior facets; we assert
+  max |J - mean| / |mean| < 5% (forward) or 15% (reverse). Latest
+  worst-case max_rel across the target set:
+
+  | Benchmark            | V         | worst max_rel | tol    |
+  |----------------------|-----------|---------------|--------|
+  | pn_1d_bias           | 0.6 V     | 1.91%         | 5%     |
+  | pn_1d_bias_reverse   | -0.55 V   | 0.020%        | 15%    |
+
+  All inside tolerance.
+
+### 5.4 MMS for coupled drift-diffusion (Phase 4)
+
+Module: `semi/verification/mms_dd.py`. Subcommand:
+`run_verification.py mms_dd`. Derivation and rate-threshold
+rationale: `docs/mms_dd_derivation.md`.
+
+Nine studies (three variants x {1D default, 1D nonlinear, 2D}) on
+the full three-block Slotboom residual with forcing terms injected
+in weak form:
+
+- **Variant A (psi-only).** `phi_n_e = phi_p_e = 0`. The
+  continuity diffusion integrals drop out and R_e collapses to
+  zero. Exercises the Poisson row of the block residual
+  (`build_dd_block_residual`) including sign, scaling, and
+  coupling-to-zero-quasi-Fermi plumbing. Variant A's continuity-block
+  errors are at machine noise (~1e-35 to 1e-41); these are
+  reported but not rate-gated because dividing one noise level
+  by another produces meaningless rates. We gate only the psi
+  block on Variant A (L^2 >= 1.75, H^1 >= 0.80).
+- **Variant B (full coupling, no R).** All three fields nontrivial,
+  lifetimes set to 1e+20 so R_e is negligible but the SRH kernel
+  is still evaluated. Verifies the drift-diffusion operators in
+  their coupled form, independent of recombination numerics.
+- **Variant C (full coupling with SRH).** Realistic lifetimes
+  tau_n = tau_p = 1e-7 s. Verifies the full residual including
+  the cross-block coupling through R_e.
+
+Finest-pair rates (N = 320 for 1D, N = 64 for 2D), default
+amplitudes (A_psi, A_n, A_p) = (0.5, 0.3, -0.3):
+
+| Study                | Block  | L^2 rate | H^1 rate |
+|----------------------|--------|----------|----------|
+| 1D A (linear)        | psi    | 2.000    | 1.000    |
+| 1D B (linear)        | psi    | 2.000    | 1.000    |
+| 1D B (linear)        | phi_n  | 2.000    | 1.000    |
+| 1D B (linear)        | phi_p  | 2.000    | 1.000    |
+| 1D C (linear)        | psi    | 2.000    | 1.000    |
+| 1D C (linear)        | phi_n  | 2.000    | 1.000    |
+| 1D C (linear)        | phi_p  | 2.000    | 1.000    |
+| 2D A                 | psi    | 1.990    | 0.996    |
+| 2D B                 | psi    | 1.990    | 0.996    |
+| 2D B                 | phi_n  | 1.995    | 1.000    |
+| 2D B                 | phi_p  | 1.995    | 1.000    |
+| 2D C                 | psi    | 1.990    | 0.996    |
+| 2D C                 | phi_n  | 1.995    | 1.000    |
+| 2D C                 | phi_p  | 1.995    | 1.000    |
+
+Every gated rate clears the L^2 >= 1.75 / H^1 >= 0.80 floor with
+>= 0.19 of headroom, matching theoretical P1 Lagrange rates to within
+roundoff. The derivation (`mms_dd_derivation.md`) documents the
+block-residual scale-disparity issue that forced the SNES
+tolerance tweak to `atol = 0.0` with `stol = 1e-12`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -100,7 +100,7 @@ Read `PLAN.md` for the short version and the current in-flight task.
 
 ## Day 4. Verification & Validation suite
 
-- **Status:** In flight on `dev/day4-vnv`.
+- **Status:** Done (2026-04-21). PR `dev/day4-vnv`.
 - **Goal:** replace single-point physical sanity tests with proper
   verification (Roache / Oberkampf-Roy sense): manufactured solutions,
   mesh-refinement convergence studies, and discrete conservation
@@ -151,17 +151,37 @@ Read `PLAN.md` for the short version and the current in-flight task.
     - New "Verification & Validation" section in `docs/PHYSICS.md`.
     - New ADR `docs/adr/0006-verification-and-validation-strategy.md`.
     - PLAN.md, ROADMAP.md, CHANGELOG.md final update.
-- **Verification:**
-  - `pn_1d`, `pn_1d_bias`, `pn_1d_bias_reverse` still green
-    (no regression).
-  - MMS-Poisson 1D and 2D: L^2 rate >= 1.85 on the finest pair.
-  - MMS-DD full coupling and with-SRH: L^2 rate >= 1.75 on each
-    of psi, Phi_n, Phi_p on the finest pair.
-  - Mesh convergence on `pn_1d`: monotone error reduction; at least
-    2x error reduction per mesh doubling on V_bi and peak |E|.
-  - Current continuity: <=5% non-uniformity at V in [0.3, 0.6] V.
-  - Charge conservation: |Q_net| <= 10^-10 of scaled charge.
-  - CI green on `dev/day4-vnv` with V&V step running.
+- **Delivered:**
+  - MMS-Poisson 1D linear / 1D nonlinear / 2D triangles with
+    finest-pair L^2 at theoretical 2.000 and H^1 at 0.999-1.000;
+    `2d_quad_smoke` sanity ratio 0.394.
+  - Mesh convergence on `pn_1d` over N in [50..1600] with
+    self-convergence Cauchy ratios at >= 1.99x per doubling for
+    E_peak and W over the first four levels (before the
+    physics-model plateau from the depletion-approximation
+    reference, which is honest-flagged in both the runner output
+    and in `docs/PHYSICS.md`). V_bi is set by the Ohmic BCs and
+    so is reported but not gated.
+  - Conservation: charge on `pn_1d` equilibrium at rel 1.5e-17
+    (threshold 1e-10); current continuity on `pn_1d_bias` V in
+    {0.30, 0.45, 0.60} V and `pn_1d_bias_reverse` V in {-0.50,
+    -1.00, -2.00} V, worst max_rel 1.91% forward / 0.020%
+    reverse inside the 5% / 15% tolerances.
+  - MMS-DD nine studies (three variants x three grids) with
+    every gated block rate >= 1.99 L^2 and >= 0.996 H^1.
+    Variant A gates only the psi block because the continuity
+    rows collapse to machine roundoff when the quasi-Fermis are
+    identically zero (documented in `mms_dd_derivation.md`
+    Amendment section).
+  - `scripts/run_verification.py` with subcommands `mms_poisson`,
+    `mesh_convergence`, `conservation`, `mms_dd`, `all`.
+  - CI `docker-fem` job now runs V&V inside the dolfinx image,
+    timeout tightened to 15 minutes, artifacts uploaded as
+    `fem-results` (renamed from `benchmark-plots`).
+  - New ADR `0006-verification-and-validation-strategy.md`, new
+    "Verification & Validation" section in `docs/PHYSICS.md`,
+    derivation artifact `docs/mms_dd_derivation.md` amended with
+    the SNES atol-0 fix rationale.
 - **Dependencies:** Day 3 (PR #5) merged into `main`.
 
 ## Day 5. Refactor, expanded test coverage, docs pass

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,9 +98,76 @@ Read `PLAN.md` for the short version and the current in-flight task.
   - CI `docker-fem` job runs the reverse benchmark on every push.
 - **Dependencies:** Day 2.
 
-## Day 4. Refactor, expanded test coverage, docs pass
+## Day 4. Verification & Validation suite
 
-- **Status:** Planned.
+- **Status:** In flight on `dev/day4-vnv`.
+- **Goal:** replace single-point physical sanity tests with proper
+  verification (Roache / Oberkampf-Roy sense): manufactured solutions,
+  mesh-refinement convergence studies, and discrete conservation
+  checks. The originally-planned refactor moves to Day 5.
+- **Rationale:** the existing benchmark "verifiers" prove the code
+  reproduces analytical reference values at one mesh resolution. They
+  do not prove convergence, do not exercise the discretization away
+  from operating points, and do not catch sign or coefficient errors
+  that happen to cancel at a single resolution. MMS is the standard
+  remedy.
+- **Deliverables:**
+  - **Phase 1: MMS for Poisson.**
+    - `semi/verification/mms_poisson.py`: 1D and 2D smooth
+      manufactured solutions, UFL-based forcing, mesh sweep,
+      L^2 / H^1 error and observed-rate computation, CSV+PNG output.
+    - `tests/fem/test_mms_poisson.py` with `tests/fem/conftest.py`
+      that skips when dolfinx is missing.
+  - **Phase 2: Mesh convergence on `pn_1d`.**
+    - `semi/verification/mesh_convergence.py`: sweep N in
+      [50, 100, 200, 400, 800, 1600], record V_bi error, peak |E|
+      error, depletion-width error, Newton iterations, solve time.
+    - `tests/fem/test_mesh_convergence.py` (3 levels for speed).
+    - Documented convergence order, including any plateau caused by
+      the depletion-approximation reference itself being
+      approximate.
+  - **Phase 3: Conservation checks.**
+    - Current continuity check (max |J_total(x) - mean| / mean)
+      added to the `pn_1d_bias` and `pn_1d_bias_reverse` verifiers.
+      Threshold +-5% forward, +-15% reverse.
+    - Charge conservation check (integrated rho over the device
+      bounded by solver tolerance) added to `pn_1d`.
+    - Unit tests on the check functions in isolation, with mock
+      `SimulationResult` objects.
+  - **Phase 4: MMS for coupled drift-diffusion.**
+    - `semi/verification/mms_dd.py`: manufactured psi, Phi_n, Phi_p
+      with three forcing terms in UFL.
+    - Three pytest tests: psi-only with frozen quasi-Fermis;
+      full three-block coupling; full coupling with nonzero SRH.
+    - Acceptance: L^2 rate >= 1.75 on each field on the finest pair.
+  - **Phase 5: CI integration.**
+    - `scripts/run_verification.py` CLI parallel to
+      `scripts/run_benchmark.py` (subcommands `mms_poisson`,
+      `mms_dd`, `mesh_convergence`, `conservation`, `all`).
+    - `.github/workflows/ci.yml`: run V&V step inside `docker-fem`,
+      upload `results/mms_*` and `results/mesh_convergence/`
+      artifacts. Total CI runtime under 15 minutes.
+  - **Final phase: Documentation.**
+    - New "Verification & Validation" section in `docs/PHYSICS.md`.
+    - New ADR `docs/adr/0006-verification-and-validation-strategy.md`.
+    - PLAN.md, ROADMAP.md, CHANGELOG.md final update.
+- **Verification:**
+  - `pn_1d`, `pn_1d_bias`, `pn_1d_bias_reverse` still green
+    (no regression).
+  - MMS-Poisson 1D and 2D: L^2 rate >= 1.85 on the finest pair.
+  - MMS-DD full coupling and with-SRH: L^2 rate >= 1.75 on each
+    of psi, Phi_n, Phi_p on the finest pair.
+  - Mesh convergence on `pn_1d`: monotone error reduction; at least
+    2x error reduction per mesh doubling on V_bi and peak |E|.
+  - Current continuity: <=5% non-uniformity at V in [0.3, 0.6] V.
+  - Charge conservation: |Q_net| <= 10^-10 of scaled charge.
+  - CI green on `dev/day4-vnv` with V&V step running.
+- **Dependencies:** Day 3 (PR #5) merged into `main`.
+
+## Day 5. Refactor, expanded test coverage, docs pass
+
+- **Status:** Planned. Was originally Day 4; pushed back one slot to
+  make room for the V&V suite.
 - **Goal:** pay down technical debt accumulated across Days 1-3 and
   expand coverage before moving to higher dimensions.
 - **Deliverables:**
@@ -113,17 +180,18 @@ Read `PLAN.md` for the short version and the current in-flight task.
     configs.
   - Update `docs/PHYSICS.md` with the scaled drift-diffusion
     derivation now that it is implemented.
-  - Add `docs/adr/0006-bc-construction-interface.md` if the BC refactor
-    introduces a new decision.
+  - Add `docs/adr/0007-bc-construction-interface.md` if the BC
+    refactor introduces a new decision (note: ADR 0006 is reserved
+    for the Day 4 V&V strategy).
 - **Verification:**
   - `pytest --cov=semi --cov-report=term-missing` shows core coverage
     at or above 95%.
   - No behavioral regressions in `pn_1d` or `pn_1d_bias`.
-- **Dependencies:** Days 2 and 3.
+- **Dependencies:** Day 4 V&V suite merged.
 
-## Day 5. 2D MOS capacitor
+## Day 6. 2D MOS capacitor
 
-- **Status:** Planned.
+- **Status:** Planned. Was originally Day 5.
 - **Goal:** extend to 2D and multi-region (oxide plus silicon).
 - **Deliverables:**
   - `benchmarks/mos_2d/mos_cap.json` with a gate, oxide, silicon
@@ -137,11 +205,11 @@ Read `PLAN.md` for the short version and the current in-flight task.
 - **Verification:**
   - `benchmark mos_2d` exits 0.
   - 2D plots rendered (psi contour, |E| contour, n and p contours).
-- **Dependencies:** Day 4 refactor.
+- **Dependencies:** Day 5 refactor.
 
-## Day 6. 3D doped resistor
+## Day 7. 3D doped resistor
 
-- **Status:** Planned.
+- **Status:** Planned. Was originally Day 6.
 - **Goal:** confirm the framework extends to 3D unstructured meshes
   with no physics changes.
 - **Deliverables:**
@@ -153,11 +221,11 @@ Read `PLAN.md` for the short version and the current in-flight task.
 - **Verification:**
   - `benchmark resistor_3d` exits 0.
   - At least two 3D slice plots (current density magnitude, potential).
-- **Dependencies:** Day 4.
+- **Dependencies:** Day 5.
 
-## Day 7. Final polish and submission packaging
+## Day 8. Final polish and submission packaging
 
-- **Status:** Planned.
+- **Status:** Planned. Was originally Day 7.
 - **Goal:** make the submission presentation-ready.
 - **Deliverables:**
   - Regenerate `notebooks/01_pn_junction_1d.ipynb` using
@@ -170,7 +238,7 @@ Read `PLAN.md` for the short version and the current in-flight task.
 - **Verification:**
   - Both notebooks execute top-to-bottom on Colab with no errors.
   - README and CHANGELOG accurately describe final state.
-- **Dependencies:** Days 5 and 6.
+- **Dependencies:** Days 6 and 7.
 
 ## Post-submission (stretch goals)
 

--- a/docs/adr/0006-verification-and-validation-strategy.md
+++ b/docs/adr/0006-verification-and-validation-strategy.md
@@ -1,0 +1,202 @@
+# 0006. Verification & Validation strategy
+
+- Status: Accepted
+- Date: 2026-04-21
+
+## Context
+
+Through Day 3 the project had three benchmark "verifiers" under
+`scripts/run_benchmark.py`: `pn_1d` (equilibrium depletion-approximation
+check), `pn_1d_bias` (forward Shockley / SNS check), and
+`pn_1d_bias_reverse` (SRH generation check). Each runs at a single
+mesh resolution against an analytical reference.
+
+In the Roache / Oberkampf-Roy sense these are **validation** exercises
+(are the equations we wrote down a reasonable model of a diode?) rather
+than **verification** exercises (did we solve those equations
+correctly?). They do not prove convergence of the FEM discretization,
+do not exercise the solver away from the junction, and do not catch
+sign or coefficient errors that happen to cancel at a single
+resolution. Several failure modes are invisible to them by
+construction:
+
+- A Poisson coefficient off by a factor (the Day-1 `lambda2` vs.
+  `L_D^2` bug went undetected for the first pass because V_bi is set
+  by the BCs alone).
+- A residual block whose sign is flipped: the coupled Newton may still
+  converge to a fixed point that happens to pass the single-point
+  check.
+- Anisotropic mesh error (e.g. a 2D form that is correct only on
+  quads but wrong on triangles).
+- Discretization that loses order silently (Galerkin degradation
+  under high Peclet, or a P1 form that is accidentally P0-like).
+
+Day 4 was originally scoped as a refactor pass. We re-scoped it to
+build a proper V&V suite because the cost of shipping a silently
+non-convergent simulator to the evaluation reviewer was higher than
+the cost of a refactor delay.
+
+The candidate verification activities considered:
+
+- **Method of Manufactured Solutions (MMS).** A smooth exact
+  solution is injected as a forcing term; the code must recover
+  theoretical FE convergence rates on a mesh sweep. Catches most
+  sign/coefficient bugs and all rate-losing bugs.
+- **Mesh convergence studies.** Re-run a physical benchmark at
+  increasing resolutions; each derived quantity must converge
+  monotonically.
+- **Discrete conservation checks.** At each bias, the total
+  current J_n + J_p is a constant in space (continuity); the
+  space-integral of charge density is zero at equilibrium (charge
+  neutrality). Both are exact consequences of the equations and
+  so are easy to gate tightly.
+- **Code-to-code comparison** against devsim / Sentaurus. Rejected
+  for Day 4: introduces an external-tool dependency and a
+  licensing gate, and adds little over MMS for a short-horizon
+  project.
+- **Experimental validation.** Out of scope; no lab data.
+
+## Decision
+
+Ship a four-phase V&V suite as the Day-4 deliverable. The suite runs
+automatically inside the `docker-fem` CI job via
+`scripts/run_verification.py all` and uploads every CSV and PNG
+artifact under `results/`.
+
+1. **MMS for equilibrium Poisson** (Phase 1). Module
+   `semi/verification/mms_poisson.py`. 1D and 2D smooth
+   manufactured solutions (sin and sin-sin with distinct
+   wavenumbers). UFL weak-form forcing (do not form
+   `ufl.div(ufl.grad(...))` directly; the constant prefactor on
+   a coarse mesh can collapse to numerical zero). Acceptance:
+   finest-pair L^2 rate >= 1.85, H^1 rate >= 0.85, monotone error
+   reduction across the sweep. A `2d_quad_smoke` sanity run
+   checks that the quad-element path is within one order of
+   magnitude of the triangle path.
+
+2. **Mesh convergence on `pn_1d`** (Phase 2). Module
+   `semi/verification/mesh_convergence.py`. Sweep N in
+   [50, 100, 200, 400, 800, 1600]; record V_bi, peak |E|, W,
+   Newton iterations, solve time. Report error both against the
+   depletion approximation (physics-model check) and as Cauchy
+   self-convergence ratios between consecutive meshes (pure
+   discretization check). Gate monotone error reduction on the
+   depletion errors for the first four levels (before the
+   physics-model plateau), and gate Cauchy ratios at >= 1.8x per
+   doubling over the same range. V_bi is set by the Ohmic BCs
+   alone, so we report it but do not gate it.
+
+3. **Conservation checks** (Phase 3). Module
+   `semi/verification/conservation.py`. Two gates:
+   - Charge conservation on `pn_1d` equilibrium:
+     |integrate(q*(p - n + N_D - N_A))| < 1e-10 * q * max|N_net| * L.
+   - Current continuity at forward bias targets (0.30, 0.45,
+     0.60 V) with `pn_1d_bias` and reverse bias targets (-0.50,
+     -1.00, -2.00 V) with `pn_1d_bias_reverse`: sample J_total
+     on ten interior facets per target, require
+     max |J - mean| / |mean| < 5% forward, < 15% reverse.
+
+4. **MMS for coupled drift-diffusion** (Phase 4). Module
+   `semi/verification/mms_dd.py`. Derivation
+   `docs/mms_dd_derivation.md`. Three variants exercise
+   progressively more of the residual:
+   - **Variant A** (psi-only) holds `phi_n_e = phi_p_e = 0` so
+     the continuity rows are rate-tested at machine noise and
+     only the psi block is gated. Purpose: prove the Poisson
+     row of the block residual assembles correctly when driven
+     by the coupled nonlinear solver, which the standalone
+     Poisson MMS cannot see.
+   - **Variant B** exercises the full three-block coupling with
+     lifetimes set to 1e+20 so R_e is numerically negligible.
+   - **Variant C** runs realistic Si lifetimes (1e-7 s) so the
+     SRH coupling between the two continuity blocks is exercised.
+
+   Acceptance: finest-pair L^2 >= 1.75, H^1 >= 0.80 on every
+   meaningful block per variant (psi-only on A; psi, phi_n,
+   phi_p on B and C). The 0.25 / 0.20 rate headroom below
+   theoretical 2 / 1 absorbs block-coupling bleed and the
+   exponential SRH numerator.
+
+**CI integration.** The `docker-fem` job adds a step that runs
+`python scripts/run_verification.py all` inside the dolfinx image.
+The job timeout tightens from 30 to 15 minutes. The existing
+`benchmark-plots` artifact is renamed `fem-results` and its path
+stays `results/`, so MMS CSVs, mesh-convergence CSVs, conservation
+CSVs, and all PNGs are uploaded together.
+
+**Documentation.** A new "Verification & Validation" section in
+`docs/PHYSICS.md` records the current finest-pair rates and the
+honest flags (depletion-model plateau, Variant A scope, block
+residual scale disparity). `docs/mms_dd_derivation.md` stays the
+standalone mathematical gate artifact.
+
+## Consequences
+
+Easier:
+
+- Any future change that silently breaks convergence order (sign
+  flip, coefficient bug, lost nonlinear term) fails CI before
+  reviewer sees it.
+- Three distinct verification activities (MMS, mesh convergence,
+  conservation) cross-check each other: a bug that hides behind
+  one usually surfaces in at least one of the other two.
+- The derivation-before-code workflow that produced
+  `mms_dd_derivation.md` is now a template. Future V&V extensions
+  (2D MOS MMS, 3D resistor convergence) follow the same pattern:
+  derivation artifact first, then implementation, then gate.
+- The `pn_1d*` benchmarks keep their role as validation exercises
+  against analytical physics; V&V and validation are now
+  visibly separate activities.
+
+Harder:
+
+- CI wall-clock pressure. The 15-minute budget is tight once the
+  dolfinx image is cached; adding a 2D MOS MMS or a 3D resistor
+  study will need either per-mesh caching or a split job. This
+  is acceptable for the submission timeline but will need
+  revisiting in Day 6-7.
+- Variant A is only gated on psi because the continuity-row
+  errors collapse to machine-noise when the quasi-Fermis are
+  identically zero. This is documented but could confuse a
+  future reader who expects "all three blocks gated on every
+  variant." The PHYSICS V&V section and the ADR both call it
+  out; the csv rows still report the numeric values.
+- The rate thresholds (L^2 >= 1.85 Poisson, >= 1.75 DD; H^1
+  >= 0.85 Poisson, >= 0.80 DD) are tighter than standard FE
+  theory strictly requires on a single mesh pair. This is
+  intentional: it keeps the gate sensitive to half-order losses
+  on smooth problems, where there is no mechanism for a real
+  rate reduction. Future stabilization work (SUPG / SG) that
+  introduces a legitimate half-order loss will need an ADR
+  update and a corresponding threshold relaxation.
+- The existing `benchmark-plots` CI artifact is renamed to
+  `fem-results`. Any downstream tooling or reviewer that fetched
+  the old name needs to update; at the time of writing there is
+  no such tooling.
+
+## Rejected alternatives
+
+- **Code-to-code comparison against devsim.** Adds an install
+  path and a license check without addressing the convergence-order
+  question that MMS settles definitively. Deferred to post-submission.
+- **Single MMS case covering both Poisson and DD.** Rejected
+  because a regression in the DD row would then swamp the Poisson
+  signal and vice versa; splitting by physics block keeps the
+  signal localized when a gate fails.
+- **Only gate L^2 rate, not H^1.** Rejected because a discretization
+  that loses one order of H^1 regularity can still pass L^2 by
+  luck; H^1 is a strictly stronger gate on smooth problems.
+- **Run V&V on every pytest invocation.** Rejected because the
+  full sweep is ~1-2 minutes of wall clock; pytest stays fast by
+  running a reduced three-level sweep in-process, and the full
+  CLI sweep runs only in CI and on demand.
+
+## Related
+
+- `docs/mms_dd_derivation.md` (Phase 4 mathematical gate).
+- `docs/PHYSICS.md` Section 5 (current V&V results).
+- `semi/verification/{mms_poisson, mesh_convergence, conservation, mms_dd}.py`.
+- `scripts/run_verification.py` (CLI entry point).
+- `.github/workflows/ci.yml` (CI integration).
+- Invariants 3, 4, 5, 6 in `PLAN.md` remain load-bearing across
+  the new verification activities.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,3 +67,4 @@ Template and background: <https://github.com/joelparkerhenderson/architecture-de
 - [0003 Target dolfinx 0.10 API only](0003-dolfinx-0-10-api.md)
 - [0004 Slotboom variables for drift-diffusion](0004-slotboom-variables-for-dd.md)
 - [0005 Docker for dev, conda and FEM-on-Colab for users](0005-docker-for-dev-conda-fem-on-colab-for-users.md)
+- [0006 Verification & Validation strategy](0006-verification-and-validation-strategy.md)

--- a/docs/mms_dd_derivation.md
+++ b/docs/mms_dd_derivation.md
@@ -280,7 +280,7 @@ Standard FE theory on a smooth problem gives
 
 per-block. The coupled system inherits the same rates provided Newton
 converges to machine precision on each mesh so that iteration error
-does not floor the FE error. We therefore tighten SNES tolerances to
+does not floor the FE error. The derivation originally proposed
 
 ```
 snes_rtol = 1.0e-14
@@ -291,6 +291,70 @@ snes_max_it = 80
 
 matching the Poisson MMS (`mms_poisson.py:259-264`) with a larger
 `max_it` allowance because the coupled system needs more iterations.
+
+**Amendment: atol = 0, stol = 1e-12 (implementation-time fix).** The
+derivation's `snes_atol = 1e-16` was tuned to the Poisson block
+residual scale and turned out to terminate SNES prematurely on the
+continuity blocks in 2D. The cause is the block-residual scale
+disparity already flagged in Section 7.3: the Poisson block carries
+`L_D^2 ~ 1.6e-3 * L_0^2` while the continuity blocks carry `L_0^2`
+alone, and in 2D the integration area further shrinks the continuity
+residual by a factor of ~`L_0^2 ~ 4e-12`. In the 2D Variant-B and
+Variant-C tests the continuity blocks' initial absolute residual
+sat at roughly 1e-18 (already below the originally-proposed
+`atol = 1e-16`), so SNES would quit after the very first iteration
+without ever touching the Poisson block, which still had a ~1e-6
+initial residual to burn down. The Poisson row then recorded
+pre-Newton interpolation error and the measured rates came out
+noisy.
+
+The fix applied in `semi/verification/mms_dd.py:368-373` is:
+
+```
+snes_rtol   = 1.0e-14
+snes_atol   = 0.0      # was 1.0e-16; removes the premature-termination floor
+snes_stol   = 1.0e-12  # step-norm takes over as the stopping criterion
+snes_max_it = 80
+```
+
+Rationale:
+
+- Setting `atol = 0.0` defers absolute-residual termination
+  entirely. Newton iterates until either (a) the relative residual
+  drops by `rtol` across all blocks, or (b) the step norm drops
+  below `stol`, whichever comes first.
+- `stol = 1.0e-12` is the meaningful floor for this problem: the
+  scaled unknowns are O(1) (all amplitudes stay in [-1, 1]), so a
+  step norm of 1e-12 means every DOF has settled to within 10^-12
+  of its converged value. This is well below the FE error at the
+  finest mesh pair (L^2 ~ 1e-8 for N = 320 in 1D), so Newton is
+  fully converged relative to the discretization error.
+- `rtol = 1.0e-14` is retained from the original. In practice the
+  `stol` criterion fires first on 1D and the `rtol` criterion
+  fires first in 2D where the residual still has headroom.
+
+**Sanity check.** After the amendment the 2D runs converge in 2 or
+4 Newton iterations (2 for Variant A where only the Poisson block
+has a non-trivial residual; 4 for B/C where all three blocks must
+be relaxed), the Poisson block reaches its rate floor, and the
+continuity blocks in Variants B and C record rates within 0.01 of
+the theoretical 2.0 / 1.0 targets. The previous tuning produced
+rates below 1.0 on the continuity blocks at N=64 because Newton
+had stopped before the linear system had actually been solved.
+
+**Variant A noise floor.** With `phi_n_e = phi_p_e = 0`, the
+continuity-block manufactured sources are identically zero and
+there is nothing to drive those fields off the initial zero. The
+continuity-block L^2 errors therefore sit at pure roundoff
+(1e-35 to 1e-41 across the sweep). Dividing one roundoff level
+by another produces meaningless rates (they hop around zero),
+so the Variant A continuity-block rates are reported in the CSV
+but not gated. The Phase-4 CLI (`run_verification.py mms_dd`)
+and the pytest gate both check only the psi block for Variant A;
+all three blocks for Variants B and C. This is consistent with
+the purpose of Variant A as stated in Section 3.4: it is a
+Poisson-row sanity check routed through the coupled solver, not
+a convergence test for the continuity rows in isolation.
 
 **Gate thresholds** (finest-pair rate, asserted on all three blocks
 independently):

--- a/docs/mms_dd_derivation.md
+++ b/docs/mms_dd_derivation.md
@@ -1,0 +1,449 @@
+# MMS Derivation: Coupled Drift-Diffusion (Phase 4 Gate)
+
+This document is the mathematical specification for the Phase-4 Method of
+Manufactured Solutions (MMS) verification of the coupled drift-diffusion
+block residual in `semi/physics/drift_diffusion.py`. It is a gate
+artifact: no Python is written until this document is approved.
+
+The MMS target is the three-field Slotboom-form system
+(`build_dd_block_residual`, lines 140-151), whose scaled residual is
+
+```
+-div( L_D^2 eps_r grad psi_hat )            - (p_hat - n_hat + N_hat) = 0
+-div( L_0^2 mu_n_hat n_hat grad phi_n_hat ) - R_hat                   = 0
+-div( L_0^2 mu_p_hat p_hat grad phi_p_hat ) + R_hat                   = 0
+```
+
+with Slotboom relations
+
+```
+n_hat = ni_hat * exp(psi_hat - phi_n_hat)
+p_hat = ni_hat * exp(phi_p_hat - psi_hat)
+```
+
+and SRH recombination
+
+```
+R_hat = ( n_hat * p_hat - ni_hat^2 ) / ( tau_p_hat * (n_hat + n1_hat)
+                                       + tau_n_hat * (p_hat + p1_hat) )
+n1_hat = ni_hat * exp( E_t/V_t ),  p1_hat = ni_hat * exp(-E_t/V_t)
+```
+
+For MMS we set `N_hat = 0` and add manufactured sources `f_psi, f_n, f_p`
+to each block so that a chosen smooth exact triple `(psi_e, phi_n_e,
+phi_p_e)` is the solution of the modified system. Each block then has a
+discretization error that decays at the FE rate, and finest-pair rates
+are asserted against the thresholds in Section 5.
+
+---
+
+## 1. Exact solutions
+
+Proposed triple (all scaled units; Omega = (0, L)^d with d in {1, 2}):
+
+**1D (d = 1):**
+
+```
+psi_e(x)   = A_psi * sin(2*pi * x / L)
+phi_n_e(x) = A_n   * sin(  pi * x / L)
+phi_p_e(x) = A_p   * sin(  pi * x / L)
+```
+
+**2D (d = 2):**
+
+```
+psi_e(x,y)   = A_psi * sin(2*pi * x/L) * sin(3*pi * y/L)
+phi_n_e(x,y) = A_n   * sin(  pi * x/L) * sin(  pi * y/L)
+phi_p_e(x,y) = A_p   * sin(  pi * x/L) * sin(  pi * y/L)
+```
+
+**Amplitudes** (default, held fixed across the mesh sweep):
+
+```
+A_psi = 0.5     # potential swing ~ 13 mV at 300 K; keeps exp(+/-psi) ~ [0.6, 1.7]
+A_n   = 0.3     # quasi-Fermi swing
+A_p   = 0.3
+```
+
+Rationale:
+
+- All three fields vanish identically on the boundary of Omega, so the
+  homogeneous-Dirichlet BC in Section 4 is exact (no interpolation noise).
+- Distinct wavenumbers in psi vs. (phi_n, phi_p) prevent accidental
+  cancellation in the combination `psi - phi_n` that appears in the
+  Slotboom exponent; the two continuity blocks therefore exercise
+  genuinely different gradients.
+- The 2D form uses two different wavenumbers on x and y for psi
+  (2*pi, 3*pi) following the existing Poisson MMS convention
+  (`semi/verification/mms_poisson.py:143-164`), which guarantees the
+  discretization sees a 2D function and not a tensor product of 1D
+  modes hit by one axis alone.
+- Amplitudes keep `|psi_e - phi_n_e|, |phi_p_e - psi_e| <= A_psi + A_n
+  = 0.8`, so `exp(...)` stays in `[exp(-0.8), exp(0.8)] ≈ [0.45, 2.23]`.
+  Newton is well-conditioned in this range and R_hat is neither
+  machine-zero (near-equilibrium) nor catastrophically cancelling.
+
+A second `nonlinear` amplitude set `(A_psi, A_n, A_p) = (1.0, 0.5, 0.5)`
+is reserved for the CLI sweep only (Section 6). The pytest gate runs the
+default amplitudes.
+
+## 2. Scaling reference values (consistency with Phase 1)
+
+MMS reuses the Phase-1 scaling constants exactly (no re-derivation). The
+values come from `semi/verification/mms_poisson.py:56-60` and are
+carried unchanged into the DD MMS harness:
+
+| Symbol          | Meaning                                    | Value                              |
+|-----------------|--------------------------------------------|------------------------------------|
+| `T_REF`         | Reference temperature                      | 300 K                              |
+| `V_T = kT/q`    | Thermal voltage (V0 scale)                 | 0.025852 V                         |
+| `L_0_REF`       | Device length (matches pn_1d benchmark)    | 2.0e-6 m                           |
+| `C_0_REF`       | Density scale (1e16 cm^-3 floor)           | 1.0e22 m^-3                        |
+| `EPS_R`         | Relative permittivity (Si)                 | 11.7                               |
+| `mu_0 = mu_n`   | Reference mobility (Si electrons)          | from `materials.get_material("Si")`|
+| `n_i`           | Intrinsic density (Si)                     | from `materials.get_material("Si")`|
+| `D_0 = V_t mu_0`| Einstein diffusivity                       | derived                            |
+| `t_0 = L_0^2/D_0`| Diffusion time                            | derived                            |
+| `lambda2`       | `eps_0 V_t / (q C_0 L_0^2)` (bare)         | ~1.6e-3 (asserted < 1)             |
+| `ni_hat`        | `n_i / C_0`                                | ~1.0e-6                            |
+
+The scaling object is built by `build_mms_scaling(L=L_0_REF)`
+(`mms_poisson.py:91-112`); the DD MMS will call the same factory to
+guarantee Phase-1 consistency. The assertion `lambda2 < 1` already
+present in that factory protects against future edits that would
+trivialize the carrier nonlinearity.
+
+**Mobility ratios.** `mu_n_over_mu0 = 1.0` (reference is electron
+mobility itself); `mu_p_over_mu0 = mu_p / mu_n = 0.45/1.4 ≈ 0.321` using
+the Si values in `materials.py`. These ratios are fixed across the sweep
+so the convergence rates measure discretization error only.
+
+**SRH lifetimes.** For Variant C: `tau_n = tau_p = 1.0e-7 s` (Si
+mid-gap default), yielding `tau_hat = tau / t_0 ≈ tau * D_0 / L_0^2`.
+For Variants A and B: `tau_hat = 1.0e+20` (effectively infinity so
+`R_hat ≈ 0`). `E_t / V_t = 0` (mid-gap traps).
+
+## 3. Forcing derivations (weak form)
+
+Let `v_psi, v_n, v_p` denote the three test functions on P1 Lagrange
+spaces. The modified block residual is
+
+```
+F_psi_mms = F_psi_prod - f_psi_weak
+F_n_mms   = F_n_prod   - f_n_weak
+F_p_mms   = F_p_prod   - f_p_weak
+```
+
+Each `f_*_weak` is constructed by substituting the exact triple into the
+production strong form and integrating by parts against the test
+function. Boundary terms vanish because (a) the exact fields vanish on
+the boundary, and (b) the test functions vanish on the Dirichlet
+boundary. We follow the same weak-form construction as the Poisson MMS
+(`mms_poisson.py:167-200`): we do NOT form `ufl.div(ufl.grad(...))`
+directly, because constant prefactors can collapse to numerical zero on
+coarse meshes. Writing the source in weak form uses the same gradient
+discretization as the production residual, so MMS verifies the
+discretization actually in use.
+
+Let
+
+```
+n_e = ni_hat * exp(psi_e - phi_n_e)
+p_e = ni_hat * exp(phi_p_e - psi_e)
+R_e = (n_e*p_e - ni_hat^2) / ( tau_p_hat*(n_e + n1_hat)
+                             + tau_n_hat*(p_e + p1_hat) )
+```
+
+### 3.1 Psi block (all variants)
+
+Strong:  `f_psi = -div(L_D^2 eps_r grad psi_e) - (p_e - n_e)`
+(recall `N_hat = 0`). Weak form applied as `-f_psi_weak`:
+
+```
+f_psi_weak =   L_D^2 * eps_r * inner(grad(psi_e), grad(v_psi)) * dx
+             - (p_e - n_e) * v_psi * dx
+```
+
+This is identical in structure to the Poisson MMS weak source but with
+`(p_e - n_e)` computed from the full Slotboom triple rather than
+`ni_hat * (exp(-psi_e) - exp(psi_e))` (which is the `phi_n_e = phi_p_e =
+0` special case).
+
+### 3.2 Electron continuity block
+
+Strong:  `f_n = -div(L_0^2 mu_n_hat n_e grad phi_n_e) - R_e`. Weak:
+
+```
+f_n_weak =   L_0^2 * mu_n_hat * n_e * inner(grad(phi_n_e), grad(v_n)) * dx
+           - R_e * v_n * dx
+```
+
+Note the `n_e` weighting on the diffusion integrand comes from the
+Slotboom current `J_n = -q D_n n grad phi_n`; it is pointwise nonzero
+everywhere in Omega because `ni_hat * exp(...) > 0`, so the block is
+coercive (ADR 0004).
+
+### 3.3 Hole continuity block
+
+Strong:  `f_p = -div(L_0^2 mu_p_hat p_e grad phi_p_e) + R_e`. Weak:
+
+```
+f_p_weak =   L_0^2 * mu_p_hat * p_e * inner(grad(phi_p_e), grad(v_p)) * dx
+           + R_e * v_p * dx
+```
+
+Sign of the `R_e` term is opposite to the electron block, matching the
+production residual at line 150.
+
+### 3.4 The three variants
+
+**Variant A -- psi-only (Poisson block sanity).**
+Set `phi_n_e = phi_p_e = 0` (identically). Then
+`grad(phi_n_e) = grad(phi_p_e) = 0`, the continuity diffusion integrals
+drop out, `n_e = ni_hat * exp(psi_e)`, `p_e = ni_hat * exp(-psi_e)`,
+and `n_e * p_e = ni_hat^2` so `R_e = 0`. The exact triple
+`(psi_e, 0, 0)` is the solution of the modified coupled system with
+
+```
+f_psi_weak = (as in 3.1)
+f_n_weak   = 0
+f_p_weak   = 0
+```
+
+Variant A is essentially the existing Poisson MMS pulled through
+`build_dd_block_residual` instead of `build_equilibrium_poisson_form`.
+Purpose: detect any block-assembly error in the Poisson row (sign,
+scaling, coupling to a zero Fermi level) that would be invisible to the
+standalone Poisson MMS.
+
+**Variant B -- full coupling, no recombination.**
+All three fields nontrivial. Set `tau_n_hat = tau_p_hat = 1.0e+20` so
+`R_e ≈ 0` to machine precision but R is not *identically* zero in the
+code path (the SRH kernel is still evaluated). The forcings are the
+full 3.1/3.2/3.3 weak forms with the `R_e * v` terms numerically
+negligible. Purpose: verify the drift-diffusion operators (the
+`n grad phi_n`, `p grad phi_p` pieces) in their coupled form without
+having to isolate recombination numerics.
+
+**Variant C -- full coupling with SRH.**
+All three fields nontrivial, realistic lifetimes
+`tau_n = tau_p = 1e-7 s`. Forcings are the full 3.1/3.2/3.3 weak forms
+with a physically nonzero `R_e`. Purpose: verify the full residual,
+including the recombination coupling between the two continuity blocks
+through the shared `R_e` term.
+
+## 4. Boundary conditions
+
+All three fields vanish identically on `boundary(Omega)` by construction
+(each exact-solution factor is a `sin(k*pi*x/L)` with `k` a positive
+integer). The homogeneous-Dirichlet BC is therefore the exact BC and is
+enforced identically to the Poisson MMS:
+
+```
+zero = fem.Constant(mesh, 0.0)
+bdofs_psi   = locate_dofs_topological(V_psi,   fdim, boundary_facets)
+bdofs_phi_n = locate_dofs_topological(V_phi_n, fdim, boundary_facets)
+bdofs_phi_p = locate_dofs_topological(V_phi_p, fdim, boundary_facets)
+bcs = [
+    fem.dirichletbc(zero, bdofs_psi,   V_psi),
+    fem.dirichletbc(zero, bdofs_phi_n, V_phi_n),
+    fem.dirichletbc(zero, bdofs_phi_p, V_phi_p),
+]
+```
+
+This choice (vs. interpolating the exact solution onto the boundary) is
+deliberate: interpolation of a nonlinear trig function onto a coarse P1
+boundary mesh introduces an O(h^2) boundary error that pollutes the
+measured L^2 rate, especially on the coarsest levels. Using
+`Constant(0.0)` keeps the BC exact across all refinements.
+
+## 5. Expected convergence rates
+
+Both spaces are P1 Lagrange on simplices (1D intervals or 2D triangles).
+Standard FE theory on a smooth problem gives
+
+```
+|| u - u_h ||_{L^2}      = O(h^2)     (rate 2)
+|| grad(u - u_h) ||_{L^2} = O(h^1)     (rate 1)
+```
+
+per-block. The coupled system inherits the same rates provided Newton
+converges to machine precision on each mesh so that iteration error
+does not floor the FE error. We therefore tighten SNES tolerances to
+
+```
+snes_rtol = 1.0e-14
+snes_atol = 1.0e-16
+snes_stol = 0.0
+snes_max_it = 80
+```
+
+matching the Poisson MMS (`mms_poisson.py:259-264`) with a larger
+`max_it` allowance because the coupled system needs more iterations.
+
+**Gate thresholds** (finest-pair rate, asserted on all three blocks
+independently):
+
+| Block           | L^2 rate  | H^1 rate  |
+|-----------------|-----------|-----------|
+| psi             | >= 1.75   | >= 0.80   |
+| phi_n           | >= 1.75   | >= 0.80   |
+| phi_p           | >= 1.75   | >= 0.80   |
+
+The 1.75 target (vs. the 1.85 used for standalone Poisson) leaves 0.25
+headroom below theoretical 2 to absorb:
+- block coupling: one block's iteration residual bleeds into another's
+  error on any given mesh;
+- SRH nonlinearity (variant C): the cross-block R term has a compound
+  exponential that is more sensitive to mesh discretization than a
+  bare exp;
+- drift weighting in continuity: the `n_e grad phi_n_e` factor is
+  mesh-variable, not constant, so the effective operator is not a
+  clean Laplacian (see Section 7).
+
+H^1 threshold is 0.80 rather than 0.85 for the same reasons. The
+monotonicity check (every level's error strictly smaller than the
+previous) is also asserted, as in the Poisson gate.
+
+## 6. Mesh plan
+
+**Pytest gate (CI):**
+
+```
+Ns_1d = [40, 80, 160]          # three levels, 2 rate estimates
+Ns_2d = [16, 32, 64]           # three levels, 2D triangles only
+```
+
+Three levels is the minimum to measure a rate plus a second-finest-pair
+sanity check against monotonicity. Four-level 1D `[40, 80, 160, 320]`
+is reserved for the CLI. Pytest wall-clock budget: each DD MMS solve
+is ~4-10x slower than Poisson MMS at the same N (three unknowns, SRH
+exp stack in R), so three levels keeps the full DD MMS gate under
+~60 s on a developer laptop.
+
+**CLI artifact sweep (`scripts/run_verification.py`):**
+
+```
+Ns_1d_linear    = [40, 80, 160, 320]        # default amplitudes
+Ns_1d_nonlinear = [40, 80, 160, 320]        # larger amplitudes
+Ns_2d           = [16, 32, 64]              # triangles, default amplitudes
+```
+
+Writes `convergence.csv` and `convergence.png` per (dim, variant)
+combination into `verification/mms_dd/<dim>_<variant>/`, mirroring the
+Poisson MMS artifact layout.
+
+## 7. Known risks
+
+### 7.1 exp() nonlinearity and amplitude cap
+
+The Slotboom form means every residual contains `exp(+/- psi_hat)` or
+`exp(psi - phi_n)` in a way that is *pointwise* nonlinear and
+*multiplicatively* coupled to `grad(phi_n)`. For amplitudes above ~1,
+three things go wrong:
+
+1. Newton ill-conditioning: the Jacobian entry d(n)/d(psi) = n itself,
+   which spans 2+ orders of magnitude across Omega when `A_psi > 1`.
+2. R_e denominator floor: at points where `n_e + p_e` is small (high
+   |psi|), the SRH denominator can dip below machine epsilon.
+3. Manufactured source magnitude asymmetry: the `p_e - n_e` term in
+   f_psi grows exponentially with A_psi; the weak form still converges
+   but the residual norms span 5+ orders of magnitude between blocks.
+
+Mitigation:
+- Pytest gate holds `(A_psi, A_n, A_p) = (0.5, 0.3, 0.3)`, keeping
+  `exp(...) \in [0.45, 2.23]`.
+- CLI nonlinear variant `(1.0, 0.5, 0.5)` still keeps arguments
+  bounded by 1.5, `exp \in [0.22, 4.48]`, comfortably inside PETSc
+  double precision. We do not add an `A_psi = 2` case here;
+  the Poisson MMS already covers that stress regime for the scalar
+  nonlinearity.
+
+### 7.2 Galerkin drift-dominant rate degradation
+
+The continuity block `L_0^2 mu_n_hat n_e inner(grad phi_n, grad v_n)`
+is a diffusion-only operator in Slotboom form -- there is no
+`grad(psi) . grad(phi_n)` term, because the drift has been absorbed
+into `n_e = ni_hat exp(psi - phi_n)`. On its face, this means the
+drift-dominant degradation that plagues direct (n, p) formulations
+(where standard Galerkin loses 0.5 order at Peclet > 1) does NOT apply
+here.
+
+However, the *effective* operator seen by Newton at each step is the
+linearization
+
+```
+J_n(phi_n_delta) = L_0^2 mu_n_hat * (
+      n_e * inner(grad phi_n_delta, grad v_n)
+    - n_e * phi_n_delta * inner(grad phi_n_e, grad v_n)   (from d n_e / d phi_n)
+)
+```
+
+and the second term is an anti-drift-like reaction, so the Jacobian has
+both a diffusion and an O(|grad phi_n|) reaction piece. For bounded
+amplitudes this is harmless. For large amplitudes with rapid phi_n
+variation the Peclet number equivalent `h * |grad phi_n_e| / 1` can
+approach 1 at N=40 (h/L = 0.025, |grad phi_n_e| <= pi*A_n/L = pi*0.3/L
+in scaled units h/L is the relevant factor so Pe ~ pi*0.3*0.025 ~ 0.024
+-- well below 1). So at the amplitudes and meshes chosen we expect no
+degradation.
+
+Mitigation / monitoring:
+- Keep A_n, A_p <= 0.5 in all gated runs.
+- If a future tightening to large `A_n` surfaces a rate floor at
+  ~1.5 in the continuity blocks, document it here as the expected
+  Galerkin signature rather than a bug, and consider SUPG or
+  Scharfetter-Gummel stabilization (deferred, out of scope for Phase 4).
+
+### 7.3 Block residual scale disparity
+
+The Poisson block residual carries `L_D^2 ~ 1.6e-3 * L_0^2`, while the
+continuity blocks carry `L_0^2` alone. Absolute SNES tolerances at
+`1e-16` are needed so the Poisson block keeps iterating after the
+continuity blocks have already reached their floors (and vice versa).
+This is the same tolerance rationale as the Poisson MMS; we reuse it.
+
+### 7.4 R_e near-equilibrium cancellation
+
+In Variant C, `n_e * p_e - ni_hat^2 = ni_hat^2 * (exp(phi_p_e - phi_n_e)
+- 1)`. For `A_n = A_p = 0.3`, the worst-case argument is
+`phi_p_e - phi_n_e \in [-0.6, 0.6]`, so the numerator swings in
+`[exp(-0.6)-1, exp(0.6)-1] = [-0.45, 0.82]` times `ni_hat^2 ~ 1e-12`.
+The denominator is `~ 2*tau_hat * ni_hat ~ 2e-6` (at tau_hat ~ 1e-1),
+so `R_e ~ 1e-6`. This is orders of magnitude below the diffusion term
+in the continuity residual (`L_0^2 mu_n_hat * ni_hat * |grad phi_n|^2
+~ 4e-12 * 1 * 1e-6 * (pi*A_n/L)^2`). Net: the SRH term in Variant C
+contributes a genuine but sub-dominant coupling. This is desired for
+gating -- it exercises the code path without dominating the error and
+masking a Poisson/continuity bug.
+
+If the measured rate on Variant C is lower than Variants A/B by more
+than 0.1, that is a signal that the R_e path is introducing
+discretization noise beyond the FE theory assumptions (likely through
+the exp cancellation in the numerator); treat it as evidence of a bug
+or poor kernel numerics, not as a legitimate rate degradation.
+
+---
+
+## Summary (for the gate reviewer)
+
+- Exact solutions are sin-products that vanish on Omega's boundary;
+  amplitudes `(0.5, 0.3, 0.3)` keep exp(...) in `[0.45, 2.23]`.
+- Scaling reuses `build_mms_scaling(L=2e-6)` from the Poisson MMS with
+  the existing `lambda2 < 1` guard. No new constants.
+- Three variants exercise Poisson-only, full coupling without R, and
+  full coupling with SRH, each with closed-form symbolic forcings in
+  weak form (Sections 3.1--3.4).
+- BCs are homogeneous Dirichlet on all three fields, enforced exactly
+  via `Constant(0.0)`.
+- Expected rates are L^2 >= 1.75 and H^1 >= 0.80 per block, with
+  monotonicity required across the sweep.
+- Pytest uses 1D `[40, 80, 160]` and 2D `[16, 32, 64]`; CLI extends 1D
+  to `[40, 80, 160, 320]` with an additional nonlinear-amplitude run.
+- The main known risks are exp() blow-up (mitigated by amplitude cap)
+  and drift-induced Galerkin degradation (shown to not apply at the
+  chosen amplitudes by a Peclet-number argument in 7.2).
+
+If all of the above is approved, Phase 4 implementation will create
+`semi/verification/mms_dd.py` and `tests/fem/test_mms_dd.py` following
+the exact structure of the Poisson MMS harness.

--- a/docs/mms_dd_derivation.md
+++ b/docs/mms_dd_derivation.md
@@ -61,8 +61,8 @@ phi_p_e(x,y) = A_p   * sin(  pi * x/L) * sin(  pi * y/L)
 
 ```
 A_psi = 0.5     # potential swing ~ 13 mV at 300 K; keeps exp(+/-psi) ~ [0.6, 1.7]
-A_n   = 0.3     # quasi-Fermi swing
-A_p   = 0.3
+A_n   =  0.3    # electron quasi-Fermi swing
+A_p   = -0.3    # hole quasi-Fermi swing, sign-flipped vs A_n
 ```
 
 Rationale:
@@ -73,19 +73,30 @@ Rationale:
   cancellation in the combination `psi - phi_n` that appears in the
   Slotboom exponent; the two continuity blocks therefore exercise
   genuinely different gradients.
+- `A_p = -A_n` (equivalently, phi_p_e and phi_n_e share a spatial
+  profile but opposite sign) is required for Variant C to be a
+  meaningful test of the SRH code path. With `A_p = +A_n` the
+  difference `phi_p_e - phi_n_e` would vanish pointwise and the SRH
+  numerator `ni_hat^2 * (exp(phi_p_e - phi_n_e) - 1)` would be
+  identically zero, collapsing Variant C onto Variant B. The sign
+  flip also matches physical convention: under forward bias the two
+  quasi-Fermi levels split in opposite directions from equilibrium.
+  Section 7.4's worst-case analysis (`phi_p_e - phi_n_e \in [-0.6, 0.6]`)
+  is already correct for this sign choice.
 - The 2D form uses two different wavenumbers on x and y for psi
   (2*pi, 3*pi) following the existing Poisson MMS convention
   (`semi/verification/mms_poisson.py:143-164`), which guarantees the
   discretization sees a 2D function and not a tensor product of 1D
   modes hit by one axis alone.
-- Amplitudes keep `|psi_e - phi_n_e|, |phi_p_e - psi_e| <= A_psi + A_n
-  = 0.8`, so `exp(...)` stays in `[exp(-0.8), exp(0.8)] ≈ [0.45, 2.23]`.
-  Newton is well-conditioned in this range and R_hat is neither
-  machine-zero (near-equilibrium) nor catastrophically cancelling.
+- Amplitudes keep `|psi_e - phi_n_e| <= A_psi + |A_n| = 0.8` and
+  `|phi_p_e - psi_e| <= A_psi + |A_p| = 0.8`, so `exp(...)` stays in
+  `[exp(-0.8), exp(0.8)] ≈ [0.45, 2.23]`. Newton is well-conditioned
+  in this range and R_hat is neither machine-zero (near-equilibrium)
+  nor catastrophically cancelling.
 
-A second `nonlinear` amplitude set `(A_psi, A_n, A_p) = (1.0, 0.5, 0.5)`
+A second `nonlinear` amplitude set `(A_psi, A_n, A_p) = (1.0, 0.5, -0.5)`
 is reserved for the CLI sweep only (Section 6). The pytest gate runs the
-default amplitudes.
+default amplitudes. The `A_p = -A_n` sign convention carries over.
 
 ## 2. Scaling reference values (consistency with Phase 1)
 
@@ -351,9 +362,9 @@ three things go wrong:
    but the residual norms span 5+ orders of magnitude between blocks.
 
 Mitigation:
-- Pytest gate holds `(A_psi, A_n, A_p) = (0.5, 0.3, 0.3)`, keeping
+- Pytest gate holds `(A_psi, A_n, A_p) = (0.5, 0.3, -0.3)`, keeping
   `exp(...) \in [0.45, 2.23]`.
-- CLI nonlinear variant `(1.0, 0.5, 0.5)` still keeps arguments
+- CLI nonlinear variant `(1.0, 0.5, -0.5)` still keeps arguments
   bounded by 1.5, `exp \in [0.22, 4.48]`, comfortably inside PETSc
   double precision. We do not add an `A_psi = 2` case here;
   the Poisson MMS already covers that stress regime for the scalar
@@ -389,7 +400,7 @@ in scaled units h/L is the relevant factor so Pe ~ pi*0.3*0.025 ~ 0.024
 degradation.
 
 Mitigation / monitoring:
-- Keep A_n, A_p <= 0.5 in all gated runs.
+- Keep `|A_n|, |A_p| <= 0.5` in all gated runs.
 - If a future tightening to large `A_n` surfaces a rate floor at
   ~1.5 in the continuity blocks, document it here as the expected
   Galerkin signature rather than a bug, and consider SUPG or
@@ -406,8 +417,9 @@ This is the same tolerance rationale as the Poisson MMS; we reuse it.
 ### 7.4 R_e near-equilibrium cancellation
 
 In Variant C, `n_e * p_e - ni_hat^2 = ni_hat^2 * (exp(phi_p_e - phi_n_e)
-- 1)`. For `A_n = A_p = 0.3`, the worst-case argument is
-`phi_p_e - phi_n_e \in [-0.6, 0.6]`, so the numerator swings in
+- 1)`. For `A_n = -A_p = 0.3`, `phi_p_e - phi_n_e = -2*A_n * sin(pi*x/L)`
+(1D) or `-2*A_n * sin(pi*x/L)*sin(pi*y/L)` (2D), so the worst-case
+argument is `phi_p_e - phi_n_e \in [-0.6, 0.6]` and the numerator swings in
 `[exp(-0.6)-1, exp(0.6)-1] = [-0.45, 0.82]` times `ni_hat^2 ~ 1e-12`.
 The denominator is `~ 2*tau_hat * ni_hat ~ 2e-6` (at tau_hat ~ 1e-1),
 so `R_e ~ 1e-6`. This is orders of magnitude below the diffusion term
@@ -428,7 +440,9 @@ or poor kernel numerics, not as a legitimate rate degradation.
 ## Summary (for the gate reviewer)
 
 - Exact solutions are sin-products that vanish on Omega's boundary;
-  amplitudes `(0.5, 0.3, 0.3)` keep exp(...) in `[0.45, 2.23]`.
+  amplitudes `(A_psi, A_n, A_p) = (0.5, 0.3, -0.3)` keep exp(...) in
+  `[0.45, 2.23]`. `A_p = -A_n` ensures `phi_p_e - phi_n_e` is non-zero
+  pointwise so Variant C's SRH term is a genuine test of the code path.
 - Scaling reuses `build_mms_scaling(L=2e-6)` from the Poisson MMS with
   the existing `lambda2 < 1` guard. No new constants.
 - Three variants exercise Poisson-only, full coupling without R, and

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -166,6 +166,16 @@ def verify_pn_1d(result) -> list[tuple[str, bool, str]]:
         f"<np>_right={np_right:.3e}, n_i^2={ni2:.3e}, rel_err={err_right:.2%}",
     ))
 
+    # 5. Global charge conservation (Phase 3 V&V)
+    from semi.verification.conservation import charge_conservation_from_result
+    Q_check = charge_conservation_from_result(result)
+    checks.append((
+        "charge conservation: |Q_net| < 1e-10 * q * max|N_net| * L",
+        Q_check.rel_error < 1.0e-10,
+        f"Q_net={Q_check.Q_net:.3e} C/m^2, "
+        f"Q_ref={Q_check.Q_ref:.3e} C/m^2, rel={Q_check.rel_error:.3e}",
+    ))
+
     # Stash analytical references for the plotter
     result._analytical = {
         "V_bi": V_bi_theory,
@@ -390,6 +400,17 @@ def verify_pn_1d_bias(result) -> list[tuple[str, bool, str]]:
             f"sim={J_sim_06:.3e}, Shockley={J_sh_06:.3e}, rel_err={err06*100:.1f}%",
         ))
 
+    # Phase 3 V&V: interior current continuity at the final forward bias.
+    from semi.verification.conservation import current_continuity_from_result
+    cc = current_continuity_from_result(result, n_samples=10)
+    V_end = iv[-1]["V"] if iv else 0.0
+    checks.append((
+        f"pn_1d_bias: J_total continuity within 5% at V={V_end:.2f} V",
+        bool(np.isfinite(cc.max_rel_dev)) and (cc.max_rel_dev < 0.05),
+        f"{cc.xs.size} samples; mean J={cc.mean_J:.3e} A/m^2, "
+        f"max dev={cc.max_abs_dev:.3e} ({cc.max_rel_dev*100:.2f}%)",
+    ))
+
     return checks
 
 
@@ -480,6 +501,20 @@ def verify_pn_1d_bias_reverse(result) -> list[tuple[str, bool, str]]:
         f"{len(V_arr)} pts; worst {rel_err[worst_i]*100:.1f}% at V="
         f"{V_arr[worst_i]:.2f} V (|sim|={J_abs_arr[worst_i]:.3e}, "
         f"ref={J_total_ref[worst_i]:.3e})",
+    ))
+
+    # Phase 3 V&V: interior current continuity at the final reverse bias.
+    # Reverse |J| is ~5 orders smaller than forward, so the absolute
+    # Newton-tolerance leakage shows up as a larger relative deviation
+    # (15% vs the 5% gate used on the forward branch).
+    from semi.verification.conservation import current_continuity_from_result
+    cc = current_continuity_from_result(result, n_samples=10)
+    V_end = iv[-1]["V"] if iv else 0.0
+    checks.append((
+        f"pn_1d_bias_reverse: J_total continuity within 15% at V={V_end:.2f} V",
+        bool(np.isfinite(cc.max_rel_dev)) and (cc.max_rel_dev < 0.15),
+        f"{cc.xs.size} samples; mean J={cc.mean_J:.3e} A/m^2, "
+        f"max dev={cc.max_abs_dev:.3e} ({cc.max_rel_dev*100:.2f}%)",
     ))
 
     return checks

--- a/scripts/run_verification.py
+++ b/scripts/run_verification.py
@@ -6,10 +6,11 @@ Sister script to `scripts/run_benchmark.py`. Each subcommand runs one
 verification activity, writes CSV+PNG artifacts under `results/`, and
 exits 0 on success.
 
-Subcommands (Phase 1 implements `mms_poisson` and `all`):
+Subcommands (Phases 1 and 2 implement `mms_poisson`, `mesh_convergence`,
+and `all`):
 
     python scripts/run_verification.py mms_poisson
-    python scripts/run_verification.py mesh_convergence    # Phase 2 (placeholder)
+    python scripts/run_verification.py mesh_convergence
     python scripts/run_verification.py conservation        # Phase 3 (placeholder)
     python scripts/run_verification.py mms_dd              # Phase 4 (placeholder)
     python scripts/run_verification.py all
@@ -68,9 +69,229 @@ def cmd_mms_poisson(args) -> int:
     return 0 if all_ok else 5
 
 
+def cmd_mesh_convergence(args) -> int:
+    """Run the pn_1d mesh-convergence sweep and gate monotone error reduction."""
+    from semi.verification.mesh_convergence import (
+        CLI_NS,
+        report_table,
+        run_cli_study,
+    )
+
+    out_dir = Path(args.out) if args.out else RESULTS_DIR / "mesh_convergence"
+    print(f"[run_verification] mesh_convergence -> {out_dir.relative_to(REPO_ROOT)}")
+    print(f"[run_verification] sweeping N = {CLI_NS}")
+    rows = run_cli_study(out_dir)
+
+    print()
+    print(report_table(rows, header="=== mesh_convergence pn_1d ==="))
+    print()
+    print("Honest flag: the depletion approximation is a model, not the")
+    print("truth. The FEM solver converges to the full Poisson-Boltzmann")
+    print("solution, so relative errors against the depletion references")
+    print("plateau on fine meshes at the physics-model gap, not at zero.")
+    print("See semi/verification/mesh_convergence.py docstring.")
+
+    # Acceptance gates.
+    # V_bi is set exactly by the Ohmic BCs and is mesh-independent to
+    # machine epsilon (not a meaningful convergence indicator), so it is
+    # reported only, not gated. E_peak and W against the depletion
+    # approximation are gated for strict monotone reduction over the
+    # first four refinements (before the physics-model plateau). The
+    # Cauchy self-convergence ratio is gated at >= 1.8x per doubling on
+    # the same range, which isolates FEM discretization error from the
+    # plateau and is the mathematically meaningful convergence rate.
+    ok = True
+
+    def _monotone(key, label):
+        errs = [r[key] for r in rows[:4]]
+        strictly_decreasing = all(
+            errs[i + 1] < errs[i] for i in range(len(errs) - 1)
+        )
+        print(
+            f"[{'PASS' if strictly_decreasing else 'FAIL'}] {label} monotone "
+            f"on N={CLI_NS[:4]}: {['%.3e' % e for e in errs]}"
+        )
+        return strictly_decreasing
+
+    def _cauchy_rate(key, label, floor=1.8):
+        ratios = [r[key + "_ratio"] for r in rows[1:4]]
+        finite = [r for r in ratios if r == r and r > 0.0]
+        worst = min(finite) if finite else float("nan")
+        passing = finite and worst >= floor
+        print(
+            f"[{'PASS' if passing else 'FAIL'}] {label} Cauchy rate >= "
+            f"{floor:.1f}x per doubling on N={CLI_NS[1:4]}: "
+            f"ratios={['%.2f' % r for r in ratios]}"
+        )
+        return bool(passing)
+
+    print(
+        f"[info] V_bi err vs depletion at finest N={CLI_NS[-1]}: "
+        f"{rows[-1]['err_Vbi_rel']:.2e} (set exactly by BCs, informational only)"
+    )
+    ok = _monotone("err_Epeak_rel", "E_peak err vs depletion") and ok
+    ok = _monotone("err_W_rel", "W err vs depletion") and ok
+    ok = _cauchy_rate("err_Epeak_cauchy", "E_peak") and ok
+    ok = _cauchy_rate("err_W_cauchy", "W") and ok
+
+    finest = rows[-1]
+    print(
+        f"[info] finest level N={finest['N']}: "
+        f"solve_time = {finest['solve_time_s']:.3f} s, "
+        f"newton_iters = {finest['newton_iters']}"
+    )
+    return 0 if ok else 6
+
+
+def cmd_conservation(args) -> int:
+    """
+    Phase 3: run conservation checks at specific bias points.
+
+    Two benchmarks drive the report:
+
+      - `pn_1d` equilibrium: integrate rho(x) and assert
+        |Q_net| < 1e-10 * q * max|N_net| * L_device.
+      - `pn_1d_bias` forward (targets 0.3, 0.45, 0.6 V) and
+        `pn_1d_bias_reverse` (targets -0.5, -1.0, -2.0 V): at each
+        target sample J_total at 10 interior facets and assert
+        max |J - mean| / |mean| < 5% (forward) or 15% (reverse).
+
+    The forward and reverse studies each run a single bias sweep (not
+    one per target) with a `post_step_hook` that records the interior
+    continuity samples on every converged bias, then the report reads
+    back the rows at the target biases. That keeps runtime close to
+    the production benchmark path.
+    """
+    import time
+
+    from semi import run as semi_run
+    from semi import schema
+    from semi.verification.conservation import (
+        charge_conservation_from_result,
+        run_bias_sweep_with_continuity,
+    )
+
+    out_dir = Path(args.out) if args.out else RESULTS_DIR / "conservation"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"[run_verification] conservation -> {out_dir.relative_to(REPO_ROOT)}")
+
+    all_ok = True
+
+    # ---- Charge conservation on pn_1d equilibrium ----
+    pn_1d_cfg = REPO_ROOT / "benchmarks" / "pn_1d" / "pn_junction.json"
+    cfg = schema.load(pn_1d_cfg)
+    t0 = time.perf_counter()
+    result = semi_run.run(cfg)
+    dt_eq = time.perf_counter() - t0
+    Q = charge_conservation_from_result(result)
+    print()
+    print("=== charge conservation (pn_1d equilibrium) ===")
+    print(f"  Q_net     = {Q.Q_net:.3e}  C/m^2")
+    print(f"  Q_ref     = {Q.Q_ref:.3e}  C/m^2   (= q * max|N_net| * L)")
+    print(f"  threshold = {Q.Q_ref * 1.0e-10:.3e}  C/m^2   (1e-10 * Q_ref)")
+    print(f"  rel       = {Q.rel_error:.3e}")
+    print(f"  solve_time= {dt_eq:.3f} s")
+    q_ok = Q.rel_error < 1.0e-10
+    print(f"  [{'PASS' if q_ok else 'FAIL'}] |Q_net| < 1e-10 * Q_ref")
+    all_ok = all_ok and q_ok
+
+    # ---- Current continuity: forward sweep ----
+    print()
+    print("=== current continuity: pn_1d_bias (forward, tol 5%) ===")
+    fwd_cfg_path = REPO_ROOT / "benchmarks" / "pn_1d_bias" / "pn_junction_bias.json"
+    fwd_cfg = schema.load(fwd_cfg_path)
+    t0 = time.perf_counter()
+    fwd_result = run_bias_sweep_with_continuity(fwd_cfg, n_samples=10)
+    dt_fwd = time.perf_counter() - t0
+    fwd_targets = [0.30, 0.45, 0.60]
+    fwd_ok = _report_continuity_table(fwd_result.iv, fwd_targets, tol=0.05)
+    print(f"  sweep_time = {dt_fwd:.3f} s")
+    all_ok = all_ok and fwd_ok
+
+    # ---- Current continuity: reverse sweep ----
+    print()
+    print("=== current continuity: pn_1d_bias_reverse (tol 15%) ===")
+    rev_cfg_path = (
+        REPO_ROOT / "benchmarks" / "pn_1d_bias_reverse" / "pn_junction_bias_reverse.json"
+    )
+    rev_cfg = schema.load(rev_cfg_path)
+    t0 = time.perf_counter()
+    rev_result = run_bias_sweep_with_continuity(rev_cfg, n_samples=10)
+    dt_rev = time.perf_counter() - t0
+    rev_targets = [-0.50, -1.00, -2.00]
+    rev_ok = _report_continuity_table(rev_result.iv, rev_targets, tol=0.15)
+    print(f"  sweep_time = {dt_rev:.3f} s")
+    all_ok = all_ok and rev_ok
+
+    # ---- CSV artifact ----
+    import csv
+    csv_path = out_dir / "conservation.csv"
+    with csv_path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["benchmark", "V", "mean_J", "max_abs_dev", "max_rel_dev",
+                    "n_pts", "pass", "tol"])
+        for V in fwd_targets:
+            row = _closest_iv_row(fwd_result.iv, V)
+            w.writerow([
+                "pn_1d_bias", row.get("V", ""), row.get("continuity_mean_J", ""),
+                row.get("continuity_max_dev", ""), row.get("continuity_max_rel", ""),
+                row.get("continuity_n_pts", ""),
+                bool(row.get("continuity_max_rel", float("inf")) < 0.05), 0.05,
+            ])
+        for V in rev_targets:
+            row = _closest_iv_row(rev_result.iv, V)
+            w.writerow([
+                "pn_1d_bias_reverse", row.get("V", ""), row.get("continuity_mean_J", ""),
+                row.get("continuity_max_dev", ""), row.get("continuity_max_rel", ""),
+                row.get("continuity_n_pts", ""),
+                bool(row.get("continuity_max_rel", float("inf")) < 0.15), 0.15,
+            ])
+        w.writerow(["pn_1d_equilibrium_charge",
+                    "", Q.Q_net, "", Q.rel_error, "",
+                    Q.rel_error < 1.0e-10, 1.0e-10])
+    print()
+    print(f"[run_verification] wrote {csv_path.relative_to(REPO_ROOT)}")
+    print(f"[run_verification] total runtime: "
+          f"{dt_eq + dt_fwd + dt_rev:.1f} s "
+          f"(eq {dt_eq:.1f}s, fwd {dt_fwd:.1f}s, rev {dt_rev:.1f}s)")
+    return 0 if all_ok else 7
+
+
+def _closest_iv_row(iv_rows, V_target):
+    """Return the iv_row whose V is closest to V_target."""
+    if not iv_rows:
+        return {}
+    return min(iv_rows, key=lambda r: abs(float(r.get("V", 0.0)) - V_target))
+
+
+def _report_continuity_table(iv_rows, targets, *, tol):
+    """Print a pass/fail table at `targets` and return overall pass/fail."""
+    print(f"  {'V':>8}  {'mean_J [A/m^2]':>16}  {'max_dev [A/m^2]':>16}  "
+          f"{'max_rel':>10}  {'pts':>4}  result")
+    all_pass = True
+    for V in targets:
+        row = _closest_iv_row(iv_rows, V)
+        if not row or "continuity_max_rel" not in row:
+            print(f"  {V:>8.3f}  {'(no row)':>16}")
+            all_pass = False
+            continue
+        rel = float(row["continuity_max_rel"])
+        passed = rel < tol
+        all_pass = all_pass and passed
+        marker = "PASS" if passed else "FAIL"
+        print(
+            f"  {float(row['V']):>8.3f}  "
+            f"{float(row['continuity_mean_J']):>16.3e}  "
+            f"{float(row['continuity_max_dev']):>16.3e}  "
+            f"{rel*100:>9.2f}%  "
+            f"{int(row['continuity_n_pts']):>4d}  [{marker}]"
+        )
+    return all_pass
+
+
 def cmd_not_implemented(name: str):
     def _run(_args) -> int:
-        print(f"[run_verification] {name}: not implemented yet (Phase 2/3/4)")
+        print(f"[run_verification] {name}: not implemented yet (Phase 4)")
         return 0
     return _run
 
@@ -80,7 +301,13 @@ def cmd_all(args) -> int:
     rc = cmd_mms_poisson(args)
     if rc != 0:
         return rc
-    # Future: chain mesh_convergence, conservation, mms_dd here.
+    rc = cmd_mesh_convergence(args)
+    if rc != 0:
+        return rc
+    rc = cmd_conservation(args)
+    if rc != 0:
+        return rc
+    # Future: chain mms_dd here.
     return 0
 
 
@@ -101,9 +328,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.study == "mms_poisson":
         return cmd_mms_poisson(args)
     if args.study == "mesh_convergence":
-        return cmd_not_implemented("mesh_convergence")(args)
+        return cmd_mesh_convergence(args)
     if args.study == "conservation":
-        return cmd_not_implemented("conservation")(args)
+        return cmd_conservation(args)
     if args.study == "mms_dd":
         return cmd_not_implemented("mms_dd")(args)
     if args.study == "all":

--- a/scripts/run_verification.py
+++ b/scripts/run_verification.py
@@ -289,11 +289,43 @@ def _report_continuity_table(iv_rows, targets, *, tol):
     return all_pass
 
 
-def cmd_not_implemented(name: str):
-    def _run(_args) -> int:
-        print(f"[run_verification] {name}: not implemented yet (Phase 4)")
-        return 0
-    return _run
+def cmd_mms_dd(args) -> int:
+    """
+    Phase 4: MMS for the coupled drift-diffusion block residual.
+
+    Runs nine studies (three variants x {1D linear, 1D nonlinear, 2D})
+    and gates the finest-pair L^2 and H^1 rates of every meaningful
+    block per variant (psi only for Variant A; psi + phi_n + phi_p for
+    Variants B and C). See docs/mms_dd_derivation.md for the
+    rate-threshold rationale; this CLI enforces the same floors the
+    pytest gate uses.
+    """
+    from semi.verification.mms_dd import report_table, run_cli_study
+
+    out_dir = Path(args.out) if args.out else RESULTS_DIR / "mms_dd"
+    print(f"[run_verification] mms_dd -> {out_dir.relative_to(REPO_ROOT)}")
+    studies = run_cli_study(out_dir)
+
+    all_ok = True
+    for label, rows in studies.items():
+        variant = "A" if "_A_" in label or label.endswith("_A") else (
+            "B" if "_B_" in label or label.endswith("_B") else "C"
+        )
+        blocks = ("psi",) if variant == "A" else ("psi", "phi_n", "phi_p")
+        print()
+        print(report_table(rows, header=f"=== mms_dd {label} ==="))
+        for b in blocks:
+            ok_l2, msg_l2 = _gate_finest_pair_rate(
+                rows, f"rate_L2_{b}", 1.75, f"{label} L2[{b}]",
+            )
+            ok_h1, msg_h1 = _gate_finest_pair_rate(
+                rows, f"rate_H1_{b}", 0.80, f"{label} H1[{b}]",
+            )
+            print(msg_l2)
+            print(msg_h1)
+            all_ok = all_ok and ok_l2 and ok_h1
+
+    return 0 if all_ok else 8
 
 
 def cmd_all(args) -> int:
@@ -307,7 +339,9 @@ def cmd_all(args) -> int:
     rc = cmd_conservation(args)
     if rc != 0:
         return rc
-    # Future: chain mms_dd here.
+    rc = cmd_mms_dd(args)
+    if rc != 0:
+        return rc
     return 0
 
 
@@ -332,7 +366,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.study == "conservation":
         return cmd_conservation(args)
     if args.study == "mms_dd":
-        return cmd_not_implemented("mms_dd")(args)
+        return cmd_mms_dd(args)
     if args.study == "all":
         return cmd_all(args)
     parser.error(f"Unknown study {args.study!r}")

--- a/scripts/run_verification.py
+++ b/scripts/run_verification.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+V&V (Verification & Validation) runner CLI.
+
+Sister script to `scripts/run_benchmark.py`. Each subcommand runs one
+verification activity, writes CSV+PNG artifacts under `results/`, and
+exits 0 on success.
+
+Subcommands (Phase 1 implements `mms_poisson` and `all`):
+
+    python scripts/run_verification.py mms_poisson
+    python scripts/run_verification.py mesh_convergence    # Phase 2 (placeholder)
+    python scripts/run_verification.py conservation        # Phase 3 (placeholder)
+    python scripts/run_verification.py mms_dd              # Phase 4 (placeholder)
+    python scripts/run_verification.py all
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RESULTS_DIR = REPO_ROOT / "results"
+
+
+def _gate_finest_pair_rate(rows, key: str, threshold: float, label: str) -> tuple[bool, str]:
+    """Pass-fail check on the finest-pair rate column."""
+    rate = rows[-1].get(key)
+    if rate is None or rate != rate:  # NaN check without numpy
+        return False, f"{label}: finest-pair {key} is NaN"
+    ok = rate >= threshold
+    marker = "PASS" if ok else "FAIL"
+    return ok, f"[{marker}] {label}: finest-pair {key} = {rate:.3f} (threshold {threshold:.2f})"
+
+
+def cmd_mms_poisson(args) -> int:
+    """Run all MMS-Poisson studies and gate the finest-pair convergence rates."""
+    from semi.verification.mms_poisson import report_table, run_cli_study
+
+    out_dir = Path(args.out) if args.out else RESULTS_DIR / "mms_poisson"
+    print(f"[run_verification] mms_poisson -> {out_dir.relative_to(REPO_ROOT)}")
+    studies = run_cli_study(out_dir)
+
+    all_ok = True
+    for label in ("1d_linear", "1d_nonlinear", "2d_triangles"):
+        rows = studies[label]
+        print()
+        print(report_table(rows, header=f"=== mms_poisson {label} ==="))
+        ok_l2, msg_l2 = _gate_finest_pair_rate(rows, "rate_L2", 1.85, f"{label} L2")
+        ok_h1, msg_h1 = _gate_finest_pair_rate(rows, "rate_H1", 0.85, f"{label} H1")
+        print(msg_l2)
+        print(msg_h1)
+        all_ok = all_ok and ok_l2 and ok_h1
+
+    smoke = studies["2d_quad_smoke"][0]
+    print()
+    print("=== mms_poisson 2d_quad_smoke (single mesh, N=64) ===")
+    print(
+        f"  triangle e_L2 = {smoke['e_L2_triangle']:.3e}, "
+        f"quad e_L2 = {smoke['e_L2_quad']:.3e}, "
+        f"ratio = {smoke['ratio_L2_quad_over_triangle']:.3f}"
+    )
+    smoke_ok = 0.1 < smoke["ratio_L2_quad_over_triangle"] < 10.0
+    print(("[PASS]" if smoke_ok else "[FAIL]") + " quad/triangle ratio in [0.1, 10]")
+    all_ok = all_ok and smoke_ok
+
+    return 0 if all_ok else 5
+
+
+def cmd_not_implemented(name: str):
+    def _run(_args) -> int:
+        print(f"[run_verification] {name}: not implemented yet (Phase 2/3/4)")
+        return 0
+    return _run
+
+
+def cmd_all(args) -> int:
+    """Run every implemented V&V activity in sequence."""
+    rc = cmd_mms_poisson(args)
+    if rc != 0:
+        return rc
+    # Future: chain mesh_convergence, conservation, mms_dd here.
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a kronos-semi V&V study and write CSV+PNG artifacts."
+    )
+    parser.add_argument("--out", help="output root directory (default: results/<study>)")
+    sub = parser.add_subparsers(dest="study", required=True)
+
+    sub.add_parser("mms_poisson", help="MMS for equilibrium Poisson (Phase 1)")
+    sub.add_parser("mesh_convergence", help="pn_1d mesh convergence (Phase 2)")
+    sub.add_parser("conservation", help="current and charge conservation (Phase 3)")
+    sub.add_parser("mms_dd", help="MMS for coupled drift-diffusion (Phase 4)")
+    sub.add_parser("all", help="run every implemented study")
+
+    args = parser.parse_args(argv)
+    if args.study == "mms_poisson":
+        return cmd_mms_poisson(args)
+    if args.study == "mesh_convergence":
+        return cmd_not_implemented("mesh_convergence")(args)
+    if args.study == "conservation":
+        return cmd_not_implemented("conservation")(args)
+    if args.study == "mms_dd":
+        return cmd_not_implemented("mms_dd")(args)
+    if args.study == "all":
+        return cmd_all(args)
+    parser.error(f"Unknown study {args.study!r}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/semi/run.py
+++ b/semi/run.py
@@ -99,8 +99,24 @@ def run_equilibrium(cfg: dict[str, Any]) -> SimulationResult:
     )
 
 
-def run_bias_sweep(cfg: dict[str, Any]) -> SimulationResult:
-    """Coupled drift-diffusion solver with optional bias ramping."""
+def run_bias_sweep(
+    cfg: dict[str, Any],
+    *,
+    post_step_hook=None,
+) -> SimulationResult:
+    """
+    Coupled drift-diffusion solver with optional bias ramping.
+
+    `post_step_hook`, if provided, is called after every successful
+    bias step with the signature
+
+        post_step_hook(V_applied, spaces, iv_row)
+
+    where `iv_row` is the freshly-appended dict in `result.iv`. The
+    hook is expected to mutate `iv_row` in place (e.g. to record
+    Phase 3 V&V continuity samples on top of the V / J the sweep
+    already records). No return value is inspected.
+    """
     from dolfinx import fem
 
     from .doping import build_profile
@@ -253,6 +269,8 @@ def run_bias_sweep(cfg: dict[str, Any]) -> SimulationResult:
     V_prev = V_seed
     _record_iv(iv_rows, V_seed, spaces, sc, ref_mat,
                sweep_contact, sweep_facet_info, mu_n_SI, mu_p_SI)
+    if post_step_hook is not None:
+        post_step_hook(V_seed, spaces, iv_rows[-1])
 
     V_end = float(v_sweep_list[-1])
     if abs(V_end - V_seed) > 0.0 and max_step_abs > 0.0:
@@ -293,6 +311,8 @@ def run_bias_sweep(cfg: dict[str, Any]) -> SimulationResult:
                 V_prev = V_try
                 _record_iv(iv_rows, V_try, spaces, sc, ref_mat,
                            sweep_contact, sweep_facet_info, mu_n_SI, mu_p_SI)
+                if post_step_hook is not None:
+                    post_step_hook(V_try, spaces, iv_rows[-1])
                 halvings = 0
                 controller.on_success(int(info.get("iterations", 0)))
                 continue

--- a/semi/verification/__init__.py
+++ b/semi/verification/__init__.py
@@ -9,4 +9,5 @@ MMS necessarily exercises the full FEM stack.
 
 Public submodules:
     mms_poisson       MMS for the equilibrium Poisson equation
+    mms_dd            MMS for the coupled drift-diffusion block residual
 """

--- a/semi/verification/__init__.py
+++ b/semi/verification/__init__.py
@@ -1,0 +1,12 @@
+"""
+Verification & Validation subpackage.
+
+This module hosts Method-of-Manufactured-Solutions (MMS) studies, mesh
+convergence sweeps, and conservation checks. Unlike the pure-Python
+core (constants, materials, scaling, doping, schema, continuation,
+diode_analytical) this subpackage is allowed to import dolfinx because
+MMS necessarily exercises the full FEM stack.
+
+Public submodules:
+    mms_poisson       MMS for the equilibrium Poisson equation
+"""

--- a/semi/verification/_convergence.py
+++ b/semi/verification/_convergence.py
@@ -1,0 +1,124 @@
+"""
+Convergence-rate bookkeeping shared across verification studies.
+
+Given a sequence of (h, error) pairs from a mesh-refinement sweep,
+compute observed rates, format a stdout table, and write a CSV plus
+log-log PNG plot. None of these are physics-specific.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+
+
+def observed_rates(hs: list[float], errors: list[float]) -> list[float]:
+    """
+    Element-wise log slope between consecutive (h, error) pairs.
+
+    Returned list has length len(hs); the first entry is NaN because
+    no previous pair exists. This matches the human-specified DataFrame
+    convention where rate_L2[0] = NaN and tests assert on .iloc[-1].
+    """
+    if len(hs) != len(errors):
+        raise ValueError("hs and errors must have equal length")
+    if len(hs) < 2:
+        return [float("nan")] * len(hs)
+    rates: list[float] = [float("nan")]
+    for i in range(1, len(hs)):
+        h_prev, h_cur = hs[i - 1], hs[i]
+        e_prev, e_cur = errors[i - 1], errors[i]
+        if e_prev <= 0.0 or e_cur <= 0.0 or h_prev == h_cur:
+            rates.append(float("nan"))
+        else:
+            rates.append(math.log(e_prev / e_cur) / math.log(h_prev / h_cur))
+    return rates
+
+
+def write_convergence_csv(
+    path: Path,
+    rows: list[dict],
+    columns: list[str],
+) -> None:
+    """Write a CSV with an explicit column order. No pandas dependency."""
+    import csv
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=columns)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({c: row.get(c, "") for c in columns})
+
+
+def write_loglog_plot(
+    path: Path,
+    hs: list[float],
+    series: dict[str, list[float]],
+    *,
+    title: str,
+    theoretical_rates: dict[str, float] | None = None,
+) -> None:
+    """
+    Write a log-log error-vs-h PNG. `series` maps label to error sequence;
+    optional `theoretical_rates` overlays guide lines anchored at the
+    first finite (h, error) point of the matching series.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(6, 4))
+    h_arr = np.asarray(hs, dtype=float)
+    for label, errs in series.items():
+        e = np.asarray(errs, dtype=float)
+        ax.loglog(h_arr, e, "o-", label=label)
+        if theoretical_rates and label in theoretical_rates:
+            slope = theoretical_rates[label]
+            anchor_idx = next(
+                (i for i, v in enumerate(e) if np.isfinite(v) and v > 0.0), None
+            )
+            if anchor_idx is not None:
+                e_ref = e[anchor_idx] * (h_arr / h_arr[anchor_idx]) ** slope
+                ax.loglog(
+                    h_arr, e_ref, "--", alpha=0.5,
+                    label=f"O(h^{slope:.0f}) reference",
+                )
+    ax.set_xlabel("h (mesh size, m)")
+    ax.set_ylabel("error norm")
+    ax.set_title(title)
+    ax.grid(True, which="both", alpha=0.3)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(path, dpi=130)
+    plt.close(fig)
+
+
+def format_table(rows: list[dict], columns: list[str], header: str = "") -> str:
+    """Pretty multi-line table for stdout. Numbers use scientific notation."""
+    widths = [max(len(c), 12) for c in columns]
+    lines: list[str] = []
+    if header:
+        lines.append(header)
+    lines.append("  ".join(c.rjust(w) for c, w in zip(columns, widths, strict=False)))
+    for row in rows:
+        cells = []
+        for c, w in zip(columns, widths, strict=False):
+            v = row.get(c, "")
+            if isinstance(v, float):
+                if math.isnan(v):
+                    s = "      ---"
+                elif c.startswith("rate"):
+                    s = f"{v:8.3f}"
+                else:
+                    s = f"{v:.3e}"
+            else:
+                s = str(v)
+            cells.append(s.rjust(w))
+        lines.append("  ".join(cells))
+    return "\n".join(lines)

--- a/semi/verification/_norms.py
+++ b/semi/verification/_norms.py
@@ -1,0 +1,43 @@
+"""
+Shared L^2 / H^1 error-norm helpers for verification studies.
+
+Both helpers return assembled scalar squared norms so callers compose
+into the convergence pipeline without thinking about UFL syntax.
+"""
+from __future__ import annotations
+
+
+def l2_error_squared(u_h, u_exact_ufl) -> float:
+    """
+    Squared L^2 error: integral of (u_h - u_exact)^2 over the mesh.
+
+    Parameters
+    ----------
+    u_h
+        dolfinx.fem.Function holding the discrete solution.
+    u_exact_ufl
+        Any UFL expression, typically a function of SpatialCoordinate.
+
+    Returns
+    -------
+    float
+        The assembled scalar (already MPI-reduced over the comm).
+    """
+    import ufl
+    from dolfinx import fem
+
+    diff = u_h - u_exact_ufl
+    form = fem.form(diff * diff * ufl.dx)
+    return float(fem.assemble_scalar(form))
+
+
+def h1_seminorm_error_squared(u_h, u_exact_ufl) -> float:
+    """
+    Squared H^1 seminorm error: integral of |grad(u_h - u_exact)|^2.
+    """
+    import ufl
+    from dolfinx import fem
+
+    diff = u_h - u_exact_ufl
+    form = fem.form(ufl.inner(ufl.grad(diff), ufl.grad(diff)) * ufl.dx)
+    return float(fem.assemble_scalar(form))

--- a/semi/verification/conservation.py
+++ b/semi/verification/conservation.py
@@ -1,0 +1,380 @@
+"""
+Conservation checks for the 1D pn junction benchmarks.
+
+Two distinct checks live here, mirroring the two things a steady-state
+drift-diffusion solution must satisfy to be self-consistent:
+
+1) Current continuity (`pn_1d_bias`, `pn_1d_bias_reverse`)
+
+   In steady state with uniform cross-section, J_total(x) = J_n + J_p
+   must be constant in space (div J = 0 with no source at the terminals).
+   The check samples J_total at ~10 interior facets via a UFL dS
+   facet-integral pattern and asserts
+
+        max |J_total(x_i) - mean(J_total)| / |mean(J_total)| < tol
+
+   with tol = 5% for forward bias (where J >> numerical noise floor) and
+   tol = 15% for reverse bias (where |J| is many orders of magnitude
+   smaller and absolute Newton residual leakage shows up relatively
+   larger).
+
+2) Charge conservation (`pn_1d` equilibrium)
+
+   For an isolated device with ohmic contacts at equilibrium the total
+   space charge integrates to zero:
+
+        integral(p - n + N_net) dx == 0    (N_net = N_D - N_A)
+
+   to within the nonlinear solver tolerance. The check asserts
+
+        |Q_net| < 1e-10 * q * max(|N_net|) * L_device
+
+   i.e. the net charge per cross-sectional area is at least ten orders
+   of magnitude smaller than the charge one would get by taking peak
+   doping uniformly over the entire device length. That matches the
+   snes_rtol ~ 1e-14 tolerance used by `run_equilibrium`.
+
+The pure-Python metric functions (`current_continuity_metric`,
+`charge_neutrality_metric`) have no dolfinx dependency and are the
+unit-testable core. The FEM helpers (`current_continuity_from_result`,
+`charge_conservation_from_result`) import dolfinx only when called.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+# numpy 2.0 renamed np.trapz to np.trapezoid; keep both paths working so
+# the pure-Python metric tests run on the 1.x CI matrix and on the 2.x
+# Docker FEM image.
+_trapz = getattr(np, "trapezoid", None) or np.trapz
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python metrics (no dolfinx)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CurrentContinuityMetric:
+    """Outcome of sampling J_total at a set of interior x-locations."""
+
+    xs: np.ndarray
+    J_vals: np.ndarray
+    mean_J: float
+    max_abs_dev: float
+    max_rel_dev: float
+
+
+def current_continuity_metric(xs, J_vals) -> CurrentContinuityMetric:
+    """
+    Reduce an array of J_total(x_i) samples to (mean, max abs deviation,
+    max relative deviation). If the mean is zero the relative deviation
+    is +inf when any sample deviates and 0 otherwise.
+    """
+    xs = np.asarray(xs, dtype=float)
+    J = np.asarray(J_vals, dtype=float)
+    if J.size == 0:
+        return CurrentContinuityMetric(xs, J, 0.0, 0.0, 0.0)
+    mean_J = float(np.mean(J))
+    abs_dev = np.abs(J - mean_J)
+    max_abs = float(np.max(abs_dev))
+    denom = abs(mean_J)
+    if denom == 0.0:
+        max_rel = float("inf") if max_abs > 0.0 else 0.0
+    else:
+        max_rel = max_abs / denom
+    return CurrentContinuityMetric(
+        xs=xs, J_vals=J, mean_J=mean_J,
+        max_abs_dev=max_abs, max_rel_dev=max_rel,
+    )
+
+
+@dataclass(frozen=True)
+class ChargeNeutralityMetric:
+    """Outcome of integrating rho(x) over the device."""
+
+    Q_net: float       # q * integral(p - n + N_net) dx, C/m^2
+    Q_ref: float       # q * max|N_net| * L, C/m^2
+    rel_error: float   # |Q_net| / Q_ref
+
+
+def charge_neutrality_metric(x, p, n, N_net, q_value) -> ChargeNeutralityMetric:
+    """
+    Integrate (p - n + N_net) dx by the trapezoidal rule and report both
+    the dimensional net charge per cross-sectional area (q times the
+    integral) and the relative-to-peak-doping reference q * max|N_net| * L.
+    """
+    x = np.asarray(x, dtype=float)
+    p = np.asarray(p, dtype=float)
+    n = np.asarray(n, dtype=float)
+    N_net = np.asarray(N_net, dtype=float)
+    order = np.argsort(x)
+    x_s = x[order]
+    rho_over_q = p[order] - n[order] + N_net[order]
+    integral = float(_trapz(rho_over_q, x_s))
+    Q_net = q_value * integral
+    L = float(x_s[-1] - x_s[0]) if x_s.size >= 2 else 0.0
+    peak_N = float(np.max(np.abs(N_net))) if N_net.size else 0.0
+    Q_ref = q_value * peak_N * L
+    rel = abs(Q_net) / Q_ref if Q_ref > 0.0 else float("inf")
+    return ChargeNeutralityMetric(Q_net=Q_net, Q_ref=Q_ref, rel_error=rel)
+
+
+# ---------------------------------------------------------------------------
+# FEM helpers (dolfinx required)
+# ---------------------------------------------------------------------------
+
+
+def _sample_interior_facets_1d(msh, n_samples: int):
+    """
+    Return `(facet_indices, xs)` for up to `n_samples` interior facets
+    on a 1D mesh, roughly evenly spaced along the x-axis, *excluding*
+    facets adjacent to boundary cells.
+
+    The exclusion matters for drift-diffusion continuity checks: cells
+    that touch a Dirichlet contact have one-sided FE gradients in which
+    grad(phi_n) is effectively (phi_n(x=0) - phi_n(x=h)) / h. That
+    difference quotient includes the prescribed BC value, which forces
+    phi_n (and hence the computed J_n) in the boundary cell to absorb
+    the full mismatch between "ideal drift-diffusion bulk" and "fixed
+    contact potential". The interior facet adjacent to that cell then
+    sees an `avg(J_n)` that is the mean of a clean interior gradient
+    and a boundary-skewed one.
+
+    In an 800-cell pn junction at forward bias the bulk-facet J_total
+    samples agree to O(1e-5) while the two boundary-adjacent facets
+    differ from the bulk by O(100%). Excluding them is the physically
+    meaningful way to measure "is J_total constant in the device
+    interior" as Phase 3 V&V intends; it does not hide any real
+    conservation defect (which would show up in the bulk too).
+    """
+    from dolfinx import fem
+
+    tdim = msh.topology.dim
+    if tdim != 1:
+        raise ValueError(
+            f"conservation sampler supports 1D only, got tdim={tdim}"
+        )
+    fdim = tdim - 1
+
+    msh.topology.create_connectivity(fdim, tdim)
+    msh.topology.create_connectivity(tdim, fdim)
+    f2c = msh.topology.connectivity(fdim, tdim)
+    c2f = msh.topology.connectivity(tdim, fdim)
+    n_facets = msh.topology.index_map(fdim).size_local
+    n_cells = msh.topology.index_map(tdim).size_local
+
+    # Collect boundary cells: any cell that owns a boundary facet.
+    boundary_cells: set[int] = set()
+    for c in range(n_cells):
+        for f in c2f.links(c):
+            if len(f2c.links(f)) == 1:
+                boundary_cells.add(c)
+                break
+
+    V = fem.functionspace(msh, ("Lagrange", 1))
+    all_coords = V.tabulate_dof_coordinates()
+
+    interior = []
+    xs = []
+    for i in range(n_facets):
+        adj = f2c.links(i)
+        if len(adj) != 2:
+            continue
+        # Skip interior facets whose gradient evaluation would pull in a
+        # boundary cell; see module docstring.
+        if int(adj[0]) in boundary_cells or int(adj[1]) in boundary_cells:
+            continue
+        dofs = fem.locate_dofs_topological(
+            V, fdim, np.array([i], dtype=np.int32)
+        )
+        if dofs.size == 0:
+            continue
+        interior.append(i)
+        xs.append(float(all_coords[dofs[0], 0]))
+
+    interior = np.array(interior, dtype=np.int32)
+    xs = np.array(xs, dtype=float)
+    if interior.size == 0:
+        return interior, xs
+
+    order = np.argsort(xs)
+    interior = interior[order]
+    xs = xs[order]
+
+    if interior.size <= n_samples:
+        return interior, xs
+
+    pick = np.linspace(0, interior.size - 1, n_samples, dtype=int)
+    return interior[pick], xs[pick]
+
+
+def _dd_mobilities_SI(cfg) -> tuple[float, float]:
+    """Return (mu_n_SI, mu_p_SI) in m^2/(V s) from the config."""
+    mob = cfg.get("physics", {}).get("mobility", {})
+    mu_n_SI = float(mob.get("mu_n", 1400.0)) * 1.0e-4
+    mu_p_SI = float(mob.get("mu_p", 450.0)) * 1.0e-4
+    return mu_n_SI, mu_p_SI
+
+
+def _semiconductor_material(cfg):
+    """Pick the semiconductor material (only one is supported for now)."""
+    from semi.materials import get_material
+
+    for _name, region in cfg["regions"].items():
+        mat = get_material(region["material"])
+        if mat.is_semiconductor():
+            return mat
+    raise ValueError("No semiconductor region found in cfg")
+
+
+def current_continuity_from_state(
+    msh,
+    sc,
+    cfg,
+    psi,
+    phi_n,
+    phi_p,
+    *,
+    n_samples: int = 10,
+) -> CurrentContinuityMetric:
+    """
+    Evaluate J_total = J_n + J_p at ~`n_samples` interior facets of the
+    1D mesh via UFL `dS` facet integrals and return the continuity
+    metric.
+
+    Each sampled facet i is tagged individually, a one-entry meshtags
+    object marks that facet, and `avg(J_total) * dS(tag_i)` is assembled.
+    In 1D dS on a 0-D entity has unit measure so the assembled scalar
+    equals avg(J_total) at that vertex. We divide by the assembled
+    measure defensively in case future dolfinx versions change that
+    convention.
+
+    This function operates on raw UFL/dolfinx state (no SimulationResult)
+    so it can be called from inside `semi.run.run_bias_sweep` to record
+    continuity at intermediate bias steps without first materializing a
+    SimulationResult.
+    """
+    import ufl
+    from dolfinx import fem
+    from dolfinx.mesh import meshtags
+    from mpi4py import MPI
+    from petsc4py import PETSc
+
+    from semi.constants import Q as Q_SI
+    from semi.physics.slotboom import n_from_slotboom, p_from_slotboom
+
+    mat = _semiconductor_material(cfg)
+    mu_n_SI, mu_p_SI = _dd_mobilities_SI(cfg)
+
+    tdim = msh.topology.dim
+    fdim = tdim - 1
+
+    facet_indices, xs = _sample_interior_facets_1d(msh, n_samples)
+    if facet_indices.size == 0:
+        return current_continuity_metric(xs, np.zeros(0))
+
+    ni_hat = fem.Constant(msh, PETSc.ScalarType(mat.n_i / sc.C0))
+
+    n_ufl = n_from_slotboom(psi, phi_n, ni_hat) * sc.C0
+    p_ufl = p_from_slotboom(psi, phi_p, ni_hat) * sc.C0
+    grad_phi_n_phys = sc.V0 * ufl.grad(phi_n)
+    grad_phi_p_phys = sc.V0 * ufl.grad(phi_p)
+
+    Jn_x = Q_SI * mu_n_SI * n_ufl * grad_phi_n_phys[0]
+    Jp_x = Q_SI * mu_p_SI * p_ufl * grad_phi_p_phys[0]
+    J_total = Jn_x + Jp_x
+
+    J_vals = np.empty(facet_indices.size, dtype=float)
+    for k, f in enumerate(facet_indices):
+        tag = 1
+        indices = np.array([int(f)], dtype=np.int32)
+        values = np.array([tag], dtype=np.int32)
+        facet_mt = meshtags(msh, fdim, indices, values)
+        dS = ufl.Measure("dS", domain=msh, subdomain_data=facet_mt, subdomain_id=tag)
+
+        I_form = fem.form(ufl.avg(J_total) * dS)
+        A_form = fem.form(ufl.avg(fem.Constant(msh, PETSc.ScalarType(1.0))) * dS)
+
+        I_local = fem.assemble_scalar(I_form)
+        A_local = fem.assemble_scalar(A_form)
+        I = msh.comm.allreduce(I_local, op=MPI.SUM)
+        A = msh.comm.allreduce(A_local, op=MPI.SUM)
+        J_vals[k] = float(I / A) if A != 0.0 else float("nan")
+
+    return current_continuity_metric(xs, J_vals)
+
+
+def current_continuity_from_result(result, n_samples: int = 10) -> CurrentContinuityMetric:
+    """
+    SimulationResult wrapper around `current_continuity_from_state`.
+    Used by the `pn_1d_bias` / `pn_1d_bias_reverse` verifiers to check
+    the continuity of the final-bias state returned by the benchmark.
+    """
+    return current_continuity_from_state(
+        msh=result.mesh,
+        sc=result.scaling,
+        cfg=result.cfg,
+        psi=result.psi,
+        phi_n=result.phi_n,
+        phi_p=result.phi_p,
+        n_samples=n_samples,
+    )
+
+
+def run_bias_sweep_with_continuity(cfg: dict, *, n_samples: int = 10):
+    """
+    Run `semi.run.run_bias_sweep(cfg)` with a post-step hook that attaches
+    `continuity_*` fields to each IV row. Returns the SimulationResult
+    whose `.iv` entries now carry:
+
+        continuity_mean_J   mean of J_total samples at this bias (A/m^2)
+        continuity_max_dev  max absolute deviation from the mean (A/m^2)
+        continuity_max_rel  max |J - mean| / |mean|  (dimensionless)
+        continuity_n_pts    number of interior-facet samples used
+    """
+    from semi.run import run_bias_sweep
+    from semi.scaling import make_scaling_from_config
+
+    ref_mat = _semiconductor_material(cfg)
+    sc = make_scaling_from_config(cfg, ref_mat)
+
+    def hook(V_applied, spaces, iv_row):
+        cc = current_continuity_from_state(
+            msh=spaces.V_psi.mesh, sc=sc, cfg=cfg,
+            psi=spaces.psi, phi_n=spaces.phi_n, phi_p=spaces.phi_p,
+            n_samples=n_samples,
+        )
+        iv_row["continuity_mean_J"] = float(cc.mean_J)
+        iv_row["continuity_max_dev"] = float(cc.max_abs_dev)
+        iv_row["continuity_max_rel"] = float(cc.max_rel_dev)
+        iv_row["continuity_n_pts"] = int(cc.xs.size)
+
+    return run_bias_sweep(cfg, post_step_hook=hook)
+
+
+def charge_conservation_from_result(result) -> ChargeNeutralityMetric:
+    """
+    Integrate q * (p - n + N_net) over the device from the dof arrays
+    produced by `run_equilibrium`. This uses NumPy trapezoidal
+    integration on the sorted 1D mesh rather than a UFL dx assembly
+    because:
+
+      - result.x_dof, result.n_phys, result.p_phys, result.N_hat are
+        already available and carry the exact quantities we need;
+      - the trapezoidal rule on P1 dofs is the same numerical value as
+        a UFL dx assembly of `(p - n + N_net) * dx` against a constant
+        test function on P1 (mass-lumped), which is what we want;
+      - the pure-Python metric is independently unit-testable with
+        synthetic arrays.
+    """
+    from semi.constants import Q as Q_SI
+
+    sc = result.scaling
+    x = np.asarray(result.x_dof[:, 0], dtype=float)
+    p = np.asarray(result.p_phys, dtype=float)
+    n = np.asarray(result.n_phys, dtype=float)
+    N_net = np.asarray(result.N_hat.x.array, dtype=float) * sc.C0
+    return charge_neutrality_metric(x, p, n, N_net, Q_SI)

--- a/semi/verification/mesh_convergence.py
+++ b/semi/verification/mesh_convergence.py
@@ -1,0 +1,369 @@
+"""
+Mesh convergence study for the 1D pn junction benchmark.
+
+Unlike `mms_poisson`, this study has no exact solution to compare against.
+Instead it treats the depletion approximation as an engineering reference
+and measures how three canonical observables behave as h -> 0:
+
+    V_bi     = psi(x=L) - psi(x=0)                    built-in potential
+    E_peak   = max |-dpsi/dx|                          peak electric field
+    W        = extent of |E| > 0.01 * E_peak           depletion width
+
+HONEST FLAG
+-----------
+The depletion approximation is *approximate*. The FEM solver converges
+to the true Poisson-Boltzmann solution (with exp(psi) / exp(-psi)
+carrier terms), not to the depletion-approximation step-charge model.
+On fine meshes the relative errors against V_bi_theory, E_peak_theory,
+and W_theory therefore plateau at a physics-limited floor (typically
+a few percent of peak field). That plateau is the difference between
+the two *models*, not a discretization bug, and tightening the mesh
+cannot remove it.
+
+The pytest subset [100, 200, 400] is chosen so discretization error
+still dominates the physics-approximation floor and the error ratio
+per mesh doubling is bounded below by a meaningful constant. The full
+CLI sweep [50..1600] exhibits the plateau and the PNG shows it.
+
+Boundary conditions, doping, material, and all other physics are taken
+from `benchmarks/pn_1d/pn_junction.json`; only `mesh.resolution` is
+overridden per level.
+"""
+from __future__ import annotations
+
+import copy
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PN_1D_CFG = REPO_ROOT / "benchmarks" / "pn_1d" / "pn_junction.json"
+
+
+@dataclass(frozen=True)
+class MeshConvRow:
+    """Per-level observables for the pn_1d mesh sweep."""
+
+    N: int
+    h: float
+    n_dofs: int
+    V_bi_sim: float
+    V_bi_theory: float
+    err_Vbi_rel: float
+    E_peak_sim: float
+    E_peak_theory: float
+    err_Epeak_rel: float
+    W_sim: float
+    W_theory: float
+    err_W_rel: float
+    newton_iters: int
+    solve_time_s: float
+
+
+def _load_base_cfg(cfg_path: str | Path | None) -> dict:
+    from semi import schema
+
+    path = Path(cfg_path) if cfg_path else DEFAULT_PN_1D_CFG
+    return schema.load(path)
+
+
+def _depletion_references(cfg: dict) -> dict:
+    """Compute V_bi, W, E_peak from the depletion approximation."""
+    from semi.constants import Q, cm3_to_m3, thermal_voltage
+    from semi.materials import get_material
+
+    prof = cfg["doping"][0]["profile"]
+    if prof["type"] != "step":
+        raise ValueError(
+            f"mesh_convergence expects a step doping profile, got {prof['type']!r}"
+        )
+    N_A = cm3_to_m3(prof["N_A_left"])
+    N_D = cm3_to_m3(prof["N_D_right"])
+
+    region_name = next(iter(cfg["regions"]))
+    mat = get_material(cfg["regions"][region_name]["material"])
+    T = float(cfg["physics"]["temperature"])
+    V_t = thermal_voltage(T)
+    n_i = mat.n_i
+    eps = mat.epsilon
+
+    V_bi = V_t * np.log(N_A * N_D / n_i**2)
+    W = np.sqrt(2.0 * eps * V_bi * (N_A + N_D) / (Q * N_A * N_D))
+    x_p = W * N_D / (N_A + N_D)
+    E_peak = Q * N_A * x_p / eps
+    return {
+        "V_bi": float(V_bi),
+        "W": float(W),
+        "E_peak": float(E_peak),
+        "N_A": float(N_A),
+        "N_D": float(N_D),
+        "n_i": float(n_i),
+        "eps": float(eps),
+    }
+
+
+def _extract_observables(result, refs: dict) -> tuple[float, float, float]:
+    """
+    Return (V_bi_sim, E_peak_sim, W_sim) from the solver output.
+
+    W_sim is extracted via charge-integration rather than threshold on |E|:
+    Q = 0.5 * integral |rho/q| dx over the whole mesh equals the total
+    depletion charge per unit area, and by charge neutrality across the
+    junction W = Q * (N_A + N_D) / (N_A * N_D). This definition is
+    threshold-free, matches the depletion approximation exactly on its
+    own model, and converges cleanly with mesh refinement because the
+    integrand is O(N_A) inside the depletion region and near-zero in
+    quasi-neutral bulk.
+    """
+    sc = result.scaling
+    x_raw = result.x_dof[:, 0]
+    order = np.argsort(x_raw)
+    x = x_raw[order]
+    psi = result.psi_phys[order]
+    n = result.n_phys[order]
+    p = result.p_phys[order]
+    N_net = result.N_hat.x.array[order] * sc.C0   # m^-3
+
+    V_bi_sim = float(psi[-1] - psi[0])
+
+    E = -np.gradient(psi, x)
+    abs_E = np.abs(E)
+    E_peak_sim = float(abs_E.max())
+
+    rho_over_q = p - n + N_net  # m^-3
+    Q_abs_total = float(np.trapezoid(np.abs(rho_over_q), x))
+    Q = 0.5 * Q_abs_total
+    N_A = refs["N_A"]
+    N_D = refs["N_D"]
+    if N_A > 0.0 and N_D > 0.0:
+        W_sim = Q * (N_A + N_D) / (N_A * N_D)
+    else:
+        W_sim = float("nan")
+
+    return V_bi_sim, E_peak_sim, W_sim
+
+
+def run_one_level(N: int, *, cfg_path: str | Path | None = None) -> MeshConvRow:
+    """
+    Run the pn_1d benchmark at resolution N and return one row of
+    convergence data. Reuses `semi.run.run_equilibrium` so the solver
+    path is the same as the production benchmark.
+    """
+    from semi.run import run_equilibrium
+
+    base_cfg = _load_base_cfg(cfg_path)
+    cfg = copy.deepcopy(base_cfg)
+    cfg["mesh"]["resolution"] = [int(N)]
+
+    refs = _depletion_references(cfg)
+
+    t0 = time.perf_counter()
+    result = run_equilibrium(cfg)
+    dt = time.perf_counter() - t0
+
+    info = result.solver_info or {}
+    if not info.get("converged", False):
+        raise RuntimeError(
+            f"pn_1d equilibrium did not converge at N={N}: "
+            f"reason={info.get('reason')}, iters={info.get('iterations')}"
+        )
+
+    V_bi_sim, E_peak_sim, W_sim = _extract_observables(result, refs)
+    extents = cfg["mesh"]["extents"][0]
+    L = float(extents[1] - extents[0])
+    h = L / float(N)
+    n_dofs = int(result.V.dofmap.index_map.size_global)
+
+    def _rel(sim: float, ref: float) -> float:
+        if not np.isfinite(sim) or ref == 0.0:
+            return float("nan")
+        return abs(sim - ref) / abs(ref)
+
+    return MeshConvRow(
+        N=int(N),
+        h=h,
+        n_dofs=n_dofs,
+        V_bi_sim=V_bi_sim,
+        V_bi_theory=refs["V_bi"],
+        err_Vbi_rel=_rel(V_bi_sim, refs["V_bi"]),
+        E_peak_sim=E_peak_sim,
+        E_peak_theory=refs["E_peak"],
+        err_Epeak_rel=_rel(E_peak_sim, refs["E_peak"]),
+        W_sim=W_sim,
+        W_theory=refs["W"],
+        err_W_rel=_rel(W_sim, refs["W"]),
+        newton_iters=int(info.get("iterations", -1)),
+        solve_time_s=float(dt),
+    )
+
+
+def run_convergence_study(
+    Ns: list[int],
+    *,
+    cfg_path: str | Path | None = None,
+) -> list[MeshConvRow]:
+    """Run the benchmark at each N in Ns (in input order)."""
+    return [run_one_level(N, cfg_path=cfg_path) for N in Ns]
+
+
+def _ratio(prev: float | None, cur: float) -> float:
+    if prev is None or not np.isfinite(cur) or cur <= 0.0 or not np.isfinite(prev):
+        return float("nan")
+    return prev / cur
+
+
+def cauchy_errors(
+    results: list[MeshConvRow],
+    *,
+    reference_index: int = -1,
+) -> list[dict[str, float]]:
+    """
+    Self-convergence errors vs the reference mesh (default: finest).
+
+    Cauchy errors remove the physics-model gap (depletion approx vs
+    true Poisson-Boltzmann) from the convergence metric. They are the
+    standard V&V choice for problems without an analytical solution
+    (Roache, Oberkampf-Roy). Error on the reference row itself is NaN
+    because it has no finer reference.
+    """
+    if not results:
+        return []
+    ref = results[reference_index]
+    out: list[dict[str, float]] = []
+    for i, r in enumerate(results):
+        if i == reference_index % len(results):
+            out.append({
+                "err_Epeak_cauchy": float("nan"),
+                "err_W_cauchy": float("nan"),
+            })
+            continue
+        dE = abs(r.E_peak_sim - ref.E_peak_sim)
+        dW = abs(r.W_sim - ref.W_sim) if np.isfinite(r.W_sim) and np.isfinite(ref.W_sim) else float("nan")
+        out.append({
+            "err_Epeak_cauchy": dE / abs(ref.E_peak_sim) if ref.E_peak_sim != 0.0 else float("nan"),
+            "err_W_cauchy": dW / abs(ref.W_sim) if ref.W_sim and np.isfinite(ref.W_sim) else float("nan"),
+        })
+    return out
+
+
+def to_table_rows(results: list[MeshConvRow]) -> list[dict]:
+    """
+    Convert dataclass rows to dicts with ratio-per-doubling columns and
+    Cauchy self-convergence columns against the finest mesh in the sweep.
+    """
+    rows: list[dict] = []
+    prev_Vbi: float | None = None
+    prev_E: float | None = None
+    prev_W: float | None = None
+    prev_E_cauchy: float | None = None
+    prev_W_cauchy: float | None = None
+    cauchy = cauchy_errors(results, reference_index=-1)
+    for r, c in zip(results, cauchy, strict=True):
+        rows.append({
+            "N": r.N,
+            "h": r.h,
+            "N_dofs": r.n_dofs,
+            "V_bi_sim": r.V_bi_sim,
+            "V_bi_theory": r.V_bi_theory,
+            "err_Vbi_rel": r.err_Vbi_rel,
+            "err_Vbi_ratio": _ratio(prev_Vbi, r.err_Vbi_rel),
+            "E_peak_sim": r.E_peak_sim,
+            "E_peak_theory": r.E_peak_theory,
+            "err_Epeak_rel": r.err_Epeak_rel,
+            "err_Epeak_ratio": _ratio(prev_E, r.err_Epeak_rel),
+            "err_Epeak_cauchy": c["err_Epeak_cauchy"],
+            "err_Epeak_cauchy_ratio": _ratio(prev_E_cauchy, c["err_Epeak_cauchy"]),
+            "W_sim": r.W_sim,
+            "W_theory": r.W_theory,
+            "err_W_rel": r.err_W_rel,
+            "err_W_ratio": _ratio(prev_W, r.err_W_rel),
+            "err_W_cauchy": c["err_W_cauchy"],
+            "err_W_cauchy_ratio": _ratio(prev_W_cauchy, c["err_W_cauchy"]),
+            "newton_iters": r.newton_iters,
+            "solve_time_s": r.solve_time_s,
+        })
+        if np.isfinite(r.err_Vbi_rel) and r.err_Vbi_rel > 0.0:
+            prev_Vbi = r.err_Vbi_rel
+        if np.isfinite(r.err_Epeak_rel) and r.err_Epeak_rel > 0.0:
+            prev_E = r.err_Epeak_rel
+        if np.isfinite(r.err_W_rel) and r.err_W_rel > 0.0:
+            prev_W = r.err_W_rel
+        if np.isfinite(c["err_Epeak_cauchy"]) and c["err_Epeak_cauchy"] > 0.0:
+            prev_E_cauchy = c["err_Epeak_cauchy"]
+        if np.isfinite(c["err_W_cauchy"]) and c["err_W_cauchy"] > 0.0:
+            prev_W_cauchy = c["err_W_cauchy"]
+    return rows
+
+
+CSV_COLUMNS = [
+    "N", "h", "N_dofs",
+    "V_bi_sim", "V_bi_theory", "err_Vbi_rel", "err_Vbi_ratio",
+    "E_peak_sim", "E_peak_theory",
+    "err_Epeak_rel", "err_Epeak_ratio",
+    "err_Epeak_cauchy", "err_Epeak_cauchy_ratio",
+    "W_sim", "W_theory",
+    "err_W_rel", "err_W_ratio",
+    "err_W_cauchy", "err_W_cauchy_ratio",
+    "newton_iters", "solve_time_s",
+]
+
+
+def write_artifacts(
+    rows: list[dict],
+    out_dir: Path,
+    *,
+    csv_name: str = "pn_1d.csv",
+    plot_name: str = "convergence.png",
+    title: str = "pn_1d mesh convergence vs depletion approximation",
+) -> None:
+    """Write the mesh-convergence CSV and log-log convergence plot."""
+    from ._convergence import write_convergence_csv, write_loglog_plot
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_convergence_csv(out_dir / csv_name, rows, CSV_COLUMNS)
+
+    hs = [r["h"] for r in rows]
+    series = {
+        "E_peak rel err (vs depletion approx)": [r["err_Epeak_rel"] for r in rows],
+        "W rel err (vs depletion approx)": [r["err_W_rel"] for r in rows],
+        "E_peak Cauchy err (vs finest FEM)": [r["err_Epeak_cauchy"] for r in rows],
+        "W Cauchy err (vs finest FEM)": [r["err_W_cauchy"] for r in rows],
+    }
+    write_loglog_plot(
+        out_dir / plot_name, hs, series,
+        title=title,
+        theoretical_rates={"E_peak Cauchy err (vs finest FEM)": 2.0},
+    )
+
+
+def report_table(rows: list[dict], header: str = "") -> str:
+    """Stdout-friendly table (subset of columns for readability)."""
+    from ._convergence import format_table
+
+    cols = [
+        "N", "h",
+        "err_Epeak_rel", "err_Epeak_ratio",
+        "err_Epeak_cauchy", "err_Epeak_cauchy_ratio",
+        "err_W_rel", "err_W_ratio",
+        "err_W_cauchy", "err_W_cauchy_ratio",
+        "newton_iters", "solve_time_s",
+    ]
+    return format_table(rows, cols, header=header)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point used by scripts/run_verification.py
+# ---------------------------------------------------------------------------
+CLI_NS = [50, 100, 200, 400, 800, 1600]
+
+
+def run_cli_study(out_dir: Path) -> list[dict]:
+    """Run the full mesh sweep and write CSV + PNG to `out_dir`."""
+    out_dir = Path(out_dir)
+    results = run_convergence_study(CLI_NS)
+    rows = to_table_rows(results)
+    write_artifacts(rows, out_dir)
+    return rows

--- a/semi/verification/mms_dd.py
+++ b/semi/verification/mms_dd.py
@@ -1,0 +1,626 @@
+"""
+Method of Manufactured Solutions (MMS) for the coupled drift-diffusion
+block residual.
+
+The production residual (`semi/physics/drift_diffusion.py`) assembles
+three coupled blocks in Slotboom form:
+
+    Poisson:   -div( L_D^2 eps_r grad psi_hat )            - (p_hat - n_hat + N_hat) = 0
+    Electron:  -div( L_0^2 mu_n_hat n_hat grad phi_n_hat ) - R_hat                   = 0
+    Hole:      -div( L_0^2 mu_p_hat p_hat grad phi_p_hat ) + R_hat                   = 0
+
+with Slotboom `n_hat = ni_hat exp(psi - phi_n)`, `p_hat = ni_hat exp(phi_p - psi)`
+and SRH `R_hat`. For MMS we set `N_hat = 0` and subtract a weak-form
+manufactured source from each block so that a chosen smooth exact triple
+`(psi_e, phi_n_e, phi_p_e)` is the solution of the modified coupled
+system. Each block's discretization error then decays at the FE rate.
+
+Three variants exercise progressively more of the residual:
+
+    A  `phi_n_e = phi_p_e = 0`, `tau_hat = infinity`:   Poisson block only
+    B  full triple, `tau_hat = infinity`:               full coupling, R ~ 0
+    C  full triple, Si lifetimes:                       full coupling with SRH
+
+See `docs/mms_dd_derivation.md` for the approved derivation; every weak
+source below tracks the sections of that document.
+"""
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .mms_poisson import (
+    C_0_REF,
+    EPS_R_DEFAULT,
+    L_0_REF,
+    T_REF,
+    _all_boundary_facets,
+    _build_mesh,
+    build_mms_scaling,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level constants. See derivation Section 2.
+# ---------------------------------------------------------------------------
+VARIANTS: tuple[str, ...] = ("A", "B", "C")
+
+#: Default amplitude triple `(A_psi, A_n, A_p)` used by the pytest gate.
+#: `A_p = -A_n` ensures Variant C's SRH numerator
+#: `ni_hat^2 * (exp(phi_p - phi_n) - 1)` is pointwise nonzero (derivation 1).
+DEFAULT_AMPS: tuple[float, float, float] = (0.5, 0.3, -0.3)
+
+#: Larger-amplitude triple reserved for the CLI sweep. Keeps |exp(...)|
+#: bounded by exp(1.5) ~ 4.48, comfortably inside PETSc double precision.
+NONLINEAR_AMPS: tuple[float, float, float] = (1.0, 0.5, -0.5)
+
+#: Variant C SRH lifetime (Si mid-gap default, seconds).
+TAU_SI_S: float = 1.0e-7
+
+#: Variant A/B "off" lifetime in scaled units. Keeps the SRH code path
+#: live but drives `R_e` below machine precision.
+TAU_OFF_HAT: float = 1.0e+20
+
+#: Mobility ratios pinned across the mesh sweep so convergence measures
+#: discretization error only. `mu_n_over_mu0 = 1.0` because mu_0 is the
+#: electron mobility itself; `mu_p / mu_n = 0.45 / 1.4` from Si defaults
+#: in `semi/materials.py`.
+MU_N_OVER_MU0: float = 1.0
+MU_P_OVER_MU0: float = 0.45 / 1.4
+
+
+@dataclass(frozen=True)
+class MMSDDCase:
+    """Specification for one mesh-level MMS-DD run."""
+
+    dim: int                                 # 1 or 2
+    N: int                                   # cells per side
+    variant: str                             # "A", "B", or "C"
+    L: float = L_0_REF                       # device length, m
+    A_psi: float = DEFAULT_AMPS[0]
+    A_n: float = DEFAULT_AMPS[1]
+    A_p: float = DEFAULT_AMPS[2]
+    eps_r: float = EPS_R_DEFAULT
+    cell_kind: str = "triangle"              # 2D only
+
+
+@dataclass(frozen=True)
+class MMSDDResult:
+    """Per-level numerical result with per-block error norms."""
+
+    dim: int
+    N: int
+    variant: str
+    h: float
+    n_dofs: int                              # identical across the three blocks
+    e_L2_psi: float
+    e_H1_psi: float
+    e_L2_phi_n: float
+    e_H1_phi_n: float
+    e_L2_phi_p: float
+    e_H1_phi_p: float
+    snes_iters: int
+    solve_time_s: float
+    cell_kind: str = "triangle"
+    A_psi: float = DEFAULT_AMPS[0]
+    A_n: float = DEFAULT_AMPS[1]
+    A_p: float = DEFAULT_AMPS[2]
+
+
+# ---------------------------------------------------------------------------
+# Exact triple and manufactured weak sources (derivation Sections 1, 3)
+# ---------------------------------------------------------------------------
+
+
+def _exact_triple_ufl(mesh, dim: int, L: float,
+                      A_psi: float, A_n: float, A_p: float,
+                      variant: str):
+    """
+    Return `(psi_e, phi_n_e, phi_p_e)` as UFL expressions.
+
+    For Variants B and C we use the full sin-product triple; for Variant
+    A the Fermi levels are identically zero. This choice matters for the
+    weak-source construction in `_build_weak_sources`: Variant A only
+    produces `f_psi_weak` (the other two manufactured sources are zero
+    and are not subtracted from the production forms, which avoids
+    compiling zero integrands).
+    """
+    import ufl
+
+    x = ufl.SpatialCoordinate(mesh)
+    if dim == 1:
+        psi_e = A_psi * ufl.sin(2.0 * ufl.pi * x[0] / L)
+        if variant == "A":
+            phi_n_e = None
+            phi_p_e = None
+        else:
+            phi_n_e = A_n * ufl.sin(ufl.pi * x[0] / L)
+            phi_p_e = A_p * ufl.sin(ufl.pi * x[0] / L)
+    elif dim == 2:
+        psi_e = (
+            A_psi
+            * ufl.sin(2.0 * ufl.pi * x[0] / L)
+            * ufl.sin(3.0 * ufl.pi * x[1] / L)
+        )
+        if variant == "A":
+            phi_n_e = None
+            phi_p_e = None
+        else:
+            phi_n_e = (
+                A_n
+                * ufl.sin(ufl.pi * x[0] / L)
+                * ufl.sin(ufl.pi * x[1] / L)
+            )
+            phi_p_e = (
+                A_p
+                * ufl.sin(ufl.pi * x[0] / L)
+                * ufl.sin(ufl.pi * x[1] / L)
+            )
+    else:
+        raise ValueError(f"Unsupported dim {dim}")
+    return psi_e, phi_n_e, phi_p_e
+
+
+def _build_weak_sources(
+    mesh,
+    spaces,
+    sc,
+    *,
+    variant: str,
+    eps_r_value: float,
+    mu_n_over_mu0: float,
+    mu_p_over_mu0: float,
+    tau_n_hat: float,
+    tau_p_hat: float,
+    psi_e,
+    phi_n_e,
+    phi_p_e,
+):
+    """
+    Build the three weak-form manufactured sources.
+
+    For Variants B and C this returns `(f_psi_weak, f_n_weak, f_p_weak)`.
+    For Variant A only `f_psi_weak` is built and the continuity-block
+    entries are `None` -- the caller must leave the production continuity
+    forms unmodified (they are already satisfied by `(psi_e, 0, 0)` because
+    `grad(phi_n_e) = 0` and `R_e = 0` there).
+
+    The weak-form construction follows Section 3 of
+    `docs/mms_dd_derivation.md`. We never form `ufl.div(ufl.grad(...))`
+    directly; integrating by parts against the test function uses the
+    same gradient discretization as the production residual, so MMS
+    verifies the exact discretization in use (compare
+    `mms_poisson.manufactured_source_weak`).
+    """
+    import ufl
+    from dolfinx import fem
+    from petsc4py import PETSc
+
+    from semi.physics.slotboom import n_from_slotboom, p_from_slotboom
+
+    v_psi = ufl.TestFunction(spaces.V_psi)
+    v_n = ufl.TestFunction(spaces.V_phi_n)
+    v_p = ufl.TestFunction(spaces.V_phi_p)
+
+    L_D2 = fem.Constant(mesh, PETSc.ScalarType(sc.lambda2 * sc.L0 ** 2))
+    L0_sq = fem.Constant(mesh, PETSc.ScalarType(sc.L0 ** 2))
+    eps_r = fem.Constant(mesh, PETSc.ScalarType(eps_r_value))
+    ni_hat = fem.Constant(mesh, PETSc.ScalarType(sc.n_i / sc.C0))
+    mu_n = fem.Constant(mesh, PETSc.ScalarType(mu_n_over_mu0))
+    mu_p = fem.Constant(mesh, PETSc.ScalarType(mu_p_over_mu0))
+    tau_n = fem.Constant(mesh, PETSc.ScalarType(tau_n_hat))
+    tau_p = fem.Constant(mesh, PETSc.ScalarType(tau_p_hat))
+
+    if variant == "A":
+        # Variant A: phi_n_e = phi_p_e = 0, so n_e * p_e = ni_hat^2 exactly
+        # and R_e vanishes pointwise. Slotboom densities reduce to
+        # ni_hat * exp(+/- psi_e), matching the Poisson MMS carrier term.
+        n_e = ni_hat * ufl.exp(psi_e)
+        p_e = ni_hat * ufl.exp(-psi_e)
+        f_psi_weak = (
+            L_D2 * eps_r * ufl.inner(ufl.grad(psi_e), ufl.grad(v_psi))
+            - (p_e - n_e) * v_psi
+        ) * ufl.dx
+        return f_psi_weak, None, None
+
+    # Variants B and C: full triple.
+    n_e = n_from_slotboom(psi_e, phi_n_e, ni_hat)
+    p_e = p_from_slotboom(psi_e, phi_p_e, ni_hat)
+
+    # SRH rate, inlined to share the same ni_hat Constant with the Poisson
+    # block (matches production code in `build_dd_block_residual`). E_t = 0
+    # is enforced module-wide, so n1 = p1 = ni_hat.
+    n1 = ni_hat * math.exp(0.0)
+    p1 = ni_hat * math.exp(-0.0)
+    R_e = (n_e * p_e - ni_hat * ni_hat) / (
+        tau_p * (n_e + n1) + tau_n * (p_e + p1)
+    )
+
+    f_psi_weak = (
+        L_D2 * eps_r * ufl.inner(ufl.grad(psi_e), ufl.grad(v_psi))
+        - (p_e - n_e) * v_psi
+    ) * ufl.dx
+    f_n_weak = (
+        L0_sq * mu_n * n_e * ufl.inner(ufl.grad(phi_n_e), ufl.grad(v_n))
+        - R_e * v_n
+    ) * ufl.dx
+    f_p_weak = (
+        L0_sq * mu_p * p_e * ufl.inner(ufl.grad(phi_p_e), ufl.grad(v_p))
+        + R_e * v_p
+    ) * ufl.dx
+    return f_psi_weak, f_n_weak, f_p_weak
+
+
+# ---------------------------------------------------------------------------
+# Per-level solve (derivation Sections 4, 5)
+# ---------------------------------------------------------------------------
+
+
+def run_one_level(case: MMSDDCase, *, sc=None) -> MMSDDResult:
+    """
+    Solve the MMS-DD problem on a single mesh level and return per-block
+    L^2 and H^1 seminorm errors together with SNES diagnostics.
+
+    Reuses `build_dd_block_residual` so future edits to the production
+    residual are automatically exercised. BCs are homogeneous Dirichlet
+    on all three fields (exact, not interpolated, because every exact
+    factor is `sin(k*pi*x/L)` with `k` a positive integer and so vanishes
+    on the boundary; see derivation Section 4).
+    """
+    import ufl
+    from dolfinx import fem
+    from petsc4py import PETSc
+
+    from semi.physics.drift_diffusion import (
+        build_dd_block_residual,
+        make_dd_block_spaces,
+    )
+    from semi.solver import solve_nonlinear_block
+
+    from ._norms import h1_seminorm_error_squared, l2_error_squared
+
+    if case.variant not in VARIANTS:
+        raise ValueError(f"variant {case.variant!r} not in {VARIANTS}")
+    if sc is None:
+        sc = build_mms_scaling(L=case.L)
+
+    mesh = _build_mesh(case.dim, case.N, case.L, case.cell_kind)
+    spaces = make_dd_block_spaces(mesh)
+
+    # N_hat = 0 for MMS; see derivation preamble.
+    N_hat_fn = fem.Function(spaces.V_psi, name="N_hat_zero")
+    N_hat_fn.x.array[:] = 0.0
+
+    # Initial guess: zero everywhere. Trivially satisfies the
+    # homogeneous Dirichlet BC and the charge-neutrality identity
+    # (n_init = p_init = ni_hat, rho_init = 0 since N_hat = 0).
+    for fn in (spaces.psi, spaces.phi_n, spaces.phi_p):
+        fn.x.array[:] = 0.0
+        fn.x.scatter_forward()
+
+    # Per-variant lifetime choice (derivation Section 2, SRH row).
+    if case.variant == "C":
+        tau_n_hat = tau_p_hat = TAU_SI_S / sc.t0
+    else:
+        tau_n_hat = tau_p_hat = TAU_OFF_HAT
+
+    # Production residual, per-block.
+    F_prod = build_dd_block_residual(
+        spaces, N_hat_fn, sc,
+        case.eps_r, MU_N_OVER_MU0, MU_P_OVER_MU0,
+        tau_n_hat, tau_p_hat, 0.0,   # E_t / V_t = 0 (mid-gap traps)
+    )
+
+    # Manufactured weak sources.
+    psi_e, phi_n_e, phi_p_e = _exact_triple_ufl(
+        mesh, case.dim, case.L,
+        case.A_psi, case.A_n, case.A_p, case.variant,
+    )
+    f_psi_weak, f_n_weak, f_p_weak = _build_weak_sources(
+        mesh, spaces, sc,
+        variant=case.variant,
+        eps_r_value=case.eps_r,
+        mu_n_over_mu0=MU_N_OVER_MU0,
+        mu_p_over_mu0=MU_P_OVER_MU0,
+        tau_n_hat=tau_n_hat,
+        tau_p_hat=tau_p_hat,
+        psi_e=psi_e,
+        phi_n_e=phi_n_e,
+        phi_p_e=phi_p_e,
+    )
+    F_psi = F_prod[0] - f_psi_weak
+    if case.variant == "A":
+        # f_n_weak = f_p_weak = 0. Leave continuity forms unmodified; they
+        # are already satisfied by (psi_e, 0, 0) (derivation Section 3.4).
+        F_phi_n = F_prod[1]
+        F_phi_p = F_prod[2]
+    else:
+        F_phi_n = F_prod[1] - f_n_weak
+        F_phi_p = F_prod[2] - f_p_weak
+
+    # Homogeneous Dirichlet BCs on all three fields, exact.
+    fdim = mesh.topology.dim - 1
+    mesh.topology.create_connectivity(fdim, mesh.topology.dim)
+    boundary_facets = _all_boundary_facets(mesh, fdim)
+    zero = fem.Constant(mesh, PETSc.ScalarType(0.0))
+    bdofs_psi = fem.locate_dofs_topological(spaces.V_psi, fdim, boundary_facets)
+    bdofs_phi_n = fem.locate_dofs_topological(spaces.V_phi_n, fdim, boundary_facets)
+    bdofs_phi_p = fem.locate_dofs_topological(spaces.V_phi_p, fdim, boundary_facets)
+    bcs = [
+        fem.dirichletbc(zero, bdofs_psi, spaces.V_psi),
+        fem.dirichletbc(zero, bdofs_phi_n, spaces.V_phi_n),
+        fem.dirichletbc(zero, bdofs_phi_p, spaces.V_phi_p),
+    ]
+
+    # SNES tolerances: rtol and max_it match the derivation (Section 5),
+    # but atol is driven below the continuity-block initial residual
+    # scale. Section 7.3 identifies the block-residual scale disparity
+    # (L_D^2 * ...  vs  L_0^2 * n_i_hat * ...) as the reason atol must
+    # reach below every block's native floor; the derivation's nominal
+    # 1e-16 is tuned to the psi block alone and prematurely terminates
+    # SNES on the continuity blocks in 2D (where the integration-area
+    # L^2 ~ 4e-12 shrinks the phi_n / phi_p residuals to ~1e-18 at
+    # initial). Driving atol to ~0 with stol controlling termination
+    # lets Newton iterate until every block has actually been solved.
+    petsc_options = {
+        "snes_rtol": 1.0e-14,
+        "snes_atol": 0.0,
+        "snes_stol": 1.0e-12,
+        "snes_max_it": 80,
+    }
+    prefix = (
+        f"mms_dd_dim{case.dim}_N{case.N}_var{case.variant}"
+        f"_amp{case.A_psi:g}_"
+    )
+    t0 = time.perf_counter()
+    info = solve_nonlinear_block(
+        [F_psi, F_phi_n, F_phi_p],
+        [spaces.psi, spaces.phi_n, spaces.phi_p],
+        bcs, prefix=prefix, petsc_options=petsc_options,
+    )
+    dt = time.perf_counter() - t0
+    if not info.get("converged", False):
+        raise RuntimeError(
+            f"MMS-DD did not converge at dim={case.dim}, N={case.N}, "
+            f"variant={case.variant}: reason={info.get('reason')}, "
+            f"iters={info.get('iterations')}"
+        )
+
+    # Per-block error norms. For Variant A the exact Fermi fields are 0,
+    # so `phi_n_e_err` below is a UFL Zero and the error reduces to the
+    # discrete function's own L^2 and H^1 seminorm.
+    psi_e_err = psi_e
+    phi_n_e_err = phi_n_e if phi_n_e is not None else 0.0
+    phi_p_e_err = phi_p_e if phi_p_e is not None else 0.0
+
+    e_L2_psi = float(np.sqrt(max(l2_error_squared(spaces.psi, psi_e_err), 0.0)))
+    e_H1_psi = float(np.sqrt(max(h1_seminorm_error_squared(spaces.psi, psi_e_err), 0.0)))
+    e_L2_phi_n = float(np.sqrt(max(l2_error_squared(spaces.phi_n, phi_n_e_err), 0.0)))
+    e_H1_phi_n = float(np.sqrt(max(h1_seminorm_error_squared(spaces.phi_n, phi_n_e_err), 0.0)))
+    e_L2_phi_p = float(np.sqrt(max(l2_error_squared(spaces.phi_p, phi_p_e_err), 0.0)))
+    e_H1_phi_p = float(np.sqrt(max(h1_seminorm_error_squared(spaces.phi_p, phi_p_e_err), 0.0)))
+
+    n_dofs = int(spaces.V_psi.dofmap.index_map.size_global)
+    return MMSDDResult(
+        dim=case.dim,
+        N=case.N,
+        variant=case.variant,
+        h=case.L / case.N,
+        n_dofs=n_dofs,
+        e_L2_psi=e_L2_psi, e_H1_psi=e_H1_psi,
+        e_L2_phi_n=e_L2_phi_n, e_H1_phi_n=e_H1_phi_n,
+        e_L2_phi_p=e_L2_phi_p, e_H1_phi_p=e_H1_phi_p,
+        snes_iters=int(info.get("iterations", -1)),
+        solve_time_s=dt,
+        cell_kind=case.cell_kind,
+        A_psi=case.A_psi, A_n=case.A_n, A_p=case.A_p,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convergence sweeps (derivation Section 6)
+# ---------------------------------------------------------------------------
+
+
+def run_convergence_study(
+    *,
+    dim: int,
+    variant: str,
+    Ns: list[int],
+    L: float = L_0_REF,
+    A_psi: float = DEFAULT_AMPS[0],
+    A_n: float = DEFAULT_AMPS[1],
+    A_p: float = DEFAULT_AMPS[2],
+    eps_r: float = EPS_R_DEFAULT,
+    cell_kind: str = "triangle",
+    sc=None,
+) -> list[MMSDDResult]:
+    """Run MMS-DD on a sequence of refinements. Returns one result per N."""
+    if sc is None:
+        sc = build_mms_scaling(L=L)
+    results: list[MMSDDResult] = []
+    for N in Ns:
+        case = MMSDDCase(
+            dim=dim, N=N, variant=variant, L=L,
+            A_psi=A_psi, A_n=A_n, A_p=A_p,
+            eps_r=eps_r, cell_kind=cell_kind,
+        )
+        results.append(run_one_level(case, sc=sc))
+    return results
+
+
+# Column order used by the tables / CSVs.
+_BLOCKS: tuple[str, ...] = ("psi", "phi_n", "phi_p")
+_ROW_COLUMNS: tuple[str, ...] = (
+    "N", "h", "N_dofs",
+    "e_L2_psi", "rate_L2_psi", "e_H1_psi", "rate_H1_psi",
+    "e_L2_phi_n", "rate_L2_phi_n", "e_H1_phi_n", "rate_H1_phi_n",
+    "e_L2_phi_p", "rate_L2_phi_p", "e_H1_phi_p", "rate_H1_phi_p",
+    "snes_iters", "solve_time_s",
+)
+
+
+def to_table_rows(results: list[MMSDDResult]) -> list[dict]:
+    """Build per-level rows with observed L^2/H^1 rates for every block."""
+    from ._convergence import observed_rates
+
+    hs = [r.h for r in results]
+    rates: dict[str, list[float]] = {}
+    for b in _BLOCKS:
+        rates[f"L2_{b}"] = observed_rates(hs, [getattr(r, f"e_L2_{b}") for r in results])
+        rates[f"H1_{b}"] = observed_rates(hs, [getattr(r, f"e_H1_{b}") for r in results])
+    rows: list[dict] = []
+    for i, r in enumerate(results):
+        row = {
+            "N": r.N,
+            "h": r.h,
+            "N_dofs": r.n_dofs,
+            "e_L2_psi": r.e_L2_psi,
+            "rate_L2_psi": rates["L2_psi"][i],
+            "e_H1_psi": r.e_H1_psi,
+            "rate_H1_psi": rates["H1_psi"][i],
+            "e_L2_phi_n": r.e_L2_phi_n,
+            "rate_L2_phi_n": rates["L2_phi_n"][i],
+            "e_H1_phi_n": r.e_H1_phi_n,
+            "rate_H1_phi_n": rates["H1_phi_n"][i],
+            "e_L2_phi_p": r.e_L2_phi_p,
+            "rate_L2_phi_p": rates["L2_phi_p"][i],
+            "e_H1_phi_p": r.e_H1_phi_p,
+            "rate_H1_phi_p": rates["H1_phi_p"][i],
+            "snes_iters": r.snes_iters,
+            "solve_time_s": r.solve_time_s,
+        }
+        rows.append(row)
+    return rows
+
+
+def report_table(rows: list[dict], header: str = "") -> str:
+    """Pretty multi-line stdout table showing psi L^2 + rate for each block."""
+    from ._convergence import format_table
+
+    cols = [
+        "N", "h", "N_dofs",
+        "e_L2_psi", "rate_L2_psi",
+        "e_L2_phi_n", "rate_L2_phi_n",
+        "e_L2_phi_p", "rate_L2_phi_p",
+    ]
+    return format_table(rows, cols, header=header)
+
+
+def write_artifacts(
+    rows: list[dict],
+    out_dir: Path,
+    *,
+    title: str,
+    csv_name: str = "convergence.csv",
+    plot_name: str = "convergence.png",
+) -> None:
+    """Write `convergence.csv` and `convergence.png` to `out_dir`."""
+    from ._convergence import write_convergence_csv, write_loglog_plot
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    write_convergence_csv(out_dir / csv_name, rows, list(_ROW_COLUMNS))
+    hs = [r["h"] for r in rows]
+    series = {
+        "L2 psi":    [r["e_L2_psi"] for r in rows],
+        "L2 phi_n":  [r["e_L2_phi_n"] for r in rows],
+        "L2 phi_p":  [r["e_L2_phi_p"] for r in rows],
+    }
+    write_loglog_plot(
+        out_dir / plot_name, hs, series,
+        title=title,
+        theoretical_rates={
+            "L2 psi": 2.0,
+            "L2 phi_n": 2.0,
+            "L2 phi_p": 2.0,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default mesh sequences
+# ---------------------------------------------------------------------------
+PYTEST_NS_1D: list[int] = [40, 80, 160]
+PYTEST_NS_2D: list[int] = [16, 32, 64]
+CLI_NS_1D: list[int] = [40, 80, 160, 320]
+CLI_NS_2D: list[int] = [16, 32, 64]
+
+
+def run_cli_study(out_dir: Path) -> dict[str, list[dict]]:
+    """
+    Artifact-production sweep used by `scripts/run_verification.py`.
+
+    Runs nine studies in total:
+      - `1d_<variant>_linear`     for variant in A,B,C (default amps, Ns=CLI_NS_1D)
+      - `1d_<variant>_nonlinear`  for variant in A,B,C (NONLINEAR_AMPS, Ns=CLI_NS_1D)
+      - `2d_<variant>`            for variant in A,B,C (default amps, Ns=CLI_NS_2D)
+
+    Each study writes `convergence.csv` and `convergence.png` into
+    `out_dir/<label>/`, mirroring the Poisson MMS artifact layout.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    sc = build_mms_scaling()
+
+    studies: dict[str, list[dict]] = {}
+
+    for variant in VARIANTS:
+        # 1D default amplitudes
+        res = run_convergence_study(
+            dim=1, variant=variant, Ns=CLI_NS_1D,
+            A_psi=DEFAULT_AMPS[0], A_n=DEFAULT_AMPS[1], A_p=DEFAULT_AMPS[2],
+            sc=sc,
+        )
+        rows = to_table_rows(res)
+        label = f"1d_{variant}_linear"
+        write_artifacts(
+            rows, out_dir / label,
+            title=(
+                f"MMS-DD 1D variant {variant} (linear, "
+                f"A_psi={DEFAULT_AMPS[0]}, A_n={DEFAULT_AMPS[1]}, "
+                f"A_p={DEFAULT_AMPS[2]})"
+            ),
+        )
+        studies[label] = rows
+
+        # 1D nonlinear amplitudes
+        res = run_convergence_study(
+            dim=1, variant=variant, Ns=CLI_NS_1D,
+            A_psi=NONLINEAR_AMPS[0], A_n=NONLINEAR_AMPS[1], A_p=NONLINEAR_AMPS[2],
+            sc=sc,
+        )
+        rows = to_table_rows(res)
+        label = f"1d_{variant}_nonlinear"
+        write_artifacts(
+            rows, out_dir / label,
+            title=(
+                f"MMS-DD 1D variant {variant} (nonlinear, "
+                f"A_psi={NONLINEAR_AMPS[0]}, A_n={NONLINEAR_AMPS[1]}, "
+                f"A_p={NONLINEAR_AMPS[2]})"
+            ),
+        )
+        studies[label] = rows
+
+        # 2D default amplitudes, triangles
+        res = run_convergence_study(
+            dim=2, variant=variant, Ns=CLI_NS_2D,
+            A_psi=DEFAULT_AMPS[0], A_n=DEFAULT_AMPS[1], A_p=DEFAULT_AMPS[2],
+            cell_kind="triangle", sc=sc,
+        )
+        rows = to_table_rows(res)
+        label = f"2d_{variant}"
+        write_artifacts(
+            rows, out_dir / label,
+            title=(
+                f"MMS-DD 2D variant {variant} (right-diagonal triangles, "
+                f"A_psi={DEFAULT_AMPS[0]}, A_n={DEFAULT_AMPS[1]}, "
+                f"A_p={DEFAULT_AMPS[2]})"
+            ),
+        )
+        studies[label] = rows
+
+    return studies

--- a/semi/verification/mms_dd.py
+++ b/semi/verification/mms_dd.py
@@ -34,10 +34,8 @@ from pathlib import Path
 import numpy as np
 
 from .mms_poisson import (
-    C_0_REF,
     EPS_R_DEFAULT,
     L_0_REF,
-    T_REF,
     _all_boundary_facets,
     _build_mesh,
     build_mms_scaling,
@@ -270,7 +268,6 @@ def run_one_level(case: MMSDDCase, *, sc=None) -> MMSDDResult:
     factor is `sin(k*pi*x/L)` with `k` a positive integer and so vanishes
     on the boundary; see derivation Section 4).
     """
-    import ufl
     from dolfinx import fem
     from petsc4py import PETSc
 

--- a/semi/verification/mms_poisson.py
+++ b/semi/verification/mms_poisson.py
@@ -1,0 +1,487 @@
+"""
+Method of Manufactured Solutions (MMS) for the scaled equilibrium
+Poisson equation.
+
+The production residual (semi/physics/poisson.py) has the shape
+
+    -div( L_D^2 eps_r grad psi_hat ) - rho_hat = 0
+    rho_hat = ni_hat * (exp(-psi_hat) - exp(psi_hat)) + N_hat
+
+For MMS we choose a smooth analytical exact solution psi_exact(x), set
+N_hat = 0 (no doping interference), and add a manufactured source f_hat
+constructed in UFL so that the modified residual
+
+    F_mms = F_production(psi)  -  f_hat * v * dx
+    f_hat = -div( L_D^2 eps_r grad psi_exact )
+            - ni_hat * (exp(-psi_exact) - exp(psi_exact))
+
+drives Newton to psi_h -> psi_exact. We then measure
+
+    e_L2 = || psi_h - psi_exact ||_{L^2}
+    e_H1 = || grad(psi_h - psi_exact) ||_{L^2}
+
+over a sequence of mesh refinements and report observed convergence
+rates p = log(e_prev / e_cur) / log(h_prev / h_cur). For P1 Lagrange on
+a smooth problem the theoretical rates are 2 in L^2 and 1 in H^1; the
+test gates assert finest-pair p within 0.15 of theoretical.
+
+Boundary conditions are homogeneous Dirichlet enforced via
+`dolfinx.fem.dirichletbc(zero_constant, ...)`. Both the 1D and 2D
+manufactured solutions vanish identically on the boundary, so this is
+the exact-BC choice and avoids polluting the MMS error with boundary
+interpolation noise.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Module-level reference scales for the MMS Scaling.
+#
+# These are deliberately hard-coded so the MMS test is self-contained and
+# does not drift with benchmark JSON edits. They are picked so:
+#   - V_T_REF = thermal voltage at 300 K (standard);
+#   - L_0_REF = 2 um device length matches the pn_1d benchmark length scale;
+#   - C_0_REF = 1e16 cm^-3 is the typical reference doping for that benchmark.
+#
+# The combination yields lambda2 ~ 1.6e-3 << 1, so the dimensionless Debye
+# length is much shorter than L_0 and the exp(+/- psi_hat) carrier term is
+# the dominant nonlinear contribution to the residual: exactly the regime we
+# want MMS to exercise. A sanity assertion below enforces lambda2 < 1 so
+# this property is self-checking against future scale changes.
+# ---------------------------------------------------------------------------
+T_REF: float = 300.0                      # K
+L_0_REF: float = 2.0e-6                    # m, matches pn_1d benchmark
+C_0_REF: float = 1.0e22                    # m^-3 = 1e16 cm^-3, typical doping
+EPS_R_DEFAULT: float = 11.7                # Si
+
+
+@dataclass(frozen=True)
+class MMSPoissonCase:
+    """Specification for one mesh-level MMS Poisson run."""
+
+    dim: int                                # 1 or 2
+    N: int                                  # cells per side
+    L: float = L_0_REF                      # device length, m
+    amplitude: float = 0.5                  # psi_exact amplitude, scaled units
+    eps_r: float = EPS_R_DEFAULT
+    cell_kind: str = "triangle"             # "triangle" or "quadrilateral" (2D only)
+
+
+@dataclass(frozen=True)
+class MMSPoissonResult:
+    """Per-level numerical result."""
+
+    dim: int
+    N: int
+    h: float
+    n_dofs: int
+    e_L2: float
+    e_H1: float
+    snes_iters: int
+    solve_time_s: float
+    cell_kind: str = "triangle"
+    amplitude: float = 0.5
+
+
+def build_mms_scaling(L: float = L_0_REF, C0: float = C_0_REF, T: float = T_REF):
+    """
+    Construct a minimal `Scaling` for MMS independent of any JSON config.
+
+    Uses Si reference parameters (mu_n, n_i) so the resulting `lambda2`
+    and `n_i / C0` are physically representative. Asserts `lambda2 < 1`
+    so the carrier nonlinearity remains non-trivial; an MMS where the
+    nonlinear term is negligible would only verify the Laplacian, not
+    the full residual.
+    """
+    from semi.materials import get_material
+    from semi.scaling import Scaling
+
+    mat = get_material("Si")
+    sc = Scaling(L0=L, C0=C0, T=T, mu0=mat.mu_n, n_i=mat.n_i)
+    if sc.lambda2 >= 1.0:
+        raise ValueError(
+            f"MMS scaling has lambda2={sc.lambda2:.3e} >= 1; the carrier "
+            "nonlinearity becomes negligible and MMS would not exercise the "
+            "exp(+/- psi) terms. Pick smaller L or larger C0."
+        )
+    return sc
+
+
+def _build_mesh(dim: int, N: int, L: float, cell_kind: str = "triangle"):
+    """Build a unit-cell-uniform mesh on [0, L]^dim."""
+    import numpy as np
+    from dolfinx import mesh as dmesh
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+    if dim == 1:
+        return dmesh.create_interval(comm, N, [0.0, L])
+    if dim == 2:
+        if cell_kind == "triangle":
+            ctype = dmesh.CellType.triangle
+        elif cell_kind == "quadrilateral":
+            ctype = dmesh.CellType.quadrilateral
+        else:
+            raise ValueError(f"Unknown cell_kind {cell_kind!r}")
+        # dolfinx 0.10 requires a DiagonalType keyword even for quads (it is
+        # ignored by the quad code path but the binding does not allow None).
+        return dmesh.create_rectangle(
+            comm,
+            [np.array([0.0, 0.0]), np.array([L, L])],
+            [N, N],
+            cell_type=ctype,
+            diagonal=dmesh.DiagonalType.right,
+        )
+    raise ValueError(f"Unsupported dim {dim}")
+
+
+def psi_exact_ufl(mesh, dim: int, L: float, amplitude: float):
+    """
+    Smooth manufactured exact solution that vanishes on the entire boundary.
+
+    1D:  amplitude * sin(2*pi*x/L)         zeros at x=0, L
+    2D:  amplitude * sin(2*pi*x/L) * sin(3*pi*y/L)   zeros on all 4 edges
+
+    The all-sin 2D form is required: sin*cos is nonzero at y=0 and would
+    require non-homogeneous Dirichlet BCs, polluting the MMS error.
+    """
+    import ufl
+
+    x = ufl.SpatialCoordinate(mesh)
+    if dim == 1:
+        return amplitude * ufl.sin(2.0 * ufl.pi * x[0] / L)
+    if dim == 2:
+        return (
+            amplitude
+            * ufl.sin(2.0 * ufl.pi * x[0] / L)
+            * ufl.sin(3.0 * ufl.pi * x[1] / L)
+        )
+    raise ValueError(f"Unsupported dim {dim}")
+
+
+def manufactured_source_weak(mesh, psi_e_ufl, v, sc, eps_r_value: float):
+    """
+    Build the weak form of the manufactured source contribution.
+
+    Conceptually we want to subtract `f_hat * v * dx` from the production
+    residual where
+
+        f_hat = -div( L_D^2 eps_r grad(psi_exact) )
+                - ni_hat * (exp(-psi_exact) - exp(psi_exact))
+
+    Integrated against the test function and using integration by parts on
+    the diffusion term (psi_exact vanishes on the boundary), this becomes
+
+        ( L_D^2 eps_r grad(psi_exact) . grad(v)
+          - ni_hat * (exp(-psi_exact) - exp(psi_exact)) * v ) dx
+
+    Working in weak form avoids `ufl.div(ufl.grad(...))` which can compile
+    to numerically zero on coarse meshes when constant prefactors get
+    pulled outside, and it uses the same gradient discretization as the
+    production residual (so MMS exactly verifies the discretization in
+    use, not a slightly different one).
+    """
+    import ufl
+    from dolfinx import fem
+    from petsc4py import PETSc
+
+    L_D2 = fem.Constant(mesh, PETSc.ScalarType(sc.lambda2 * sc.L0 ** 2))
+    eps_r = fem.Constant(mesh, PETSc.ScalarType(eps_r_value))
+    ni_hat = fem.Constant(mesh, PETSc.ScalarType(sc.n_i / sc.C0))
+
+    return (
+        L_D2 * eps_r * ufl.inner(ufl.grad(psi_e_ufl), ufl.grad(v))
+        - ni_hat * (ufl.exp(-psi_e_ufl) - ufl.exp(psi_e_ufl)) * v
+    ) * ufl.dx
+
+
+def run_one_level(case: MMSPoissonCase, *, sc=None) -> MMSPoissonResult:
+    """
+    Solve the MMS-Poisson problem on a single mesh level and return the
+    error norms together with SNES diagnostics.
+
+    Reuses `build_equilibrium_poisson_form` so any future change to the
+    production residual is automatically exercised by MMS.
+    """
+    import ufl
+    from dolfinx import fem
+    from petsc4py import PETSc
+
+    from semi.physics.poisson import build_equilibrium_poisson_form
+    from semi.solver import solve_nonlinear
+
+    from ._norms import h1_seminorm_error_squared, l2_error_squared
+
+    if sc is None:
+        sc = build_mms_scaling(L=case.L)
+
+    mesh = _build_mesh(case.dim, case.N, case.L, case.cell_kind)
+    V = fem.functionspace(mesh, ("Lagrange", 1))
+    v = ufl.TestFunction(V)
+
+    # Manufactured exact solution (UFL expression on this mesh).
+    psi_e = psi_exact_ufl(mesh, case.dim, case.L, case.amplitude)
+
+    # N_hat = 0 to keep the focus on discretization vs the carrier term.
+    N_hat = fem.Function(V, name="N_hat_zero")
+    N_hat.x.array[:] = 0.0
+
+    # Initial guess: zero. Trivially satisfies the homogeneous BC.
+    psi = fem.Function(V, name="psi_hat_mms")
+    psi.x.array[:] = 0.0
+
+    # Homogeneous Dirichlet on the full boundary, exact (not interpolated)
+    # because psi_exact vanishes there.
+    fdim = mesh.topology.dim - 1
+    mesh.topology.create_connectivity(fdim, mesh.topology.dim)
+    boundary_facets = _all_boundary_facets(mesh, fdim)
+    bdofs = fem.locate_dofs_topological(V, fdim, boundary_facets)
+    zero = fem.Constant(mesh, PETSc.ScalarType(0.0))
+    bcs = [fem.dirichletbc(zero, bdofs, V)]
+
+    # Residual: production form minus the weak-form manufactured source.
+    F_prod = build_equilibrium_poisson_form(V, psi, N_hat, sc, case.eps_r)
+    src_weak = manufactured_source_weak(mesh, psi_e, v, sc, case.eps_r)
+    F = F_prod - src_weak
+
+    # Tighten SNES tolerances so the carrier nonlinearity is fully iterated.
+    # The production default snes_atol = 1e-12 lets Newton stop after one
+    # step on this problem (the residual norm is dominated by the small
+    # L_D^2 prefactor), which leaves an O(amplitude^2) iteration error
+    # that floors the L^2 convergence rate. Driving atol to ~machine zero
+    # forces enough iterations that the L^2 error reflects pure FE
+    # discretization, which is what MMS is supposed to measure.
+    petsc_options = {
+        "snes_rtol": 1.0e-14,
+        "snes_atol": 1.0e-16,
+        "snes_stol": 0.0,
+        "snes_max_it": 50,
+    }
+    t0 = time.perf_counter()
+    info = solve_nonlinear(
+        F, psi, bcs,
+        prefix=f"mms_poisson_dim{case.dim}_N{case.N}_amp{case.amplitude:g}_",
+        petsc_options=petsc_options,
+    )
+    dt = time.perf_counter() - t0
+    if not info.get("converged", False):
+        raise RuntimeError(
+            f"MMS-Poisson did not converge at dim={case.dim}, N={case.N}: "
+            f"reason={info.get('reason')}, iters={info.get('iterations')}"
+        )
+
+    e_L2 = float(np.sqrt(max(l2_error_squared(psi, psi_e), 0.0)))
+    e_H1 = float(np.sqrt(max(h1_seminorm_error_squared(psi, psi_e), 0.0)))
+
+    n_dofs = int(V.dofmap.index_map.size_global)
+    return MMSPoissonResult(
+        dim=case.dim,
+        N=case.N,
+        h=case.L / case.N,
+        n_dofs=n_dofs,
+        e_L2=e_L2,
+        e_H1=e_H1,
+        snes_iters=int(info.get("iterations", -1)),
+        solve_time_s=dt,
+        cell_kind=case.cell_kind,
+        amplitude=case.amplitude,
+    )
+
+
+def _all_boundary_facets(mesh, fdim: int):
+    """Indices of every facet on the exterior boundary."""
+    from dolfinx import mesh as dmesh
+
+    return dmesh.locate_entities_boundary(
+        mesh, fdim, lambda x: np.full(x.shape[1], True)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convergence sweeps (used by tests and the CLI)
+# ---------------------------------------------------------------------------
+
+def run_convergence_study(
+    *,
+    dim: int,
+    Ns: list[int],
+    L: float = L_0_REF,
+    amplitude: float = 0.5,
+    eps_r: float = EPS_R_DEFAULT,
+    cell_kind: str = "triangle",
+    sc=None,
+) -> list[MMSPoissonResult]:
+    """
+    Run MMS-Poisson on a sequence of refinements. Returns one result per
+    mesh size, in input order.
+    """
+    if sc is None:
+        sc = build_mms_scaling(L=L)
+    results: list[MMSPoissonResult] = []
+    for N in Ns:
+        case = MMSPoissonCase(
+            dim=dim, N=N, L=L, amplitude=amplitude,
+            eps_r=eps_r, cell_kind=cell_kind,
+        )
+        results.append(run_one_level(case, sc=sc))
+    return results
+
+
+def to_table_rows(results: list[MMSPoissonResult]) -> list[dict]:
+    """Build the (h, N_dofs, e_L2, rate_L2, e_H1, rate_H1) rows."""
+    from ._convergence import observed_rates
+
+    hs = [r.h for r in results]
+    e_L2s = [r.e_L2 for r in results]
+    e_H1s = [r.e_H1 for r in results]
+    r_L2 = observed_rates(hs, e_L2s)
+    r_H1 = observed_rates(hs, e_H1s)
+    rows = []
+    for i, r in enumerate(results):
+        rows.append({
+            "N": r.N,
+            "h": r.h,
+            "N_dofs": r.n_dofs,
+            "e_L2": r.e_L2,
+            "rate_L2": r_L2[i],
+            "e_H1": r.e_H1,
+            "rate_H1": r_H1[i],
+            "snes_iters": r.snes_iters,
+            "solve_time_s": r.solve_time_s,
+        })
+    return rows
+
+
+def write_artifacts(
+    rows: list[dict],
+    out_dir: Path,
+    *,
+    title: str,
+    csv_name: str = "convergence.csv",
+    plot_name: str = "convergence.png",
+) -> None:
+    """Write convergence.csv and convergence.png to `out_dir`."""
+    from ._convergence import write_convergence_csv, write_loglog_plot
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    columns = [
+        "N", "h", "N_dofs",
+        "e_L2", "rate_L2",
+        "e_H1", "rate_H1",
+        "snes_iters", "solve_time_s",
+    ]
+    write_convergence_csv(out_dir / csv_name, rows, columns)
+    hs = [r["h"] for r in rows]
+    series = {
+        "L2 error": [r["e_L2"] for r in rows],
+        "H1 seminorm error": [r["e_H1"] for r in rows],
+    }
+    write_loglog_plot(
+        out_dir / plot_name, hs, series,
+        title=title,
+        theoretical_rates={"L2 error": 2.0, "H1 seminorm error": 1.0},
+    )
+
+
+def report_table(rows: list[dict], header: str = "") -> str:
+    """Pretty multi-line stdout table."""
+    from ._convergence import format_table
+
+    cols = ["N", "h", "N_dofs", "e_L2", "rate_L2", "e_H1", "rate_H1"]
+    return format_table(rows, cols, header=header)
+
+
+# ---------------------------------------------------------------------------
+# Default mesh sequences for the CLI (broader than what tests use).
+# ---------------------------------------------------------------------------
+CLI_NS_1D = [40, 80, 160, 320, 640]
+CLI_NS_2D = [16, 32, 64, 128]
+
+
+def run_cli_study(out_dir: Path) -> dict[str, list[dict]]:
+    """
+    Run the artifact-production sweep used by `scripts/run_verification.py`.
+
+    Returns a dict mapping study label to row list. Three studies are run:
+    1D linear (amplitude 0.5), 1D nonlinear (amplitude 2.0), and 2D
+    triangles (amplitude 0.5). A separate 2D quadrilateral smoke test at
+    N=64 is run and its single-level error is appended to a comparison
+    file.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    sc = build_mms_scaling()
+
+    studies: dict[str, list[dict]] = {}
+
+    # 1D linear regime (amplitude 0.5)
+    res = run_convergence_study(
+        dim=1, Ns=CLI_NS_1D, amplitude=0.5, sc=sc,
+    )
+    rows = to_table_rows(res)
+    write_artifacts(
+        rows, out_dir / "1d_linear",
+        title="MMS Poisson 1D linear regime (amplitude 0.5)",
+    )
+    studies["1d_linear"] = rows
+
+    # 1D nonlinear regime (amplitude 2.0)
+    res = run_convergence_study(
+        dim=1, Ns=CLI_NS_1D, amplitude=2.0, sc=sc,
+    )
+    rows = to_table_rows(res)
+    write_artifacts(
+        rows, out_dir / "1d_nonlinear",
+        title="MMS Poisson 1D nonlinear regime (amplitude 2.0)",
+    )
+    studies["1d_nonlinear"] = rows
+
+    # 2D triangles (amplitude 0.5)
+    res = run_convergence_study(
+        dim=2, Ns=CLI_NS_2D, amplitude=0.5, sc=sc, cell_kind="triangle",
+    )
+    rows = to_table_rows(res)
+    write_artifacts(
+        rows, out_dir / "2d_triangles",
+        title="MMS Poisson 2D right-diagonal triangles (amplitude 0.5)",
+    )
+    studies["2d_triangles"] = rows
+
+    # 2D quadrilateral smoke test at N=64; compare against triangle row at
+    # the same N. The quad mesh on a square produces fewer DOFs per cell
+    # but the L^2 error should be of comparable magnitude to the triangle
+    # case at the same h.
+    quad_case = MMSPoissonCase(
+        dim=2, N=64, amplitude=0.5, cell_kind="quadrilateral",
+    )
+    quad_result = run_one_level(quad_case, sc=sc)
+    tri_64 = next(r for r in studies["2d_triangles"] if r["N"] == 64)
+    smoke_row = {
+        "N": quad_result.N,
+        "h": quad_result.h,
+        "N_dofs_quad": quad_result.n_dofs,
+        "e_L2_quad": quad_result.e_L2,
+        "e_H1_quad": quad_result.e_H1,
+        "N_dofs_triangle": tri_64["N_dofs"],
+        "e_L2_triangle": tri_64["e_L2"],
+        "e_H1_triangle": tri_64["e_H1"],
+        "ratio_L2_quad_over_triangle": (
+            quad_result.e_L2 / tri_64["e_L2"] if tri_64["e_L2"] > 0 else float("nan")
+        ),
+    }
+    from ._convergence import write_convergence_csv
+
+    write_convergence_csv(
+        out_dir / "2d_quad_smoke.csv",
+        [smoke_row],
+        list(smoke_row.keys()),
+    )
+    studies["2d_quad_smoke"] = [smoke_row]
+
+    return studies

--- a/tests/fem/conftest.py
+++ b/tests/fem/conftest.py
@@ -1,0 +1,19 @@
+"""
+FEM-only test fixtures and collection guard.
+
+Tests in this directory require dolfinx and run only inside the
+Dockerized FEM environment. The pure-Python CI matrix does not have
+dolfinx installed, so we tell pytest to skip the entire subdirectory
+when the import fails.
+"""
+from __future__ import annotations
+
+try:
+    import dolfinx  # noqa: F401
+
+    HAS_DOLFINX = True
+except ImportError:
+    HAS_DOLFINX = False
+
+if not HAS_DOLFINX:
+    collect_ignore_glob = ["*"]

--- a/tests/fem/test_conservation.py
+++ b/tests/fem/test_conservation.py
@@ -1,0 +1,87 @@
+"""
+FEM-level conservation tests (Phase 3 V&V).
+
+These tests run the full Poisson / drift-diffusion solver on the
+standard pn_1d benchmarks and assert:
+
+    1) charge neutrality (pn_1d equilibrium):
+       |Q_net| < 1e-10 * q * max|N_net| * L
+
+    2) current continuity on the final forward bias (V=0.6 V):
+       max|J_total(x) - mean(J_total)| / |mean(J_total)| < 5%
+
+    3) current continuity on the final reverse bias (V=-2.0 V):
+       max|J_total(x) - mean(J_total)| / |mean(J_total)| < 15%
+
+Skipped at collection time when dolfinx is not importable (see
+tests/fem/conftest.py). These tests are slow (~1 min each for the
+bias sweeps) so they are kept in tests/fem/ rather than tests/.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_pn_1d_charge_neutrality_at_equilibrium():
+    """
+    Integrate q * (p - n + N_net) over the pn_1d device and require
+    the result to be at least ten orders of magnitude smaller than
+    q * max|N_net| * L. That matches the snes_rtol ~ 1e-14 used by
+    run_equilibrium and is the tightest honest threshold.
+    """
+    from semi import run as semi_run
+    from semi import schema
+    from semi.verification.conservation import charge_conservation_from_result
+
+    cfg = schema.load(REPO_ROOT / "benchmarks" / "pn_1d" / "pn_junction.json")
+    result = semi_run.run(cfg)
+    m = charge_conservation_from_result(result)
+    assert m.Q_ref > 0.0, f"empty Q_ref: {m}"
+    assert m.rel_error < 1.0e-10, (
+        f"|Q_net|={m.Q_net:.3e} C/m^2 fails 1e-10 * Q_ref "
+        f"({m.Q_ref:.3e}); rel={m.rel_error:.3e}"
+    )
+
+
+def test_pn_1d_bias_forward_current_continuity():
+    """
+    At the end of the pn_1d_bias forward sweep (V=0.6 V) the interior
+    current continuity must be within 5%.
+    """
+    from semi import run as semi_run
+    from semi import schema
+    from semi.verification.conservation import current_continuity_from_result
+
+    cfg_path = REPO_ROOT / "benchmarks" / "pn_1d_bias" / "pn_junction_bias.json"
+    cfg = schema.load(cfg_path)
+    result = semi_run.run(cfg)
+    cc = current_continuity_from_result(result, n_samples=10)
+    assert cc.xs.size >= 8, f"expected ~10 samples, got {cc.xs.size}"
+    assert cc.max_rel_dev < 0.05, (
+        f"forward J continuity: max rel dev {cc.max_rel_dev*100:.2f}% "
+        f"(mean={cc.mean_J:.3e}, max_dev={cc.max_abs_dev:.3e})"
+    )
+
+
+def test_pn_1d_bias_reverse_current_continuity():
+    """
+    At the end of the pn_1d_bias_reverse sweep (V=-2.0 V) the interior
+    current continuity must be within 15%.
+    """
+    from semi import run as semi_run
+    from semi import schema
+    from semi.verification.conservation import current_continuity_from_result
+
+    cfg_path = (
+        REPO_ROOT / "benchmarks" / "pn_1d_bias_reverse" / "pn_junction_bias_reverse.json"
+    )
+    cfg = schema.load(cfg_path)
+    result = semi_run.run(cfg)
+    cc = current_continuity_from_result(result, n_samples=10)
+    assert cc.xs.size >= 8, f"expected ~10 samples, got {cc.xs.size}"
+    assert cc.max_rel_dev < 0.15, (
+        f"reverse J continuity: max rel dev {cc.max_rel_dev*100:.2f}% "
+        f"(mean={cc.mean_J:.3e}, max_dev={cc.max_abs_dev:.3e})"
+    )

--- a/tests/fem/test_mesh_convergence.py
+++ b/tests/fem/test_mesh_convergence.py
@@ -1,0 +1,95 @@
+"""
+Mesh-convergence tests for the pn_1d benchmark.
+
+For a problem with no analytical solution, the standard V&V gate is
+Cauchy self-convergence: compare coarser FEM solutions against a finer
+FEM reference on the same mesh family, not against a physics model
+(depletion approximation) that the FEM solver is not targeting.
+
+This test runs N = [100, 200, 400, 1600] and asserts the >= 2x error-
+ratio-per-doubling rule on the Cauchy error at N = [100, 200, 400],
+with N = 1600 serving as the reference. It also asserts monotone
+reduction in the depletion-approx relative error over the same subset,
+to smoke-test that the benchmark observables (V_bi, peak |E|, W) keep
+approaching the physical values as h -> 0.
+
+See the module docstring of `semi/verification/mesh_convergence.py`
+for why Cauchy convergence is the right gate here.
+"""
+from __future__ import annotations
+
+PYTEST_NS = [100, 200, 400, 1600]
+ASSERT_NS = [100, 200, 400]          # rates are asserted only on these
+MIN_RATIO_PER_DOUBLING = 2.0
+
+
+def _assert_monotone_decreasing(errs, label, ns):
+    for i in range(len(errs) - 1):
+        assert errs[i + 1] < errs[i], (
+            f"{label}: error should decrease monotonically at "
+            f"N={ns[i + 1]}, got {errs[i + 1]:.3e} >= {errs[i]:.3e}"
+        )
+
+
+def _assert_halving(errs, label, ns):
+    for i in range(1, len(errs)):
+        ratio = errs[i - 1] / errs[i] if errs[i] > 0.0 else float("inf")
+        assert ratio >= MIN_RATIO_PER_DOUBLING, (
+            f"{label}: error ratio per mesh doubling at N={ns[i]} is "
+            f"{ratio:.2f}, below the {MIN_RATIO_PER_DOUBLING:.2f} floor "
+            f"(errs={errs})"
+        )
+
+
+def test_mesh_convergence_pn_1d_cauchy_halves_per_doubling():
+    """
+    Cauchy self-convergence errors (FEM vs finest FEM) at
+    N = [100, 200, 400] must reduce by >= 2x per mesh doubling and
+    decrease monotonically. This is the discretization-error gate and
+    is unaffected by the depletion-approx plateau that floors
+    err_Epeak_rel on fine meshes.
+    """
+    from semi.verification.mesh_convergence import (
+        cauchy_errors,
+        run_convergence_study,
+    )
+
+    results = run_convergence_study(PYTEST_NS)
+    cauchy = cauchy_errors(results, reference_index=-1)
+    E_errs = [c["err_Epeak_cauchy"] for c in cauchy[:-1]]
+    W_errs = [c["err_W_cauchy"] for c in cauchy[:-1]]
+
+    _assert_monotone_decreasing(E_errs, "E_peak Cauchy", ASSERT_NS)
+    _assert_monotone_decreasing(W_errs, "W Cauchy", ASSERT_NS)
+    _assert_halving(E_errs, "E_peak Cauchy", ASSERT_NS)
+    _assert_halving(W_errs, "W Cauchy", ASSERT_NS)
+
+
+def test_mesh_convergence_pn_1d_depletion_error_monotone():
+    """
+    Smoke test that the depletion-approximation relative error also
+    decreases monotonically on the asserted subset, even though its
+    absolute magnitude is floored by the physics-model gap. No ratio
+    is enforced here; see the module docstring for why.
+    """
+    from semi.verification.mesh_convergence import run_convergence_study
+
+    results = run_convergence_study(ASSERT_NS)
+    E_errs = [r.err_Epeak_rel for r in results]
+    W_errs = [r.err_W_rel for r in results]
+
+    _assert_monotone_decreasing(E_errs, "E_peak rel", ASSERT_NS)
+    _assert_monotone_decreasing(W_errs, "W rel", ASSERT_NS)
+
+
+def test_mesh_convergence_pn_1d_newton_converges():
+    """Equilibrium Poisson must converge in single-digit iterations at
+    every refinement level used by the test subset."""
+    from semi.verification.mesh_convergence import run_convergence_study
+
+    results = run_convergence_study(ASSERT_NS)
+    for r in results:
+        assert 0 < r.newton_iters < 20, (
+            f"pn_1d Newton took {r.newton_iters} iterations at N={r.N}; "
+            "expected single digits"
+        )

--- a/tests/fem/test_mms_dd.py
+++ b/tests/fem/test_mms_dd.py
@@ -1,0 +1,129 @@
+"""
+MMS convergence tests for the coupled drift-diffusion block residual.
+
+Mesh sequences here are the pytest-budget subset (3 levels in 1D and 2D)
+so the full FEM test suite stays under the docker-fem budget. The CLI in
+`scripts/run_verification.py` runs the fuller sweep used for the
+published convergence plots. See `docs/mms_dd_derivation.md` for the
+approved derivation and rate targets.
+
+Variant A gates the psi block only: `phi_n_e = phi_p_e = 0` identically,
+so the Fermi-level errors are at Newton-noise level and do not carry a
+meaningful observed rate. Variants B and C gate all three blocks.
+"""
+from __future__ import annotations
+
+import math
+
+
+PYTEST_NS_1D = [40, 80, 160]
+PYTEST_NS_2D = [16, 32, 64]
+
+# Derivation Section 5: L^2 >= 1.75 and H^1 >= 0.80 per gated block.
+RATE_L2_FLOOR = 1.75
+RATE_H1_FLOOR = 0.80
+
+
+def _finest_pair_rate(hs, errors):
+    """Log slope of the last two (h, err) pairs."""
+    h_prev, h_cur = hs[-2], hs[-1]
+    e_prev, e_cur = errors[-2], errors[-1]
+    return math.log(e_prev / e_cur) / math.log(h_prev / h_cur)
+
+
+def _assert_monotone_and_rates(results, blocks):
+    """
+    Assert strict monotone L^2 error reduction and finest-pair rates on
+    every block in `blocks`. `blocks` is a subset of ("psi", "phi_n",
+    "phi_p").
+    """
+    hs = [r.h for r in results]
+    for b in blocks:
+        eL2 = [getattr(r, f"e_L2_{b}") for r in results]
+        eH1 = [getattr(r, f"e_H1_{b}") for r in results]
+        assert all(eL2[i + 1] < eL2[i] for i in range(len(eL2) - 1)), (
+            f"L^2 error on block {b!r} should decrease monotonically: {eL2}"
+        )
+        rate_L2 = _finest_pair_rate(hs, eL2)
+        rate_H1 = _finest_pair_rate(hs, eH1)
+        assert rate_L2 >= RATE_L2_FLOOR, (
+            f"block {b!r}: finest-pair L^2 rate {rate_L2:.3f} < "
+            f"{RATE_L2_FLOOR:.2f}"
+        )
+        assert rate_H1 >= RATE_H1_FLOOR, (
+            f"block {b!r}: finest-pair H^1 rate {rate_H1:.3f} < "
+            f"{RATE_H1_FLOOR:.2f}"
+        )
+
+
+def test_mms_dd_1d_variant_A():
+    """
+    Variant A: Poisson block only, phi_n_e = phi_p_e = 0. Only the psi
+    block has a meaningful convergence rate; the continuity blocks solve
+    the trivially-zero exact solution and their errors are at Newton
+    noise level.
+    """
+    from semi.verification.mms_dd import run_convergence_study
+
+    results = run_convergence_study(
+        dim=1, variant="A", Ns=PYTEST_NS_1D,
+    )
+    _assert_monotone_and_rates(results, blocks=("psi",))
+
+
+def test_mms_dd_1d_variant_B():
+    """
+    Variant B: full three-block coupling with tau_hat = infinity so the
+    SRH term is numerically negligible but the kernel path is still
+    exercised. All three blocks must converge.
+    """
+    from semi.verification.mms_dd import run_convergence_study
+
+    results = run_convergence_study(
+        dim=1, variant="B", Ns=PYTEST_NS_1D,
+    )
+    _assert_monotone_and_rates(results, blocks=("psi", "phi_n", "phi_p"))
+
+
+def test_mms_dd_1d_variant_C():
+    """
+    Variant C: full coupling with physical Si SRH lifetimes; R_e is
+    pointwise nonzero because A_p = -A_n forces phi_p_e - phi_n_e != 0.
+    All three blocks must converge at the gate rate.
+    """
+    from semi.verification.mms_dd import run_convergence_study
+
+    results = run_convergence_study(
+        dim=1, variant="C", Ns=PYTEST_NS_1D,
+    )
+    _assert_monotone_and_rates(results, blocks=("psi", "phi_n", "phi_p"))
+
+
+def test_mms_dd_2d_variant_A():
+    """2D right-diagonal triangles, Variant A (psi block only)."""
+    from semi.verification.mms_dd import run_convergence_study
+
+    results = run_convergence_study(
+        dim=2, variant="A", Ns=PYTEST_NS_2D, cell_kind="triangle",
+    )
+    _assert_monotone_and_rates(results, blocks=("psi",))
+
+
+def test_mms_dd_2d_variant_B():
+    """2D Variant B: full coupling, R ~ 0; all three blocks must converge."""
+    from semi.verification.mms_dd import run_convergence_study
+
+    results = run_convergence_study(
+        dim=2, variant="B", Ns=PYTEST_NS_2D, cell_kind="triangle",
+    )
+    _assert_monotone_and_rates(results, blocks=("psi", "phi_n", "phi_p"))
+
+
+def test_mms_dd_2d_variant_C():
+    """2D Variant C: full coupling with SRH; all three blocks gated."""
+    from semi.verification.mms_dd import run_convergence_study
+
+    results = run_convergence_study(
+        dim=2, variant="C", Ns=PYTEST_NS_2D, cell_kind="triangle",
+    )
+    _assert_monotone_and_rates(results, blocks=("psi", "phi_n", "phi_p"))

--- a/tests/fem/test_mms_dd.py
+++ b/tests/fem/test_mms_dd.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import math
 
-
 PYTEST_NS_1D = [40, 80, 160]
 PYTEST_NS_2D = [16, 32, 64]
 

--- a/tests/fem/test_mms_poisson.py
+++ b/tests/fem/test_mms_poisson.py
@@ -1,0 +1,152 @@
+"""
+MMS-Poisson convergence tests.
+
+Mesh sequences here are the pytest-budget subset (4 levels in 1D, 3 in
+2D) so the full FEM test suite stays under one minute on the docker-fem
+job. The CLI in `scripts/run_verification.py` runs the fuller sweep
+used for the published convergence plot.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+PYTEST_NS_1D = [40, 80, 160, 320]
+PYTEST_NS_2D = [16, 32, 64]
+
+
+def _finest_pair_rate(hs, errors):
+    """log slope of the last two (h, err) pairs."""
+    h_prev, h_cur = hs[-2], hs[-1]
+    e_prev, e_cur = errors[-2], errors[-1]
+    return math.log(e_prev / e_cur) / math.log(h_prev / h_cur)
+
+
+def test_mms_poisson_1d_linear_regime():
+    """
+    amplitude = 0.5: exp(+/- psi) ~ 1 + psi + psi^2/2, so the residual is
+    dominated by the Laplacian perturbation. L^2 rate must be >= 1.85 on
+    the finest pair; H^1 rate must be >= 0.85.
+    """
+    from semi.verification.mms_poisson import run_convergence_study
+
+    results = run_convergence_study(dim=1, Ns=PYTEST_NS_1D, amplitude=0.5)
+    hs = [r.h for r in results]
+    eL2 = [r.e_L2 for r in results]
+    eH1 = [r.e_H1 for r in results]
+
+    # Monotone error reduction across the sweep
+    assert all(eL2[i + 1] < eL2[i] for i in range(len(eL2) - 1)), \
+        f"L^2 error should decrease monotonically: {eL2}"
+
+    rate_L2 = _finest_pair_rate(hs, eL2)
+    rate_H1 = _finest_pair_rate(hs, eH1)
+    assert rate_L2 >= 1.85, (
+        f"finest-pair L^2 rate {rate_L2:.3f} < 1.85 for amplitude=0.5"
+    )
+    assert rate_H1 >= 0.85, (
+        f"finest-pair H^1 rate {rate_H1:.3f} < 0.85 for amplitude=0.5"
+    )
+
+
+def test_mms_poisson_1d_nonlinear_regime():
+    """
+    amplitude = 2.0: exp(2) ~ 7.4, so the carrier-nonlinearity dominates
+    the residual. This is the regime physical devices operate in
+    (real pn junctions see ~20 V_T of band bending). L^2 rate must
+    still be >= 1.85 on the finest pair. Rate degradation here is a
+    legitimate finding to document; the prompt explicitly says do not
+    lower the tolerance to make the test pass.
+    """
+    from semi.verification.mms_poisson import run_convergence_study
+
+    results = run_convergence_study(dim=1, Ns=PYTEST_NS_1D, amplitude=2.0)
+    hs = [r.h for r in results]
+    eL2 = [r.e_L2 for r in results]
+    eH1 = [r.e_H1 for r in results]
+
+    assert all(eL2[i + 1] < eL2[i] for i in range(len(eL2) - 1)), \
+        f"L^2 error should decrease monotonically: {eL2}"
+
+    rate_L2 = _finest_pair_rate(hs, eL2)
+    rate_H1 = _finest_pair_rate(hs, eH1)
+    assert rate_L2 >= 1.85, (
+        f"finest-pair L^2 rate {rate_L2:.3f} < 1.85 for amplitude=2.0"
+    )
+    assert rate_H1 >= 0.85, (
+        f"finest-pair H^1 rate {rate_H1:.3f} < 0.85 for amplitude=2.0"
+    )
+
+
+def test_mms_poisson_2d_convergence():
+    """
+    2D right-diagonal triangles; L^2 rate >= 1.85 on the finest pair.
+    """
+    from semi.verification.mms_poisson import run_convergence_study
+
+    results = run_convergence_study(
+        dim=2, Ns=PYTEST_NS_2D, amplitude=0.5, cell_kind="triangle",
+    )
+    hs = [r.h for r in results]
+    eL2 = [r.e_L2 for r in results]
+    eH1 = [r.e_H1 for r in results]
+
+    assert all(eL2[i + 1] < eL2[i] for i in range(len(eL2) - 1)), \
+        f"L^2 error should decrease monotonically: {eL2}"
+
+    rate_L2 = _finest_pair_rate(hs, eL2)
+    rate_H1 = _finest_pair_rate(hs, eH1)
+    assert rate_L2 >= 1.85, (
+        f"finest-pair 2D L^2 rate {rate_L2:.3f} < 1.85"
+    )
+    assert rate_H1 >= 0.85, (
+        f"finest-pair 2D H^1 rate {rate_H1:.3f} < 0.85"
+    )
+
+
+def test_mms_poisson_2d_quad_smoke():
+    """
+    Single-mesh-size quadrilateral mesh at N=64; error must be of the
+    same order as the triangle case at the same N. This is a smoke
+    test, not a convergence study: we only verify the operator works
+    on a quad mesh, not that convergence rates are identical (the two
+    element families differ in a non-trivial way).
+    """
+    from semi.verification.mms_poisson import (
+        MMSPoissonCase,
+        run_convergence_study,
+        run_one_level,
+    )
+
+    quad = run_one_level(MMSPoissonCase(
+        dim=2, N=64, amplitude=0.5, cell_kind="quadrilateral",
+    ))
+    tri = run_convergence_study(
+        dim=2, Ns=[64], amplitude=0.5, cell_kind="triangle",
+    )[0]
+    ratio = quad.e_L2 / tri.e_L2
+    # Quad on a square has half the DOFs of right-diagonal triangles at
+    # the same N, so some error inflation is expected; a ratio in
+    # [0.1, 10] range means the two are comparable, not pathological.
+    assert 0.1 < ratio < 10.0, (
+        f"quad/triangle L^2 ratio {ratio:.3f} outside [0.1, 10] at N=64"
+    )
+
+
+@pytest.mark.parametrize("dim", [1, 2])
+def test_mms_poisson_snes_converges(dim):
+    """
+    Newton converges in a small number of iterations on a representative
+    mesh level for each dim. Zero iterations is allowed (initial guess
+    can be exact in the linearized regime) but more than 20 indicates
+    something has regressed in the residual or initial guess.
+    """
+    from semi.verification.mms_poisson import MMSPoissonCase, run_one_level
+
+    N = 80 if dim == 1 else 32
+    result = run_one_level(MMSPoissonCase(dim=dim, N=N, amplitude=0.5))
+    assert result.snes_iters < 20, (
+        f"SNES took {result.snes_iters} iterations on dim={dim} N={N}; "
+        "expected single digits"
+    )

--- a/tests/test_conservation_metrics.py
+++ b/tests/test_conservation_metrics.py
@@ -1,0 +1,219 @@
+"""
+Pure-Python unit tests for the Phase 3 V&V conservation metrics.
+
+These tests exercise the dolfinx-free reduction functions in
+`semi.verification.conservation`:
+
+    current_continuity_metric(xs, J_vals)  -> CurrentContinuityMetric
+    charge_neutrality_metric(x, p, n, N_net, q) -> ChargeNeutralityMetric
+
+The functions take raw arrays, so we fabricate `J_n`, `J_p`, and
+(n, p, N_net) profiles directly rather than constructing a dolfinx
+SimulationResult. That's what "Mock SimulationResult with known J_n,
+J_p for continuity check" / "Mock charge profile for charge check"
+means operationally: the FEM stack is not needed to verify the
+reduction math is correct.
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from semi.constants import Q
+from semi.verification.conservation import (
+    charge_neutrality_metric,
+    current_continuity_metric,
+)
+
+
+# ---------------------------------------------------------------------------
+# current_continuity_metric
+# ---------------------------------------------------------------------------
+
+
+def test_continuity_flat_current_passes_5_percent():
+    """
+    If J_n + J_p is constant in space (the physically correct answer),
+    the metric's max relative deviation is exactly zero and the 5%
+    forward gate passes trivially.
+    """
+    xs = np.linspace(1.0e-6, 1.9e-5, 10)
+    J_n = np.full(10, 12.0)
+    J_p = np.full(10, -2.0)
+    m = current_continuity_metric(xs, J_n + J_p)
+    assert m.mean_J == pytest.approx(10.0)
+    assert m.max_abs_dev == pytest.approx(0.0)
+    assert m.max_rel_dev == pytest.approx(0.0)
+    assert m.max_rel_dev < 0.05
+
+
+def test_continuity_noisy_within_tolerance_passes_5_percent():
+    """
+    1% white noise on a 10 A/m^2 baseline must fall under the 5%
+    forward-bias gate.
+    """
+    rng = np.random.default_rng(seed=42)
+    xs = np.linspace(1.0e-6, 1.9e-5, 10)
+    J_mean = 10.0
+    J_vals = J_mean + 0.01 * J_mean * rng.standard_normal(10)
+    m = current_continuity_metric(xs, J_vals)
+    assert m.max_rel_dev < 0.05
+    assert m.mean_J == pytest.approx(J_mean, rel=0.02)
+
+
+def test_continuity_15_percent_outlier_fails_5_percent_passes_15_percent():
+    """
+    An outlier at 15% of the mean must fail the 5% forward gate and
+    pass the 15% reverse gate. This exercises both thresholds in one
+    synthetic profile.
+    """
+    xs = np.linspace(0.0, 2.0e-5, 10)
+    J_vals = np.full(10, 10.0)
+    J_vals[5] = 10.0 * 1.12        # +12% outlier in one sample
+    m = current_continuity_metric(xs, J_vals)
+    # Mean is 10.12; max deviation ~1.08 A/m^2 at the outlier; rel ~10.7%.
+    assert 0.05 < m.max_rel_dev < 0.15
+
+
+def test_continuity_zero_mean_zero_deviation_is_zero():
+    """
+    At V=0 the physical answer is J=0 everywhere. The metric must
+    report 0 deviation with 0 mean and rel_dev = 0 (not inf).
+    """
+    m = current_continuity_metric(np.linspace(0, 1, 5), np.zeros(5))
+    assert m.mean_J == 0.0
+    assert m.max_abs_dev == 0.0
+    assert m.max_rel_dev == 0.0
+
+
+def test_continuity_zero_mean_nonzero_deviation_is_inf():
+    """
+    If the mean collapses to zero but samples deviate (pathological
+    cancellation), rel_dev is +inf so the gate always fails loudly.
+    """
+    m = current_continuity_metric(
+        np.linspace(0, 1, 4), np.array([1.0, -1.0, 1.0, -1.0])
+    )
+    assert m.mean_J == pytest.approx(0.0)
+    assert m.max_abs_dev > 0.0
+    assert math.isinf(m.max_rel_dev)
+
+
+def test_continuity_empty_inputs_are_safe():
+    """An empty samples array must not raise and must report zeros."""
+    m = current_continuity_metric(np.empty(0), np.empty(0))
+    assert m.mean_J == 0.0
+    assert m.max_rel_dev == 0.0
+
+
+# ---------------------------------------------------------------------------
+# charge_neutrality_metric
+# ---------------------------------------------------------------------------
+
+
+def test_charge_neutrality_symmetric_step_junction_is_zero():
+    """
+    Synthetic symmetric step junction: N_A on the left, N_D on the
+    right, and p(x) = N_A on the left, n(x) = N_D on the right, with
+    zero minority carriers. This is a charge-neutral profile and
+    integrating (p - n + N_net) gives zero analytically.
+
+    N_net here is N_D - N_A (the sign convention the benchmark uses).
+    """
+    N = 201
+    L = 2.0e-5
+    x = np.linspace(0.0, L, N)
+    N_A = 1.0e23
+    N_D = 1.0e23
+    # Step profile at x = L/2: N_net = N_D on the right, -N_A on the left.
+    N_net = np.where(x < L / 2, -N_A, N_D)
+    # Perfect majority-carrier mirror image: p = N_A on the left, n = N_D
+    # on the right, minority ~0.
+    p = np.where(x < L / 2, N_A, 0.0)
+    n = np.where(x < L / 2, 0.0, N_D)
+
+    m = charge_neutrality_metric(x, p, n, N_net, Q)
+    # Exact analytic zero modulo trapezoid rounding on the discontinuity.
+    Q_ref_expected = Q * max(N_A, N_D) * L
+    assert m.Q_ref == pytest.approx(Q_ref_expected, rel=1.0e-12)
+    assert m.rel_error < 1.0e-10
+
+
+def test_charge_neutrality_excess_charge_is_detected():
+    """
+    A 1e-9 fractional imbalance on top of peak doping must produce a
+    relative error above the 1e-10 gate and therefore be caught.
+    """
+    N = 101
+    L = 1.0e-5
+    x = np.linspace(0.0, L, N)
+    N_A = 1.0e22
+    # Imbalanced: p on the left, n on the right, with a tiny asymmetry.
+    N_net = np.where(x < L / 2, -N_A, N_A)
+    p = np.where(x < L / 2, N_A * (1 + 1.0e-9), 0.0)
+    n = np.where(x < L / 2, 0.0, N_A)
+    m = charge_neutrality_metric(x, p, n, N_net, Q)
+    assert m.rel_error > 1.0e-10
+    assert m.Q_net > 0.0
+
+
+def test_charge_neutrality_sort_is_robust_to_unordered_input():
+    """
+    The metric must sort coordinates before applying the trapezoidal
+    rule; feeding an unordered x must give the same answer as the
+    sorted version.
+    """
+    x = np.array([0.0, 0.5, 0.25, 1.0, 0.75])
+    N_A = 1.0e22
+    # Linear rho = +N_A * x - N_A/2 (zero mean over [0,1])
+    rho_over_q = N_A * x - N_A / 2.0
+    # Encode rho as p - n + N_net with N_net=0.
+    p = np.where(rho_over_q > 0, rho_over_q, 0.0)
+    n = np.where(rho_over_q < 0, -rho_over_q, 0.0)
+    N_net = np.zeros_like(x)
+
+    m = charge_neutrality_metric(x, p, n, N_net, Q)
+    # The integral of N_A * x - N_A/2 over [0, 1] is 0.
+    assert abs(m.Q_net) < Q * N_A * 1.0e-12
+    assert m.Q_ref == 0.0   # N_net is all zeros; reference collapses
+    assert math.isinf(m.rel_error)
+
+
+def test_charge_neutrality_reference_uses_max_abs_N_net_and_L():
+    """
+    The reference charge is q * max|N_net| * (x_max - x_min); verify
+    directly so future refactors do not silently drop a factor.
+    """
+    x = np.linspace(0.0, 2.0, 5)
+    N_net = np.array([-3.0, -2.0, 0.0, 4.0, 1.0])
+    m = charge_neutrality_metric(x, np.zeros(5), np.zeros(5), N_net, Q)
+    assert m.Q_ref == pytest.approx(Q * 4.0 * 2.0)
+
+
+def test_charge_threshold_matches_phase3_spec():
+    """
+    The acceptance threshold specified by Phase 3 is 1e-10 * q *
+    max|N_net| * L. A sanity synthetic that sits just under it must
+    pass; one just over it must fail.
+    """
+    x = np.linspace(0.0, 1.0e-5, 11)
+    N_A = 1.0e23
+    L = 1.0e-5
+    Q_ref = Q * N_A * L
+    # |Q_net| == 0.5 * threshold -> must pass with margin.
+    target_rel = 0.5e-10
+    # Integral of constant c over [0, L] is c * L.
+    c = target_rel * N_A
+    p = np.full_like(x, c)
+    n = np.zeros_like(x)
+    N_net = np.full_like(x, -N_A + 0.0) + np.zeros_like(x)
+    # Actually rework: keep max|N_net| = N_A; use rho-via-minor-excess-p.
+    N_net = np.full_like(x, -N_A)
+    p = np.full_like(x, N_A + c)     # slight excess
+    n = np.zeros_like(x)             # no compensation
+    m = charge_neutrality_metric(x, p, n, N_net, Q)
+    # |Q_net| ~= q * c * L = q * (0.5e-10 * N_A) * L = 0.5e-10 * Q_ref
+    assert m.rel_error < 1.0e-10
+    assert m.Q_ref == pytest.approx(Q_ref, rel=1.0e-12)

--- a/tests/test_conservation_metrics.py
+++ b/tests/test_conservation_metrics.py
@@ -27,7 +27,6 @@ from semi.verification.conservation import (
     current_continuity_metric,
 )
 
-
 # ---------------------------------------------------------------------------
 # current_continuity_metric
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Day 4 delivers a Verification & Validation suite that replaces the
single-point benchmark "verifiers" with four separate verification
activities, each gated in CI:

- **MMS for equilibrium Poisson** (`mms_poisson`): 1D linear, 1D
  nonlinear, 2D triangles + 2D quad smoke. Finest-pair rates at
  theoretical L^2 = 2.000, H^1 = 0.999-1.000.
- **Mesh convergence on `pn_1d`** (`mesh_convergence`): N sweep
  [50..1600]; Cauchy self-convergence >= 1.99x per doubling on
  E_peak and W over the first four levels (before the depletion-
  approximation plateau, which is honest-flagged in the runner and
  in `docs/PHYSICS.md`).
- **Discrete conservation** (`conservation`): charge on `pn_1d`
  equilibrium at rel 1.5e-17; current continuity on forward
  (V in {0.30, 0.45, 0.60} V, 5% tol) and reverse (V in {-0.50,
  -1.00, -2.00} V, 15% tol) sweeps with worst max_rel 1.91% /
  0.020%.
- **MMS for coupled drift-diffusion** (`mms_dd`): three variants
  (psi-only / full coupling no R / full coupling with SRH) x three
  grids (1D default, 1D nonlinear, 2D). Every gated block rate
  >= 1.99 L^2 and >= 0.996 H^1. Derivation-first workflow:
  `docs/mms_dd_derivation.md` was approved before any MMS-DD code
  landed.

The `docker-fem` CI job now runs `python scripts/run_verification.py all`
inside the dolfinx container; timeout tightened from 30 to 15
minutes; the `benchmark-plots` artifact is renamed `fem-results`
and uploads the full `results/` tree.

Documentation:
- New "Verification & Validation" section in `docs/PHYSICS.md`
  (Section 5).
- New ADR `docs/adr/0006-verification-and-validation-strategy.md`.
- Amendment to `docs/mms_dd_derivation.md` documenting the SNES
  tolerance fix (atol = 0.0, stol = 1e-12; the originally-proposed
  atol = 1e-16 was below the 2D continuity-block initial residual
  and terminated Newton prematurely).

The original Day-4 refactor pass is pushed to Day 5.

## Test plan

- [x] `docker-fem` CI job green with V&V step
- [x] pytest 3.10 / 3.11 / 3.12 green
- [x] ruff clean
- [x] `run_verification.py all` exits 0 locally
- [x] MMS-Poisson finest-pair rates L^2 = 2.000 / H^1 = 1.000
- [x] Mesh convergence Cauchy ratios >= 1.99x per doubling
- [x] Charge conservation rel 1.5e-17 vs. 1e-10 threshold
- [x] Current continuity worst max_rel 1.91% fwd / 0.020% rev
- [x] MMS-DD all gated block rates >= 1.99 L^2 / 0.996 H^1
- [x] No regression in `pn_1d`, `pn_1d_bias`, `pn_1d_bias_reverse`
- [x] CI wall-clock inside 15-minute budget (docker-fem 3m22s observed)

## CI evidence

Pre-PR `docker-fem` run on `dev/day4-vnv` @ 94ce41c — all 5 jobs green
(pure-python 3.10/3.11/3.12, lint, docker-fem):
https://github.com/rwalkerlewis/kronos-semi/actions/runs/24740669309

## Out of scope

- Refactor of `semi/run.py` / BC extraction (Day 5).
- 2D MOS capacitor (Day 6), 3D resistor (Day 7).
- devsim code-to-code comparison (post-submission).

Generated with [Claude Code](https://claude.com/claude-code)
