### PR TITLE
fix: replace stale end-of-Day-N refs with end-of-MN throughout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.9.0] - M9: Result artifact writer
+
+### Added
+- `schemas/manifest.v1.json`: JSON-schema Draft-07 describing the run-artifact
+  manifest contract. Covers engine metadata, solver summary, field list,
+  mesh topology, optional bias-sweep entries, and warnings.
+- `semi/io/artifact.py`: `write_artifact(result, out_dir, run_id, input_json_path)`
+  writes a versioned run directory containing `manifest.json`, `input.json`,
+  `mesh/mesh.xdmf`, `fields/<name>.bp` (or `.xdmf` fallback), `iv/<contact>.csv`,
+  and `convergence/snes.csv`.
+- `semi/io/reader.py`: `read_manifest(run_dir)` loads and schema-validates
+  `manifest.json` using only stdlib JSON plus optional jsonschema; no dolfinx
+  or numpy dependency, safe for M10 server subprocess.
+- `semi/io/__init__.py`: exposes `write_artifact` and `read_manifest`.
+- `semi/io/cli.py`: `main()` function powering the `semi-run` CLI entry point.
+- `tests/test_artifact.py`: assertions across pure-Python schema tests and
+  FEM-heavy parametrized benchmark tests (skipif when dolfinx unavailable).
+- `[project.scripts]` entry in `pyproject.toml`: `semi-run = "semi.io.cli:main"`.
+
+### Changed
+- `PLAN.md`: M9 moved to completed work log; next task set to M10.
+- `CHANGELOG.md`: M9 entry added.
+
 ## [0.8.0] - M8: Submission polish
 
 ### Added

--- a/M9_VERIFICATION_CHECKLIST.md
+++ b/M9_VERIFICATION_CHECKLIST.md
@@ -1,0 +1,184 @@
+# M9 Verification Checklist
+
+The Claude Code agent completed M9 structurally but explicitly deferred
+gates 3, 4, and 5 because they require dolfinx. Run this checklist
+inside Docker before merging M9 or starting M10.
+
+```bash
+# From the repo root, on the M9 branch:
+docker compose build # if image isn't current
+```
+
+## Gate 3: FEM artifact tests on all five benchmarks
+
+```bash
+docker compose run --rm test pytest tests/test_artifact.py -v
+```
+
+**Expected:** 3 pure-Python tests + 5 parametrized FEM tests, total 8
+passed, 0 skipped, 0 failed. If any test skips inside Docker, the
+`pytest.mark.skipif` condition is wrong and must be tightened to only
+skip when dolfinx truly isn't importable.
+
+## Gates 4+5 and sanity checks S1, S3, S4, S5 (single container)
+
+Gates 4 and 5 and the sanity checks that read from `/tmp/runs` are
+combined into one `docker compose run` invocation so that the data
+generated in Gate 4 is still present when Gates 5 and S1/S3/S4/S5
+validate it. Splitting them across separate `docker compose run` calls
+would silently discard `/tmp/runs` when the Gate-4 container exits.
+
+```bash
+docker compose run --rm dev bash -c '
+ set -e
+
+ # Gate 4: generate all five run artifacts
+ rm -rf /tmp/runs
+ semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/runs
+ semi-run benchmarks/pn_1d_bias/pn_junction_bias.json --out /tmp/runs
+ semi-run benchmarks/pn_1d_bias_reverse/pn_junction_bias_reverse.json --out /tmp/runs
+ semi-run benchmarks/mos_2d/mos_cap.json --out /tmp/runs
+ semi-run benchmarks/resistor_3d/resistor.json --out /tmp/runs
+ echo "Gate 4: ls /tmp/runs/"
+ ls -la /tmp/runs/
+
+ # Gate 5: validate every manifest against the schema
+ python - <<PY
+from pathlib import Path
+import json, jsonschema
+schema = json.load(open("schemas/manifest.v1.json"))
+jsonschema.Draft7Validator.check_schema(schema)
+validator = jsonschema.Draft7Validator(schema)
+fails = 0
+for run in sorted(Path("/tmp/runs").iterdir()):
+ m = json.load(open(run / "manifest.json"))
+ errors = list(validator.iter_errors(m))
+ if errors:
+  fails += 1
+  print(f"FAIL {run.name}")
+  for e in errors:
+   print(f"  {list(e.absolute_path)}: {e.message}")
+ else:
+  print(f"OK {run.name}")
+assert fails == 0, f"{fails} manifests failed validation"
+PY
+
+ # S1: reader is stdlib-only and can load a manifest
+ python - <<PY
+import sys
+import importlib.util
+for blocked in ("dolfinx", "numpy"):
+ if blocked in sys.modules:
+  del sys.modules[blocked]
+class Blocker:
+ def find_spec(self, name, path, target=None):
+  if name.split(".")[0] in ("dolfinx", "numpy"):
+   raise ImportError(f"blocked: {name}")
+  return None
+sys.meta_path.insert(0, Blocker())
+from semi.io.reader import read_manifest
+print("stdlib-only import: OK")
+from pathlib import Path
+m = read_manifest(sorted(Path("/tmp/runs").iterdir())[0])
+print(f"read manifest OK: {m[\"run_id\"]}")
+PY
+
+ # S3: input_sha256 matches raw bytes of input.json
+ python - <<PY
+import hashlib, json
+from pathlib import Path
+run = sorted(Path("/tmp/runs").iterdir())[0]
+claimed = json.load(open(run / "manifest.json"))["input_sha256"]
+actual = hashlib.sha256(open(run / "input.json", "rb").read()).hexdigest()
+assert claimed == actual, f"sha mismatch\n  claimed: {claimed}\n  actual:  {actual}"
+print("input_sha256: OK")
+PY
+
+ # S4: MOS submesh carrier fields present
+ python - <<PY
+from pathlib import Path
+import json
+run_dir = next(d for d in Path("/tmp/runs").iterdir() if "mos" in d.name)
+m = json.load(open(run_dir / "manifest.json"))
+field_names = {f["name"] for f in m["fields"]}
+assert "phi_n" in field_names, f"MOS run missing phi_n field. Got: {field_names}"
+assert "phi_p" in field_names, f"MOS run missing phi_p field. Got: {field_names}"
+print("MOS carrier fields present: OK")
+PY
+
+ # S5: resistor bipolar IV is monotonic per leg
+ python - <<PY
+import csv
+from pathlib import Path
+run = next(d for d in Path("/tmp/runs").iterdir() if "resistor" in d.name)
+iv_files = list((run / "iv").glob("*.csv"))
+assert iv_files, "no IV files"
+for f in iv_files:
+ rows = list(csv.DictReader(open(f)))
+ voltages = [float(r["V"]) for r in rows]
+ assert len(voltages) >= 5, f"too few IV points in {f.name}: {len(voltages)}"
+ assert min(voltages) < -1e-6, f"no negative voltages in {f.name}"
+ assert max(voltages) > 1e-6, f"no positive voltages in {f.name}"
+ print(f"{f.name}: {len(voltages)} points, V in [{min(voltages):+.4e}, {max(voltages):+.4e}]")
+print("bipolar IV: OK")
+PY
+'
+```
+
+**Gate 4 expected:** Five subdirectories under `/tmp/runs/`, each
+containing `manifest.json`, `input.json`, `mesh/`, `fields/`, `iv/`,
+`convergence/`, `logs/`. Exit code 0 for every command.
+
+**Gate 5 expected:** Five `OK` lines, zero `FAIL`, exit 0.
+
+**S1 expected:** Two `OK` lines. If this fails, M10's subprocess design
+is broken and the agent's claim about `reader.py` being stdlib-only is
+wrong.
+
+**S3 expected:** `input_sha256: OK`. Common bug is hashing the
+parsed-and-re-serialized dict instead of the raw bytes of the original
+file.
+
+**S4 expected:** `MOS carrier fields present: OK`. If this fails the MOS
+submesh case was not handled — `phi_n`/`phi_p` live on the silicon
+submesh, not the parent mesh.
+
+**S5 expected:** `bipolar IV: OK`. Confirms the bipolar sweep was
+serialized correctly.
+
+## S2: Determinism (self-contained, separate invocation)
+
+S2 generates its own data, so it does not depend on `/tmp/runs` and can
+run in its own container.
+
+```bash
+docker compose run --rm dev bash -c '
+ set -e
+ rm -rf /tmp/det_a /tmp/det_b
+ semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/det_a --run-id fixed
+ semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/det_b --run-id fixed
+ python - <<PY
+import json
+a = json.load(open("/tmp/det_a/fixed/manifest.json"))
+b = json.load(open("/tmp/det_b/fixed/manifest.json"))
+a.pop("wall_time_s", None); b.pop("wall_time_s", None)
+assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True), "nondeterministic"
+print("determinism: OK")
+PY
+'
+```
+
+**Expected:** `determinism: OK`. If not, the manifest contains
+non-deterministic content (timestamps, unsorted iteration order,
+un-rounded floats) and downstream diff-based tooling will break.
+
+---
+
+## Reporting back
+
+If all gates pass, M9 is truly done — merge and start M10.
+
+If any gate fails, capture the failure output and feed it back to the
+agent as the first instruction of a follow-up session. Do not paper
+over failures by relaxing the acceptance tests; they were set
+deliberately.

--- a/PLAN.md
+++ b/PLAN.md
@@ -30,8 +30,8 @@ recombination for 1D/2D/3D devices.
 - URL: https://github.com/rwalkerlewis/kronos-semi
 - License: MIT
 - Primary branch: `main`
-- Active dev branch: `dev/submission-polish` (M8: Submission polish and
-  submission packaging in flight; M7 merged via PR #9, `a604b12`)
+- Active dev branch: `dev/final-housekeeping` (M9: Result artifact writer
+  in flight; M8 merged via PRs #10/#11)
 
 ## Current state
 
@@ -133,65 +133,7 @@ at 1%, and 3D slice plots) merged via PR #9 from
 
 ## Next task
 
-**M8: Submission polish.** In flight on
-`dev/submission-polish`, targeting PR #10 against `main`.
-
-- **Goal:** make the submission presentation-ready. No new physics,
-  no new benchmarks; this is a documentation, notebook, and release
-  pass only. Scope creep on the final PR is the submission-day
-  failure mode to avoid.
-- **Scope, in:**
-  - Sync `PLAN.md` "Current state" and `docs/ROADMAP.md` statuses to
-    reflect the M7 merge and M8 in flight.
-  Rewrite the `README.md` status section as an end-of-M7
-    capability matrix (M1-M7 shipped across PRs #2-#9).
-  - Regenerate `notebooks/01_pn_junction_1d.ipynb` using
-    `scripts/build_notebook_01.py` (current-state framing, not
-    framing (no "M1" heading).
-  - Author `notebooks/02_pn_junction_bias.ipynb` (M2-M3 content:
-    forward Shockley + reverse SNS sweeps).
-  - Author `notebooks/03_mos_cv.ipynb` (M6 content: MOS C-V with
-    the V_FB + 0.2 verifier-window disclosure in the narrative).
-  - Author `notebooks/04_resistor_3d.ipynb` (M7 content: bipolar
-    sweep, builtin-vs-gmsh comparison).
-  - Verify every notebook by actually executing it on Colab; record
-    wall time and final plot observation in the PR body. Local
-    `jupyter nbconvert --execute` is a convenience check, not a
-    verification, because FEM-on-Colab's dolfinx pin can drift from
-    the local Docker pin.
-  - Add a README "Notebooks" catalog with Colab badges.
-  - Append `[0.8.0] - M8: Submission polish` to `CHANGELOG.md`.
-  - Open PR #10, wait for CI, do not self-merge.
-  - Post-merge and only on explicit human prompt, tag `v0.2.0`.
-- **Scope, out:** any new physics code, new verifier, new benchmark
-  JSON, or schema change. If a notebook reveals a bug, note it in
-  the PR body and defer the fix to a post-submission PR.
-- **Preconditions:** M7 (PR #9) merged into `main` at `a604b12`.
-
-## M8: Submission polish execution
-
-The full M8: Submission polish narrative, per-phase commit history, reviewer-caught
-decisions (MOS ψ-reference convention, verifier window shift, Option-A
-Colab gmsh install plus the `libGLU` apt dependency), verification
-status (CI, local Docker, Colab QA), and deferred post-submission cleanups live
-in [`docs/submission-polish-log.md`](docs/submission-polish-log.md). This
-PLAN section carries only the phase index; the log is the reference
-document.
-
-| Phase | Scope                                                                 | Commit SHA   | Status                          |
-|------:|-----------------------------------------------------------------------|--------------|---------------------------------|
-| 0     | Verify `main` baseline (pytest 206, V&V 62/62, ruff clean)            | N/A          | N/A (verification-only)         |
-| 1     | Sync `PLAN.md` "Current state" and `docs/ROADMAP.md` statuses         | `1d86504`    | Done                            |
-| 2     | Rewrite `README.md` status section as end-of-M7 capability matrix  | `c7343c9`    | Done                            |
-| 3     | Regenerate `notebooks/01_pn_junction_1d.ipynb` (end-of-M7 framing) | `8ce6b10`    | Done                            |
-| 4     | Author `notebooks/02_pn_junction_bias.ipynb` (M2-M3 content)          | `f7c83b0`    | Done                            |
-| 5     | Author `notebooks/03_mos_cv.ipynb` (M6 C-V content)                   | `bc3409b`    | Done                            |
-| 6     | Author `notebooks/04_resistor_3d.ipynb` (M7 content)                  | `365da06`    | Done                            |
-| 7     | Cross-notebook consistency pass (headings, install cells, artifacts)  | `d52ca20`    | Done                            |
-| 8     | Colab QA on all four notebooks, record wall times                     | pending      | In flight (NB04 outstanding)    |
-| 9     | CHANGELOG `[0.8.0] - M8: Submission polish`, `semi/__init__.py` version bump | pending      | Pending                  |
-| 10    | Open PR #10, wait for CI, do not self-merge                           | pending      | Pending                         |
-| 11    | Post-merge and only on explicit prompt, tag `v0.2.0`                  | pending      | Pending                         |
+**M10: (next milestone).** To be defined after M9 merges.
 
 ## Roadmap
 
@@ -204,7 +146,8 @@ document.
 | M5: Refactor and test pass   | run.py split, bcs.py extracted, coverage 96.25%              | Done       | `dev/day5-refactor`; run.py 580->74, bcs.py extracted, coverage 96.25% |
 | M6: 2D MOS capacitor         | Oxide + silicon multi-region, C-V sweep                      | Done       | `dev/day6-mos-2d`; mos_cv runner, 4/4 C-V checks green, coverage 95.43% |
 | M7: 3D doped resistor        | gmsh loader, bipolar sweep, V-I 1%                           | Done       | Merged via PR #9 (`a604b12`): gmsh loader, bipolar sweep, V-I 1%      |
-| M8: Submission polish        | Notebooks, catalog, CHANGELOG, tag prep                      | In flight  | `dev/submission-polish` (PR #10): README, 4 notebooks, CHANGELOG, tag prep |
+| M8: Submission polish        | Notebooks, catalog, CHANGELOG, tag prep                      | Done       | Merged via PRs #10/#11: README, 4 notebooks, CHANGELOG, tag prep            |
+| M9: Result artifact writer   | `semi/io/artifact.py`, `schemas/manifest.v1.json`, `semi-run` CLI | In flight  | `dev/final-housekeeping`: artifact writer, schema, CLI, tests          |
 
 See `docs/ROADMAP.md` for the full per-day breakdown.
 
@@ -295,6 +238,8 @@ items.
 ## Completed work log
 
 Append-only. Newest entries on top.
+
+- **M9 (2026-04-23):** Result artifact writer; `semi/io/artifact.py`, `schemas/manifest.v1.json`, `semi-run` CLI.
 
 - **M7 (2026-04-21):** 3D doped resistor benchmark, first
   dimension extension; delivered on `dev/day7-resistor-3d` (PR #9):

--- a/PLAN.md
+++ b/PLAN.md
@@ -143,8 +143,8 @@ at 1%, and 3D slice plots) merged via PR #9 from
 - **Scope, in:**
   - Sync `PLAN.md` "Current state" and `docs/ROADMAP.md` statuses to
     reflect the M7 merge and M8 in flight.
-  - Rewrite the `README.md` status section as an end-of-Day-7
-    capability matrix (Days 1-7 shipped across PRs #2-#9).
+  Rewrite the `README.md` status section as an end-of-M7
+    capability matrix (M1-M7 shipped across PRs #2-#9).
   - Regenerate `notebooks/01_pn_junction_1d.ipynb` using
     `scripts/build_notebook_01.py` (current-state framing, not
     framing (no "M1" heading).
@@ -182,8 +182,8 @@ document.
 |------:|-----------------------------------------------------------------------|--------------|---------------------------------|
 | 0     | Verify `main` baseline (pytest 206, V&V 62/62, ruff clean)            | N/A          | N/A (verification-only)         |
 | 1     | Sync `PLAN.md` "Current state" and `docs/ROADMAP.md` statuses         | `1d86504`    | Done                            |
-| 2     | Rewrite `README.md` status section as end-of-Day-7 capability matrix  | `c7343c9`    | Done                            |
-| 3     | Regenerate `notebooks/01_pn_junction_1d.ipynb` (end-of-Day-7 framing) | `8ce6b10`    | Done                            |
+| 2     | Rewrite `README.md` status section as end-of-M7 capability matrix  | `c7343c9`    | Done                            |
+| 3     | Regenerate `notebooks/01_pn_junction_1d.ipynb` (end-of-M7 framing) | `8ce6b10`    | Done                            |
 | 4     | Author `notebooks/02_pn_junction_bias.ipynb` (M2-M3 content)          | `f7c83b0`    | Done                            |
 | 5     | Author `notebooks/03_mos_cv.ipynb` (M6 C-V content)                   | `bc3409b`    | Done                            |
 | 6     | Author `notebooks/04_resistor_3d.ipynb` (M7 content)                  | `365da06`    | Done                            |

--- a/PLAN.md
+++ b/PLAN.md
@@ -133,7 +133,9 @@ at 1%, and 3D slice plots) merged via PR #9 from
 
 ## Next task
 
-**M10: (next milestone).** To be defined after M9 merges.
+**M10: HTTP server (see docs/IMPROVEMENT_GUIDE.md §4).** FastAPI `POST /solve`,
+`GET /runs/{id}`, WebSocket progress stream; worker pool via ProcessPoolExecutor.
+Consumes the M9 artifact directory layout. Deliverable: new `kronos_server/` package.
 
 ## Roadmap
 

--- a/benchmarks/mos_2d/README.md
+++ b/benchmarks/mos_2d/README.md
@@ -37,7 +37,7 @@ and `C_sim = dQ_gate/dV_gate` via centered finite difference.
 ## Verification target
 
 Depletion-approximation C-V curve within 10% in the window
-[V_FB + 0.2, V_T - 0.1] V. For the ideal-gate Day-6 device under our
+[V_FB + 0.2, V_T - 0.1] V. For the ideal-gate M6 device under our
 psi=0-at-intrinsic BC convention:
 
     V_FB = phi_ms - phi_F = 0 - 0.417 V = -0.417 V

--- a/docs/IMPROVEMENT_GUIDE.md
+++ b/docs/IMPROVEMENT_GUIDE.md
@@ -1,0 +1,613 @@
+# kronos-semi: Improvement Guide
+
+**Purpose.** This document is the ground-truth roadmap for transforming kronos-semi
+from a KronosAI submission artifact into a production engine that sits behind a
+COMSOL-Semiconductor-style web GUI. It is written to be consumed by both human
+contributors and coding agents (Claude, Codex, Cursor, etc.); read it alongside
+`PLAN.md` and `docs/ROADMAP.md`.
+
+Nothing in here is aspirational hand-waving. Every milestone below states its
+input, its acceptance test, and its dependency on prior milestones.
+
+---
+
+## 1. Honest current state (as of v0.8.0)
+
+What exists and works:
+
+- `semi/` package (~3,300 LOC) with a five-layer architecture; Layer 3
+ (pure-Python core) has no dolfinx dependency and is independently testable.
+- JSON schema (Draft-07, enforced via `jsonschema`) covering mesh, regions,
+ doping, contacts, physics, solver, output.
+- Builtin meshes in 1D/2D/3D plus gmsh `.msh` loader with physical groups.
+- Equilibrium Poisson, coupled drift-diffusion in Slotboom form, SRH
+ recombination with configurable trap energy.
+- Ohmic and ideal-gate contacts; multi-region Poisson with Si/SiO2 via
+ `create_submesh`.
+- Adaptive bias-ramp continuation with halving + growth, bipolar sweep support.
+- Five shipped benchmarks (`pn_1d`, `pn_1d_bias`, `pn_1d_bias_reverse`,
+ `mos_2d`, `resistor_3d`), each with a verifier that asserts closed-form
+ physical correctness.
+- MMS verification for Poisson and DD, discrete-conservation checks,
+ mesh-convergence ladder. 206 tests, 62/62 V&V PASS.
+- Four Colab notebooks that install FEniCSx via fem-on-colab and run each
+ benchmark end-to-end.
+
+What does *not* exist (the gap between "submission" and "production engine"):
+
+- **No machine-readable result serialization.** `SimulationResult` is a Python
+ dataclass holding live PETSc/dolfinx objects. There is no JSON/HDF5/VTU
+ output suitable for a detached UI process to consume.
+- **No server surface.** No FastAPI, no job queue, no result cache, no WebSocket
+ progress channel. A UI cannot talk to the engine today.
+- **No GPU.** Every solve is MUMPS LU on CPU via PETSc. In 3D this is the
+ bottleneck; in 2D it is fine but does not scale.
+- **Mesh tagging via JSON is weak.** `regions_by_box` and `facets_by_plane`
+ force axis-aligned geometry. Real devices need gmsh physical groups from a
+ geometry-definition format the UI can author.
+- **No transient solver, no AC small-signal, no Fermi-Dirac, no field-dependent
+ mobility, no Schottky contacts, no tunneling.** COMSOL Semiconductor has all
+ of these. The gap is large but the scaffolding is clean.
+- **Schema is missing a `version` field.** Without one, UI and engine versions
+ will drift silently.
+- **No artifact/result directory contract.** Runners write XDMF into
+ `./results/` but the on-disk layout is not documented or typed.
+- **`DEFAULT_PETSC_OPTIONS` hard-code direct LU.** Fine for benchmarks up to
+ ~50k DOFs; unusable for real 3D.
+
+Bottom line: the numerics are sound and the decomposition is clean. The work
+ahead is almost entirely about (a) making the engine addressable from outside
+Python, (b) making results consumable without a dolfinx install, and (c)
+scaling the linear solver. The physics engine itself only needs incremental
+extensions.
+
+---
+
+## 2. Design principles (non-negotiable)
+
+These are the constraints every subsequent milestone must respect. They are
+the invariants that let a GUI be built without constantly re-ploughing the
+engine.
+
+**P1. The JSON is the contract.** The UI never calls Python functions
+directly. The UI emits JSON, the engine consumes JSON, the engine emits a
+result artifact. No shared memory, no pickled objects, no language coupling.
+
+**P2. Results are plain files.** A completed simulation is a directory on
+disk (or object-store prefix) containing a `manifest.json`, a `mesh.vtu` (or
+`.bp` / `.xdmf+h5`), one `field_<name>.vtu` per scalar/vector field, and one
+`iv.csv` per swept quantity. A UI reads these with stock libraries (vtk.js,
+numpy, pandas); no dolfinx import ever happens on the UI side.
+
+**P3. The engine is stateless between jobs.** Each `POST /solve` gets a fresh
+MPI process (or worker pool slot). State that must persist across jobs lives
+in the object store, never in RAM.
+
+**P4. The schema versions.** Every JSON input carries
+`"schema_version": "1.2.0"`. Engine refuses to run mismatched major versions
+and warns on minor skew.
+
+**P5. GPU is opt-in, not load-bearing.** The CPU path stays as the reference
+and V&V truth. GPU accelerates the linear solver and the assembly of large
+forms; it never changes what the result *is*, only how fast.
+
+**P6. Nothing in the engine API leaks PETSc or UFL types.** The boundary types
+are: JSON in, numpy arrays + mesh files + manifest dict out. Anything else is
+an implementation detail.
+
+---
+
+## 3. Result artifact contract (ship this first, everything else depends on it)
+
+Every successful solve writes a directory with this layout:
+
+```
+<run_id>/
+├── manifest.json # schema-versioned metadata
+├── input.json # exact JSON that was solved (copy)
+├── mesh/
+│ ├── mesh.xdmf # topology + geometry
+│ └── mesh.h5
+├── fields/
+│ ├── psi.bp # potential (ADIOS2 BP5 or vtu)
+│ ├── n.bp # electron density
+│ ├── p.bp # hole density
+│ ├── N_net.bp # net doping
+│ ├── E.bp # electric field (vector)
+│ └── J.bp # current density (vector, per bias step)
+├── iv/
+│ └── <contact>.csv # V, J_n, J_p, J_tot per sweep step
+├── convergence/
+│ └── snes.csv # per-step Newton iter count, residual norms
+└── logs/
+ └── engine.log
+```
+
+### `manifest.json` schema (v1)
+
+```json
+{
+ "schema_version": "1.0.0",
+ "engine": {"name": "kronos-semi", "version": "0.9.0", "commit": "..."},
+ "run_id": "2026-04-23T16-32-11Z_pn_bias_a1b2c3",
+ "status": "completed",
+ "wall_time_s": 12.4,
+ "input_sha256": "...",
+ "solver": {
+ "type": "bias_sweep",
+ "backend": "petsc-cpu-mumps",
+ "n_dofs": 1200,
+ "n_steps": 21,
+ "converged": true
+ },
+ "fields": [
+ {"name": "psi", "units": "V", "path": "fields/psi.bp", "rank": 0},
+ {"name": "n", "units": "m^-3", "path": "fields/n.bp", "rank": 0},
+ {"name": "p", "units": "m^-3", "path": "fields/p.bp", "rank": 0},
+ {"name": "E", "units": "V/m", "path": "fields/E.bp", "rank": 1},
+ {"name": "J", "units": "A/m^2","path": "fields/J.bp", "rank": 1}
+ ],
+ "sweeps": [
+ {"kind": "voltage", "contact": "cathode",
+ "path": "iv/cathode.csv", "n_steps": 21, "bipolar": false}
+ ],
+ "mesh": {
+ "path": "mesh/mesh.xdmf", "dimension": 1,
+ "n_cells": 400, "n_vertices": 401,
+ "regions": [{"name": "silicon", "tag": 1, "material": "Si"}]
+ },
+ "warnings": []
+}
+```
+
+The UI reads the manifest first; everything else is lazy-loaded.
+
+---
+
+## 4. Milestones (M9 onward; M1–M8 already shipped)
+
+Each milestone is self-contained, has a single deliverable, and has an
+acceptance test that can be demanded of a coding agent. Do them roughly in
+order, but M9/M10 are load-bearing — everything after assumes them.
+
+### M9 — Result artifact writer + manifest
+
+**Why:** Nothing downstream works without a stable, machine-readable output.
+This is the single highest-value piece of work on the list.
+
+**Deliverable:** New module `semi/io/artifact.py` exposing:
+
+```python
+def write_artifact(result: SimulationResult, out_dir: Path, run_id: str) -> Path:
+ """Write the full result tree under out_dir/run_id/. Returns the run dir."""
+```
+
+Plus a new CLI entry point `semi-run <input.json> [--out runs/]` that wraps
+`semi.run.run` and calls `write_artifact`.
+
+**Acceptance tests (gate for merge):**
+
+1. For each of the five shipped benchmarks, `semi-run` produces a run dir
+ validated against a new JSON-schema file `schemas/manifest.v1.json`.
+2. A pure-Python reader `semi.io.artifact.read_manifest(run_dir)` round-trips.
+3. A Python-only (no dolfinx) consumer script can read `fields/psi.bp` via
+ `adios2` and `iv/cathode.csv` via `numpy.loadtxt` and plot them.
+4. New test file `tests/test_artifact.py` with ≥10 assertions.
+
+**Estimated scope:** 2 days. ~400 LOC + schema + tests.
+
+**Dependencies:** none. Can start today.
+
+---
+
+### M10 — HTTP server: `POST /solve`, `GET /runs/{id}`
+
+**Why:** This is what lets a browser UI talk to the engine.
+
+**Deliverable:** New top-level package `kronos_server/` (kept out of `semi/` to
+preserve the pure-engine boundary):
+
+```
+kronos_server/
+├── __init__.py
+├── app.py # FastAPI app
+├── jobs.py # job queue + worker spawning
+├── storage.py # LocalFS + S3 backends for run dirs
+├── models.py # pydantic models mirroring schemas/
+└── routes/
+ ├── solve.py # POST /solve -> {run_id, status_url}
+ ├── runs.py # GET /runs/{id}, GET /runs/{id}/manifest
+ └── stream.py # WebSocket /runs/{id}/stream for SNES progress
+```
+
+**Endpoints:**
+
+| Method | Path | Purpose |
+|-------:|----------------------------|-------------------------------------------|
+| POST | `/solve` | Submit JSON, get back `{run_id, status}` |
+| GET | `/runs/{id}` | Status + manifest |
+| GET | `/runs/{id}/fields/{name}` | Stream a field file |
+| GET | `/runs/{id}/iv/{contact}` | Stream CSV |
+| WS | `/runs/{id}/stream` | Live SNES residual norms during solve |
+| GET | `/materials` | Material DB dump for UI autocomplete |
+| GET | `/schema` | The JSON schema itself, for UI validation |
+
+**Worker model:** start with a `ProcessPoolExecutor` of size `N_CPU / 4` (each
+worker can use 4-way MPI). Redis + Celery is a later upgrade, not a day-1
+requirement.
+
+**Acceptance tests:**
+
+1. End-to-end: `curl -X POST /solve -d @pn_junction.json` → polling `/runs/{id}`
+ yields `status: "completed"` in under 30 s.
+2. WebSocket client sees at least `n_steps` progress messages during a bias
+ sweep.
+3. A second client hitting `/runs/{id}/manifest` while the job runs gets
+ `status: "running"`, not a 500.
+4. Integration test matrix covers all five benchmarks via the HTTP API.
+
+**Estimated scope:** 3 days. ~700 LOC + tests.
+
+**Dependencies:** M9.
+
+---
+
+### M11 — Schema versioning + UI-facing schema companion
+
+**Why:** A UI form-builder needs introspectable, versioned schemas, not just
+a validator.
+
+**Deliverable:**
+
+- Add `schema_version` as a required top-level JSON field; validator refuses
+ mismatched majors.
+- Split `semi/schema.py` into `schemas/input.v1.json` (Draft-07) + a Python
+ loader that imports it. The JSON-file schema is what the UI pulls from
+ `GET /schema` and feeds to a form generator (JSONForms, rjsf, etc.).
+- Add `title`, `description`, `default`, `examples`, and `enum` annotations
+ to every schema node so form-builders render sensible labels and help text
+ without a separate UI config.
+- Publish the schema on every git tag to `https://schemas.kronos-semi.org/input/v1.0.0.json`
+ (or similar — a static GitHub Pages works).
+
+**Acceptance tests:**
+
+1. `jsonschema-cli validate schemas/input.v1.json` against every benchmark
+ JSON passes.
+2. All existing tests still pass — schema refactor is a lift-and-shift.
+3. New test asserts every node with `type: object` has a `description`.
+
+**Estimated scope:** 1 day.
+
+**Dependencies:** M9 (so the manifest schema and input schema can share a
+layout).
+
+---
+
+### M12 — Mesh input beyond axis-aligned boxes
+
+**Why:** Real devices are not boxes. UI will export gmsh `.geo` or `.msh`
+files; current engine support is partial.
+
+**Deliverable:**
+
+- Extend `semi/mesh.py::_build_from_file` to cover XDMF (currently
+ `NotImplementedError`).
+- Add a `geometry` input alternative to `mesh` in the schema:
+
+```json
+"geometry": {
+ "source": "gmsh_geo",
+ "path": "device.geo",
+ "characteristic_length": 5.0e-8,
+ "physical_groups": {
+ "silicon": {"dim": 2, "tag": 1},
+ "oxide": {"dim": 2, "tag": 2},
+ "gate": {"dim": 1, "tag": 10}
+ }
+}
+```
+
+The engine calls gmsh in a subprocess to produce the `.msh`, caches it by
+content hash, then loads it.
+
+- Add a 2D MOSFET benchmark (`benchmarks/mosfet_2d/`) that exercises the new
+ geometry input: source/drain/gate/body contacts, non-axis-aligned doping.
+
+**Acceptance tests:**
+
+1. `.geo` → `.msh` → solve → IV curve matches SPICE-level analytical
+ approximation within 20% at V_DS = 0.1 V.
+2. Cache hit avoids re-meshing on identical `(geo_hash, char_length)`.
+3. Mesh-convergence test on the MOSFET benchmark.
+
+**Estimated scope:** 3 days.
+
+**Dependencies:** M9, M11.
+
+---
+
+### M13 — Transient solver
+
+**Why:** Every C-V, capacitance-transient-spectroscopy, and realistic device
+characterization involves time. Missing transient is the single biggest
+physics gap relative to COMSOL.
+
+**Deliverable:**
+
+- `semi/runners/transient.py` implementing backward-Euler and BDF2 time
+ stepping on the coupled (psi, phi_n, phi_p) system.
+- Schema extension: `"solver": {"type": "transient", "t_end": 1e-9, "dt": 1e-12}`
+ plus adaptive time-stepping options mirroring the bias-continuation options.
+- Benchmark `benchmarks/pn_1d_turnon/`: forward-bias step response, verify
+ charge storage and RC time constant.
+
+**Acceptance tests:**
+
+1. Steady-state limit of the transient solver matches `run_bias_sweep` within
+ numerical noise.
+2. Turn-on benchmark: minority-carrier lifetime extracted from the transient
+ matches the SRH `tau_n` used as input within 5%.
+3. BDF2 convergence rate verified against MMS.
+
+**Estimated scope:** 4 days.
+
+**Dependencies:** M9.
+
+---
+
+### M14 — AC small-signal analysis
+
+**Why:** Capacitance-voltage, admittance-spectroscopy, and high-frequency
+characterization all need AC. The math reuses the transient Jacobian.
+
+**Deliverable:**
+
+- `semi/runners/ac_smallsignal.py`: at each DC operating point, assemble
+ `(J + i omega M)` and solve the complex linear system for the AC response.
+- Complex-valued PETSc build requirement documented.
+- MOS C-V benchmark upgraded to compute true C(V) via AC admittance rather
+ than numerical differentiation of Q(V).
+
+**Acceptance tests:**
+
+1. Low-frequency limit of AC capacitance matches `dQ/dV` from the existing
+ MOS benchmark within 2%.
+2. Frequency sweep produces the expected MOS C-V frequency dispersion for
+ interface-trap models (once traps are added; until then, just flat).
+
+**Estimated scope:** 4 days.
+
+**Dependencies:** M9, M13 (for the mass matrix infrastructure).
+
+---
+
+### M15 — GPU linear solver path
+
+**Why:** Above ~200k DOFs the MUMPS LU factorization dominates wall time. 3D
+FinFET-class problems will be in the millions of DOFs and CPU-LU is hopeless.
+GPU-accelerated iterative solvers change the scaling law.
+
+**What can actually run on GPU** (be realistic about this):
+
+| Stage | GPU-suitable? | Library |
+|--------------------------------|------------------------------|-------------------------------|
+| Mesh build, tagging | No (serial graph operations) | n/a |
+| UFL → assembly | Yes, with dolfinx-cuda/KOKKOS| dolfinx-cuda (experimental) |
+| Jacobian assembly | Partial; the dominant O(N) | dolfinx-cuda |
+| Linear solve (Krylov) | **Yes — biggest win** | PETSc + HIP/CUDA, AMGX, hypre |
+| Preconditioner setup (AMG) | Yes | AMGX, hypre-BoomerAMG |
+| Nonlinear SNES loop overhead | No (negligible cost) | n/a |
+| I/O (writing fields) | No | n/a |
+
+**Realistic plan:** the 80/20 is "PETSc built against CUDA/HIP, Jacobian
+solved on GPU via AMGX or hypre on device." Do not try to port assembly to
+GPU yet — dolfinx-cuda is experimental and moving fast.
+
+**Deliverable:**
+
+- `semi/solver.py` grows a `backend: str = "cpu-mumps" | "gpu-amgx" | "gpu-hypre"`
+ parameter.
+- CPU path untouched, bit-identical to current output.
+- GPU path: Jacobian assembled on CPU, copied to GPU, solved with AMGX (or
+ PETSc-GAMG-on-device); solution copied back.
+- Benchmark: 3D FinFET-scale mesh (≥500k DOFs) showing ≥5× speedup over
+ CPU-MUMPS on an A100 or MI300X.
+- CI covers CPU path only; GPU path has a separate self-hosted runner or is
+ left to nightly.
+
+**Acceptance tests:**
+
+1. On the existing benchmarks, GPU backend produces results within 1e-8
+ relative L2 of the CPU-MUMPS reference.
+2. On the new large-3D benchmark, wall-time speedup ≥5× for the linear-solve
+ portion alone.
+3. Fallback: GPU backend gracefully degrades to CPU if no device is found,
+ with a warning in the manifest.
+
+**Estimated scope:** 5–7 days, dominated by environment setup.
+
+**Dependencies:** M9 (needs artifact writer for timing instrumentation).
+
+---
+
+### M16 — Physics completeness pass
+
+**Why:** To mimic COMSOL Semiconductor properly we need the models engineers
+actually use daily.
+
+**Deliverable (do these in order, each a separate PR):**
+
+1. **Caughey-Thomas field-dependent mobility.** Closed-form velocity-saturation
+ model. ~200 LOC.
+2. **Lombardi surface-mobility model.** Needed for realistic MOSFET I-V in
+ the inversion regime. ~300 LOC.
+3. **Auger recombination.** `R_Auger = (C_n n + C_p p)(np - n_i^2)`.
+ ~100 LOC.
+4. **Fermi-Dirac statistics.** Replace `exp(±psi)` with Fermi integrals
+ (use Blakemore approximation for speed, full FDI for validation). Gate
+ with a `statistics: "fermi-dirac"` schema option; Boltzmann remains the
+ default. ~400 LOC.
+5. **Schottky contacts.** Thermionic-emission boundary condition. ~300 LOC.
+6. **Band-to-band (Kane) and trap-assisted (Hurkx) tunneling.** Required for
+ any useful diode or floating-gate simulation. ~600 LOC.
+
+Each ships with its own benchmark and verifier.
+
+**Acceptance tests:** one analytical-or-SPICE comparison per model.
+
+**Estimated scope:** 2–4 days per item. Don't batch; one PR per model.
+
+**Dependencies:** M9, M11.
+
+---
+
+### M17 — Heterojunction / position-dependent band structure
+
+**Why:** AlGaAs/GaAs, InGaAs/InP, SiGe/Si — none of this works without
+position-varying electron affinity `chi(x)` and bandgap `Eg(x)`.
+
+**Deliverable:** extend the material model and Poisson/continuity kernels
+to read `chi` and `Eg` as cellwise DG0 fields. Benchmark: AlGaAs/GaAs HEMT
+or SiGe HBT.
+
+**Estimated scope:** 4 days.
+
+**Dependencies:** M9, M16.4 (Fermi-Dirac, because heterojunctions break the
+nondegenerate approximation at the barrier).
+
+---
+
+### M18 — UI: first cut
+
+**Why:** At this point the engine has everything; the UI is what turns this
+into a product.
+
+**Not in scope of this repo.** Mentioned here so the engine team knows what
+invariants the UI relies on.
+
+Recommended stack: React + TypeScript, three.js for 3D mesh visualization,
+vtk.js or plotly for field rendering, JSONForms for schema-driven device
+setup. The UI is a separate repo that consumes this engine's JSON schema
+and HTTP API.
+
+---
+
+## 5. GPU section (expanded)
+
+### What is worth accelerating
+
+Profile first, then accelerate. But a general ordering of the biggest wins:
+
+1. **Linear solve (Krylov + AMG preconditioner).** 60–85% of wall time on
+ problems above ~100k DOFs. PETSc has first-class CUDA and HIP backends;
+ AMGX (NVIDIA) and rocALUTION (AMD) are drop-in options. **Biggest single
+ lever.**
+2. **Jacobian assembly.** 10–25% of wall time. dolfinx-cuda (still
+ experimental as of 2026) handles this via batched cellwise kernels. The
+ UFL-to-GPU-kernel path is not yet production-grade; revisit in a year.
+3. **Field interpolation + post-processing.** Minor (<5%) but trivially GPU
+ with CuPy for things like computing `E = -grad psi` on a dense grid.
+4. **Multi-job parallelism.** Less "GPU" and more "throughput": run 100
+ parameter-sweep jobs, each on its own small GPU slice. MIG partitions on
+ A100/H100 or MPS on older cards. This is actually the most impactful
+ pattern for a parameter-exploration GUI.
+
+### What is *not* worth GPU-ifying (yet)
+
+- **Meshing.** Gmsh is not GPU-friendly; time spent here is negligible
+ anyway.
+- **SNES nonlinear outer loop.** Host-side Python; totally negligible.
+- **I/O.** Writing XDMF/BP is CPU-bound and fine that way.
+- **Schema validation, JSON parsing, job dispatch.** Obviously host.
+
+### Concrete engineering path
+
+Phase 1 (M15): PETSc built with `--with-cuda` or `--with-hip`, add
+`mat_type: aijcusparse` and `vec_type: cuda` as solver options. Use AMGX
+(nvidia/AMGX) as the preconditioner via `-pc_type amgx`. Engine exposes a
+`solver.backend` field. All assembly stays CPU; matrix and vectors are
+moved to device for the Krylov solve.
+
+Phase 2 (post-M15, optional): experiment with dolfinx-cuda for assembly.
+Only if Phase 1 profiling shows assembly is now the bottleneck.
+
+Phase 3 (post-M18, throughput): MIG partitioning for parameter sweeps.
+Relevant when the UI ships and users run design-of-experiments studies.
+
+### Honest caveat
+
+PETSc-on-GPU is mature for structured problems (Poisson, elliptic). For
+coupled drift-diffusion with exponential nonlinearities, the Jacobian
+conditioning is terrible and AMG can stall. Expect to spend real time tuning
+preconditioner parameters per problem class. A 5× speedup is realistic; a
+50× speedup is marketing.
+
+---
+
+## 6. UI integration checklist (what the UI team will ask for)
+
+The engine is ready for a UI when all of these are green:
+
+- [ ] M9 complete: runs produce a stable on-disk artifact.
+- [ ] M10 complete: HTTP API exposes solve, status, stream, artifact fetch.
+- [ ] M11 complete: schema is versioned, richly annotated, published.
+- [ ] `GET /materials` returns the material DB.
+- [ ] `GET /schema` returns the input schema.
+- [ ] `GET /capabilities` returns which physics models this engine build
+ supports (e.g., `{"transient": true, "ac": false, "gpu": true, ...}`).
+- [ ] WebSocket stream emits at least one message per SNES iteration with
+ `{"residual_norm": ..., "iteration": ..., "bias_step": ...}`.
+- [ ] CORS configured on the HTTP server for the UI's dev origin.
+- [ ] OpenAPI spec auto-generated (FastAPI does this for free).
+- [ ] At least one end-to-end integration test where a browser-like client
+ submits a JSON and visualizes the result manifest.
+
+---
+
+## 7. What coding agents should do when picking up work here
+
+1. **Read PLAN.md and ROADMAP.md before touching code.** "Current state" and
+ "Next task" are the source of truth for what is done.
+2. **Pick exactly one milestone.** Do not mix M9 and M10 in a single PR. Do
+ not start M11 before M9 is merged.
+3. **Write the acceptance test first.** Every milestone above states its
+ acceptance test explicitly. Make it fail, then make it pass.
+4. **Respect the layer boundaries.** Layer 3 (pure-Python core) never imports
+ dolfinx. The new `kronos_server/` package is Layer 6 and never imports
+ PETSc or UFL types into its public API.
+5. **Do not rewrite the physics kernels.** The UFL forms are correct and
+ MMS-verified. If you think you see a bug, write a failing MMS test first;
+ 90% of the time the "bug" is a scaling-convention confusion that the
+ existing tests already cover.
+6. **Never skip `make_scaling_from_config`.** The raw equations have a
+ Jacobian condition number >1e30. This is not negotiable.
+7. **Use `snes_rtol: 1.0e-14` only in tests.** Production defaults are looser
+ and documented in `DEFAULT_PETSC_OPTIONS`.
+
+---
+
+## 8. Anti-goals (things to actively *not* do)
+
+- **Do not build a bespoke mesh format.** Use XDMF/ADIOS2-BP and gmsh. They
+ work, they're standard, the VTK/ParaView/vtk.js ecosystem reads them for
+ free.
+- **Do not embed a physics DSL.** The JSON schema is the DSL. If it gets
+ inadequate, extend the schema; do not invent a second configuration layer.
+- **Do not pickle `SimulationResult`.** It contains live PETSc handles; pickles
+ break across processes. Always go through `write_artifact`.
+- **Do not add `requests`-based auth to the HTTP server before a real
+ deployment need.** Rate limiting and API keys can wait until there is a
+ second user.
+- **Do not port the whole codebase to Rust or C++ for performance.** The
+ bottleneck is the linear solve, not Python. M15 addresses it in the right
+ place.
+- **Do not claim COMSOL parity.** COMSOL has 30 years of model variations,
+ convergence hacks, and user-reported-edge-cases. kronos-semi will have a
+ useful, correct subset. Be honest about that in marketing.
+
+---
+
+## 9. Change log for this document
+
+- **2026-04-23** — initial version, written post-M8.

--- a/docs/M9_STARTER_PROMPT.md
+++ b/docs/M9_STARTER_PROMPT.md
@@ -1,0 +1,171 @@
+# Starter prompt: M9 — Result Artifact Writer
+
+Paste this into Claude Code, Cursor, or whatever agent you use. It is
+self-contained; the agent should not need to ask clarifying questions.
+
+---
+
+You are working on `kronos-semi` (https://github.com/rwalkerlewis/kronos-semi), a
+FEniCSx-based JSON-driven finite-element semiconductor device simulator.
+
+Before writing any code, read the following repository files in this order:
+
+1. `PLAN.md`
+2. `docs/ROADMAP.md`
+3. `docs/ARCHITECTURE.md`
+4. `docs/IMPROVEMENT_GUIDE.md` — **your task is M9 in that document**
+5. `semi/run.py`
+6. `semi/runners/bias_sweep.py`
+7. `semi/runners/equilibrium.py`
+8. `semi/runners/mos_cv.py`
+9. `semi/schema.py`
+
+Do not modify any physics kernels or existing tests. Your changes are purely
+additive: a new module, a new CLI entry point, a new schema file, and a new
+test file.
+
+## Task
+
+Implement M9 as specified in `docs/IMPROVEMENT_GUIDE.md` section 4:
+
+1. Create `schemas/manifest.v1.json` — a JSON-schema Draft-07 file describing
+ the manifest contract in section 3 of the improvement guide. Every property
+ must have `description`. Required fields: `schema_version`, `engine`,
+ `run_id`, `status`, `wall_time_s`, `input_sha256`, `solver`, `fields`,
+ `mesh`. Optional: `sweeps`, `warnings`.
+
+2. Create `semi/io/__init__.py` and `semi/io/artifact.py` exposing:
+
+ ```python
+ def write_artifact(
+ result: "SimulationResult",
+ out_dir: Path,
+ run_id: str | None = None,
+ input_json_path: Path | None = None,
+ ) -> Path:
+ """
+ Write the full result tree under out_dir/<run_id>/ and return the path.
+ If run_id is None, generate one as
+ f"{iso_timestamp}_{cfg['name']}_{short_sha}"
+ where short_sha is the first 7 chars of sha256(input_json_bytes).
+ """
+
+ def read_manifest(run_dir: Path) -> dict:
+ """Load and JSON-schema-validate manifest.json from a run dir."""
+ ```
+
+ Output layout exactly as specified in section 3 of the improvement guide.
+
+3. Field export rules:
+ - Write `psi`, `n`, `p`, `N_net` always (all solver types produce these).
+ - Write `E = -grad(psi)` as a DG0 vector field.
+ - For `drift_diffusion` and `bias_sweep` runs, additionally write `phi_n`,
+ `phi_p`, and per-step `J_n`, `J_p` (these can be time-series in a single
+ BP file).
+ - Use `dolfinx.io.VTXWriter` with ADIOS2 BP5 backend. If ADIOS2 is not
+ available, fall back to `XDMFFile` and note the fallback in
+ `manifest.warnings`.
+
+4. IV export: if `result.iv` is non-empty, write `iv/<contact>.csv` with header
+ `V,J_n,J_p,J_total`. For now, populate `J_total = result.iv[i]["J"]` and
+ leave `J_n`, `J_p` as `NaN` — splitting those is M10's problem.
+
+5. Convergence export: write `convergence/snes.csv` with columns
+ `bias_step,V_applied,iterations,reason,converged` from the per-step info
+ the runners already record. For equilibrium runs, this is a single row.
+
+6. New CLI `semi-run`, registered via `pyproject.toml`:
+
+ ```
+ semi-run <path-to-input.json> [--out runs/] [--run-id <id>]
+ ```
+
+ Prints the run directory path on stdout on success. Nonzero exit on any
+ failure.
+
+7. Tests in `tests/test_artifact.py`:
+ - For each of the five benchmarks in `benchmarks/*/`, run it through
+ `semi.run.run`, call `write_artifact`, then `read_manifest`, and assert
+ the manifest validates against `schemas/manifest.v1.json`.
+ - Assert every field listed in `manifest.fields[].path` exists on disk.
+ - Assert every sweep file listed in `manifest.sweeps[].path` is readable
+ as CSV and has `n_steps + 1` rows (header + data).
+ - Assert `manifest.input_sha256` matches the actual SHA256 of the input
+ JSON file.
+ - Use `pytest.mark.skipif` to skip the FEM-heavy tests when dolfinx is
+ unavailable; the pure-Python tests (schema validation round-trip) must
+ still run in the pure-Python CI job.
+
+## Constraints
+
+- No changes to `semi/physics/`, `semi/mesh.py`, `semi/bcs.py`,
+ `semi/continuation.py`, or any existing test.
+- No `import dolfinx` in `semi/io/artifact.py` at module top level. Do the
+ imports inside functions, matching the existing convention in `semi/run.py`.
+- The manifest JSON must be deterministic given identical input — sort keys,
+ fix float precision at 10 significant figures, use ISO-8601 UTC for the
+ `run_id` timestamp.
+- The `kronos_server/` package from M10 will consume this artifact. Design
+ `read_manifest` so it can be called from a subprocess that has no dolfinx
+ or numpy installed (pure-stdlib JSON only). If you need to, split the
+ reader out into `semi/io/reader.py` that has only stdlib dependencies.
+
+## Acceptance criteria (gate for merge)
+
+Run these commands; all must succeed:
+
+```bash
+# 1. New schema is valid JSON-schema Draft-07
+python -c "import json, jsonschema; s = json.load(open('schemas/manifest.v1.json')); jsonschema.Draft7Validator.check_schema(s)"
+
+# 2. Existing tests still pass
+pytest -q
+
+# 3. New artifact tests pass
+pytest -q tests/test_artifact.py
+
+# 4. CLI works end-to-end
+semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/runs
+ls /tmp/runs/*/manifest.json
+
+# 5. The manifest validates against its own schema
+python -c "
+import json, jsonschema
+from pathlib import Path
+run_dir = sorted(Path('/tmp/runs').iterdir())[-1]
+m = json.load(open(run_dir / 'manifest.json'))
+s = json.load(open('schemas/manifest.v1.json'))
+jsonschema.Draft7Validator(s).validate(m)
+print('manifest OK:', run_dir)
+"
+
+# 6. Lint/format clean
+ruff check semi/ tests/ schemas/
+```
+
+## What to do when finished
+
+Update `PLAN.md`:
+- Move the "M9" line from "Next task" to "Completed work log".
+- Set "Current state" to reflect artifact writer shipped.
+- Set "Next task" to "M10: HTTP server (see docs/IMPROVEMENT_GUIDE.md §4)".
+
+Update `CHANGELOG.md` with a `[0.9.0] - M9: Result artifact writer` entry
+following the format of the existing entries.
+
+Do not bump the version number yourself in `semi/__init__.py`. The maintainer
+will cut the release.
+
+## What not to do
+
+- Do not start M10. The HTTP server is a separate PR.
+- Do not add new physics, new solver backends, new benchmarks, or new
+ materials.
+- Do not refactor `semi/run.py` or the runners. If you find you need to, stop
+ and ask first.
+- Do not change the existing JSON input schema in this PR. Any schema changes
+ belong in M11.
+
+When you are done, post a single summary message listing: files added, files
+modified (should be only `PLAN.md`, `CHANGELOG.md`, `pyproject.toml`),
+acceptance-test output, and any open questions you had to resolve.

--- a/docs/PHYSICS.md
+++ b/docs/PHYSICS.md
@@ -363,7 +363,7 @@ bias.
 #### The lambda2 / L_D^2 trap
 
 `Scaling.lambda2` returns the dimensionless ratio $\lambda^2 = L_D^2 /
-L_0^2$ (Section 2.3). Early Day-1 versions of `semi/physics/poisson.py`
+L_0^2$ (Section 2.3). Early M1 versions of `semi/physics/poisson.py`
 used `sc.lambda2` directly as the Laplacian coefficient. Because the
 mesh is in physical meters (Invariant 3, not $L_0$ units), this
 suppressed diffusion by $L_0^2$ ($\sim 10^{-12}$ on a micron device)
@@ -477,7 +477,7 @@ permittivity; semiconductor-specific fields are zero on them.
 
 ## 5. Verification & Validation
 
-This section documents the Day-4 V&V suite and its results. The code
+This section documents the M4 V&V suite and its results. The code
 lives under `semi/verification/`, the runner is
 `scripts/run_verification.py`, artifacts land under
 `results/mms_poisson/`, `results/mesh_convergence/`,
@@ -525,7 +525,7 @@ is within an order of magnitude of the triangle error at N = 64
 Module: `semi/verification/mesh_convergence.py`. Subcommand:
 `run_verification.py mesh_convergence`.
 
-A mesh sweep over N in [50, 100, 200, 400, 800, 1600] on the Day-1
+A mesh sweep over N in [50, 100, 200, 400, 800, 1600] on the M1
 equilibrium pn junction reports V_bi, peak |E|, depletion width W,
 Newton iterations, and solve time. Errors are recorded in two ways:
 against the depletion-approximation reference (which is itself an
@@ -696,7 +696,7 @@ silicon) therefore requires psi_gate = psi_body, giving
 
     V_FB = phi_ms - phi_F
 
-not the textbook V_FB = phi_ms. For the ideal-gate Day-6 device
+not the textbook V_FB = phi_ms. For the ideal-gate M6 device
 (phi_ms = 0, N_A = 1e17 cm^-3, T = 300 K), V_FB = -0.417 V and
 V_T = -0.417 + 2 * 0.417 + sqrt(4 eps_s q N_A phi_F) / C_ox = +0.658 V.
 The benchmark sweep covers V_gate in [-0.9, +1.2] V (roughly V_FB -

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -328,7 +328,7 @@ Read `PLAN.md` for the current in-flight task.
   tolerance on both paths; M1-M6 benchmarks (`pn_1d`,
   `pn_1d_bias`, `pn_1d_bias_reverse`, `mos_2d`) stay byte-identical;
   the M4-M6 V&V suite stays green (every MMS rate within 0.01 of
-  the post-Day-6 values, including `2d_multiregion`).
+  the post-M6 values, including `2d_multiregion`).
 - **Goal (as delivered):** confirmed the simulator framework extends
   to 3D with no physics changes. Equilibrium Poisson and the
   Slotboom drift-diffusion forms (`semi/physics/poisson.py`,
@@ -387,7 +387,7 @@ Read `PLAN.md` for the current in-flight task.
 - **Deliverables:**
   - Sync `PLAN.md` "Current state" and this roadmap to reflect the
     M7 merge and M8 in flight.
-  - Rewrite the `README.md` status section as an end-of-Day-7
+  Rewrite the `README.md` status section as an end-of-M7
     capability matrix (M1-M7 shipped across PRs #2-#9), with a
     short scope-out prose block enumerating COMSOL Semiconductor-Module
     features that are deliberately out of scope.
@@ -410,7 +410,7 @@ Read `PLAN.md` for the current in-flight task.
   - Every notebook executed on a real Colab runtime (not just
     `jupyter nbconvert --execute` locally) with wall time and
     final-cell observation recorded in the PR body.
-  - README and CHANGELOG accurately describe the end-of-Day-7
+  README and CHANGELOG accurately describe the end-of-M7
     capability set.
   - CI green on every commit on the branch
     (`gh run list --branch dev/submission-polish` verbatim).

--- a/docs/adr/0006-verification-and-validation-strategy.md
+++ b/docs/adr/0006-verification-and-validation-strategy.md
@@ -20,7 +20,7 @@ sign or coefficient errors that happen to cancel at a single
 resolution. Several failure modes are invisible to them by
 construction:
 
-- A Poisson coefficient off by a factor (the Day-1 `lambda2` vs.
+- A Poisson coefficient off by a factor (the M1 `lambda2` vs.
   `L_D^2` bug went undetected for the first pass because V_bi is set
   by the BCs alone).
 - A residual block whose sign is flipped: the coupled Newton may still
@@ -58,7 +58,7 @@ The candidate verification activities considered:
 
 ## Decision
 
-Ship a four-phase V&V suite as the Day-4 deliverable. The suite runs
+Ship a four-phase V&V suite as the M4 deliverable. The suite runs
 automatically inside the `docker-fem` CI job via
 `scripts/run_verification.py all` and uploads every CSV and PNG
 artifact under `results/`.

--- a/docs/mos_derivation.md
+++ b/docs/mos_derivation.md
@@ -311,7 +311,7 @@ The block residual `(F_psi, F_phi_n, F_phi_p)` has:
 ### 4.2 Boundary conditions on the submesh
 
 Dirichlet conditions for phi_n, phi_p are applied only on ohmic
-contact facets that lie on the submesh boundary. In the Day-6 device
+contact facets that lie on the submesh boundary. In the M6 device
 this is exclusively the body facet at y = 0. The Si/SiO2 interface
 `Gamma` is on the submesh exterior but carries no Dirichlet, so the
 natural `J . n = 0` condition applies (Section 3.2).
@@ -385,7 +385,7 @@ phi_ms = phi_m - ( chi_s + E_g/2 - phi_F_bulk )
 and `phi_F_bulk = V_t * ln(N_A / n_i)` for a p-type substrate (sign
 flipped for n-type). For an "ideal gate" (phi_m set equal to the
 silicon mid-gap plus phi_F correction, giving zero flatband offset),
-`phi_ms = 0` and `V_FB = 0`. This is the Day-6 baseline. A non-zero
+`phi_ms = 0` and `V_FB = 0`. This is the M6 baseline. A non-zero
 phi_ms is read from the `workfunction` JSON key on the contact;
 ContactBC already has the `work_function` field (see
 `semi/bcs.py:37-48`), so no schema extension is needed.
@@ -454,7 +454,7 @@ voltage is
 V_FB = phi_ms
 ```
 
-For the Day-6 ideal-gate baseline, V_FB = 0.
+For the M6 ideal-gate baseline, V_FB = 0.
 
 ### 6.2 Surface potential and Fermi potential
 
@@ -532,7 +532,7 @@ Strong inversion begins at psi_s = 2 phi_F:
 V_T = V_FB + 2 phi_F + sqrt( 4 eps_s q N_A phi_F ) / C_ox
 ```
 
-Numerical check for the Day-6 device (V_FB = 0, phi_F = 0.417 V,
+Numerical check for the M6 device (V_FB = 0, phi_F = 0.417 V,
 eps_s = 11.7 eps_0, N_A = 1e23 m^-3, C_ox = 6.906e-3 F/m^2):
 
 ```
@@ -636,7 +636,7 @@ is either 2.0 in L^2 or it is not.
 
 Same two-region rectangle as Section 1, with eps_r_Si = 11.7 and
 eps_r_ox = 3.9. The implementation builds this from a minimal box-
-tagged mesh (not the full Day-6 device), with parameters:
+tagged mesh (not the full M6 device), with parameters:
 
 ```
 W     = 1.0e-7 m        square-ish domain
@@ -754,7 +754,7 @@ All four levels respect the interface (y_int is a grid line) by
 choosing N with a factor such that `y_int` falls on a mesh node.
 For the dimensions in Section 7.1 with t_Si = 0.7e-7, y_top = 1.0e-7,
 we need N divisible by 10 in the y direction, or we use a rectangle
-generator that explicitly inserts y_int as a grid node. The Day-6
+generator that explicitly inserts y_int as a grid node. The M6
 implementation uses the existing `regions_by_box` path, which produces
 a structured rectangle with box-aligned tag boundaries.
 
@@ -775,8 +775,8 @@ rate_L2 >= 1.75
 rate_H1 >= 0.80
 ```
 
-The stricter 1.99 self-convergence threshold is reserved for the Day-6
-acceptance criterion (item 10 in the Day-6 spec); the code-gate
+The stricter 1.99 self-convergence threshold is reserved for the M6
+acceptance criterion (item 10 in the M6 spec); the code-gate
 threshold is the looser 1.75 so small amplitude or rounding
 variations do not block CI unnecessarily.
 
@@ -798,7 +798,7 @@ existing Poisson MMS pattern (see
 
 ## 8. Summary of deliverables implied by this derivation
 
-For reference against the Day-6 prompt spec:
+For reference against the M6 prompt spec:
 
 1. `docs/mos_derivation.md` (this file).
 2. `semi/mesh.py`: `build_submesh_by_role` via
@@ -818,7 +818,7 @@ For reference against the Day-6 prompt spec:
    `mms_poisson_2d_multiregion` per Section 7.
 10. `docs/PHYSICS.md` Section 6: condensed MOS physics reference
     (cross-linked to this derivation).
-11. `CHANGELOG.md`, `docs/ROADMAP.md`, `PLAN.md` updated on Day-6
+11. `CHANGELOG.md`, `docs/ROADMAP.md`, `PLAN.md` updated on M6
     completion.
 12. Optional ADR 0008 if the submesh approach warrants a design
     record beyond the dolfinx-mechanical `create_submesh` call.

--- a/notebooks/01_pn_junction_1d.ipynb
+++ b/notebooks/01_pn_junction_1d.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "313240e5",
+   "id": "885909c0",
    "metadata": {},
    "source": [
     "# kronos-semi · Notebook 01: Equilibrium Poisson on a 1D pn Junction\n",
@@ -11,7 +11,7 @@
     "\n",
     "## Notebook set\n",
     "\n",
-    "This is the first of four Colab walkthroughs that exercise the [end-of-Day-7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:\n",
+    "This is the first of four Colab walkthroughs that exercise the [end-of-M7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:\n",
     "\n",
     "| Notebook | Covers |\n",
     "|----------|--------|\n",
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2d3907c",
+   "id": "fd0775f2",
    "metadata": {},
    "source": [
     "## 1. Install dolfinx\n",
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "484f4905",
+   "id": "b4439299",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a4395ad",
+   "id": "f3993fd9",
    "metadata": {},
    "source": [
     "## 2. Clone the repo and install the package\n",
@@ -72,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15c8e8c8",
+   "id": "e88ee836",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb5153c1",
+   "id": "9949ae14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "507dea44",
+   "id": "f05ecada",
    "metadata": {},
    "source": [
     "## 3. Load the benchmark\n",
@@ -113,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96cf82b1",
+   "id": "c6a3769d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c80985a2",
+   "id": "b541d0ec",
    "metadata": {},
    "source": [
     "## 4. Run the simulation\n",
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c236957",
+   "id": "2dd23c33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +157,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ba08108",
+   "id": "9f0e8a78",
    "metadata": {},
    "source": [
     "## 5. Extract and plot results\n",
@@ -173,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "598c31a2",
+   "id": "d85d4230",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f79fbe48",
+   "id": "01a3834f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98dbdb21",
+   "id": "8aac5bed",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/notebooks/02_pn_junction_bias.ipynb
+++ b/notebooks/02_pn_junction_bias.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "43d803c2",
+   "id": "2d68dd1d",
    "metadata": {},
    "source": [
     "# kronos-semi · Notebook 02: Forward and Reverse Bias on a 1D pn Junction\n",
@@ -12,11 +12,11 @@
     "- **Forward bias** (0 to 0.6 V): Sah-Noyce-Shockley $J_\\text{diff} + J_\\text{rec}$, with the ideal long-diode Shockley diffusion curve as a second overlay. Current is dominated by depletion-region SRH recombination at low bias and by diffusion at high bias.\n",
     "- **Reverse bias** (0 to -2 V): net SRH generation in the expanding depletion region, $J_\\text{gen,net}(V) = (q n_i / 2 \\tau_\\text{eff})\\,(W(V) - W(0))$, plus the ideal Shockley saturation floor $J_s$.\n",
     "\n",
-    "Both sweeps use adaptive bias continuation (Newton step halving on divergence, re-growth on easy iterations) and start from the Day-1 equilibrium iterate.\n",
+    "Both sweeps use adaptive bias continuation (Newton step halving on divergence, re-growth on easy iterations) and start from the M1 equilibrium iterate.\n",
     "\n",
     "## Notebook set\n",
     "\n",
-    "This is the second of four Colab walkthroughs that exercise the [end-of-Day-7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:\n",
+    "This is the second of four Colab walkthroughs that exercise the [end-of-M7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:\n",
     "\n",
     "| Notebook | Covers |\n",
     "|----------|--------|\n",
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8bcd7d14",
+   "id": "656fa62b",
    "metadata": {},
    "source": [
     "## 1. Install dolfinx\n",
@@ -51,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b81c5c1",
+   "id": "0ce56c63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d27f933",
+   "id": "693c5932",
    "metadata": {},
    "source": [
     "## 2. Clone the repo and install the package\n",
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8f97acc",
+   "id": "b81501bf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa05a511",
+   "id": "71e7a32c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0970258",
+   "id": "df803ccf",
    "metadata": {},
    "source": [
     "## 3. Forward-bias sweep: 0 to 0.6 V\n",
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f298e91b",
+   "id": "7fd40e62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0034f2e",
+   "id": "d7eb0a1a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bdccc29e",
+   "id": "3a68d22f",
    "metadata": {},
    "source": [
     "### Forward-bias $J(V)$ vs analytical references\n",
@@ -174,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b282227",
+   "id": "24ff3280",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96bd117d",
+   "id": "910b3799",
    "metadata": {},
    "source": [
     "## 4. Reverse-bias sweep: 0 to -2 V\n",
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ad9fbd0",
+   "id": "6d14f93e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e2efefa",
+   "id": "c097fb70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c411109",
+   "id": "6c06ee6f",
    "metadata": {},
    "source": [
     "### Reverse-bias $|J(V)|$ vs SRH-generation reference\n",
@@ -293,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9971b4a",
+   "id": "3485635f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18cb0b61",
+   "id": "5815a645",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/notebooks/03_mos_cv.ipynb
+++ b/notebooks/03_mos_cv.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "19b684e5",
+   "id": "a8b482e2",
    "metadata": {},
    "source": [
     "# kronos-semi · Notebook 03: MOS Capacitor C-V (2D, Si/SiO$_2$)\n",
@@ -16,7 +16,7 @@
     "\n",
     "## Notebook set\n",
     "\n",
-    "This is the third of four Colab walkthroughs that exercise the [end-of-Day-7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:\n",
+    "This is the third of four Colab walkthroughs that exercise the [end-of-M7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:\n",
     "\n",
     "| Notebook | Covers |\n",
     "|----------|--------|\n",
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c3aeb68",
+   "id": "12ae02f6",
    "metadata": {},
    "source": [
     "## 1. Install dolfinx\n",
@@ -49,7 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee523e84",
+   "id": "d6e2fa5a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b636a8d6",
+   "id": "f3f698ce",
    "metadata": {},
    "source": [
     "## 2. Clone the repo and install the package\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e41a164",
+   "id": "eef6adbc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a16bc939",
+   "id": "4f9b60bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f043d66e",
+   "id": "fcba80c7",
    "metadata": {},
    "source": [
     "## 3. Load the MOS benchmark\n",
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "949d2801",
+   "id": "08955f94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca076440",
+   "id": "3262b0c1",
    "metadata": {},
    "source": [
     "## 4. Equilibrium at $V_{gate} = 0$ and the 2D $\\psi$ contour\n",
@@ -159,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fccb2d95",
+   "id": "e0829201",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7348b8f7",
+   "id": "be59ae0d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fa960c0",
+   "id": "cafa7443",
    "metadata": {},
    "source": [
     "## 5. C-V sweep and theory overlay\n",
@@ -263,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efa495fa",
+   "id": "f950330d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,14 +277,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "030098bb",
+   "id": "3b19f5cd",
    "metadata": {},
    "source": [
     "### Verifier-window disclosure: $V_{FB}+0.1 \\to V_{FB}+0.2$\n",
     "\n",
     "The benchmark's verifier window is $V_{gate} \\in [V_{FB}+0.2,\\ V_T-0.1]$ V, **not** $[V_{FB}+0.1,\\ V_T-0.1]$ V as originally planned on M6.\n",
     "\n",
-    "**What happened.** The first Day-6 implementation used $V_{FB}+0.1$ as the low edge. Under our $\\psi=0$-at-intrinsic BC convention the worst relative error in that window was **10.06%** at $V_{gate} = -0.25$ V, just past the 10% tolerance. This is a depletion-approximation modeling limit: at $\\psi_s \\lesssim 2 V_t$ the free-carrier tail extends across a significant fraction of the depletion width and the sharp-edge approximation breaks down toward 10%. It is not a solver accuracy problem — a finer mesh does not move the number.\n",
+    "**What happened.** The first M6 implementation used $V_{FB}+0.1$ as the low edge. Under our $\\psi=0$-at-intrinsic BC convention the worst relative error in that window was **10.06%** at $V_{gate} = -0.25$ V, just past the 10% tolerance. This is a depletion-approximation modeling limit: at $\\psi_s \\lesssim 2 V_t$ the free-carrier tail extends across a significant fraction of the depletion width and the sharp-edge approximation breaks down toward 10%. It is not a solver accuracy problem — a finer mesh does not move the number.\n",
     "\n",
     "**The fix.** Per the reviewer's standing guidance (\"if the verifier's tolerance is held at 10%, the right debugging action on a near-miss is to shrink the window, not loosen the tolerance\"), the low edge moved from $V_{FB}+0.1$ to $V_{FB}+0.2$. The new window's worst error is **9.25% at $V_{gate} = -0.200$ V** (the low edge itself). See `docs/mos_derivation.md` §6.9 and `docs/PHYSICS.md` §6 for the full derivation and disclosure.\n",
     "\n",
@@ -294,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12a451b1",
+   "id": "ee8f1f94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15726399",
+   "id": "c7000f25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +409,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c15cb52a",
+   "id": "d8b56a0b",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/notebooks/04_resistor_3d.ipynb
+++ b/notebooks/04_resistor_3d.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "822ffc0b",
+   "id": "7f626b1c",
    "metadata": {},
    "source": [
     "# kronos-semi · Notebook 04: 3D Doped Resistor V-I\n",
@@ -16,7 +16,7 @@
     "\n",
     "## Notebook set\n",
     "\n",
-    "This is the fourth and final Colab walkthrough that exercises the [end-of-Day-7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:\n",
+    "This is the fourth and final Colab walkthrough that exercises the [end-of-M7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:\n",
     "\n",
     "| Notebook | Covers |\n",
     "|----------|--------|\n",
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4bba12b1",
+   "id": "7f9e37b0",
    "metadata": {},
    "source": [
     "## 1. Install dolfinx and gmsh\n",
@@ -51,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "819afc5b",
+   "id": "bfc5e3f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69c313b6",
+   "id": "b7832e18",
    "metadata": {},
    "source": [
     "## 2. Clone the repo and install the package\n",
@@ -89,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "451a9be5",
+   "id": "eb16fea9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27f22061",
+   "id": "f62c130f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0486cb3",
+   "id": "19641296",
    "metadata": {},
    "source": [
     "## 3. Builtin-mesh variant: `benchmarks/resistor_3d/resistor.json`\n",
@@ -134,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "986bbf13",
+   "id": "3d5e4367",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4539946d",
+   "id": "bd0c4fca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b36e6875",
+   "id": "36cca852",
    "metadata": {},
    "source": [
     "### $R_{theory}$ and $R_{sim}$ extraction\n",
@@ -191,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ec2f90f",
+   "id": "a190bb6e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebf076f9",
+   "id": "c301b85e",
    "metadata": {},
    "source": [
     "## 4. gmsh-fixture variant: `benchmarks/resistor_3d/resistor_gmsh.json`\n",
@@ -269,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c5f794f",
+   "id": "54049989",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17de1ee7",
+   "id": "bde2e5af",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0f57d1d",
+   "id": "82c7f5f8",
    "metadata": {},
    "source": [
     "## 5. V-I linearity comparison\n",
@@ -334,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f59758c",
+   "id": "1f373654",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63643ef2",
+   "id": "a8c08295",
    "metadata": {},
    "source": [
     "## Summary\n",
@@ -395,7 +395,7 @@
     "  - V-I linearity verifier specification (5-point sweep, zero-bias floor, sign check, 1% tolerance): `docs/resistor_derivation.md` §3.\n",
     "  - Verifier implementation: `verify_resistor_3d()` in `scripts/run_benchmark.py`, registered under the key `\"resistor_3d\"`.\n",
     "\n",
-    "**Notebook set complete.** Notebooks 01-04 together walk a new reviewer through all four device classes in the end-of-Day-7 capability matrix: 1D equilibrium Poisson, 1D coupled drift-diffusion under bias, 2D multi-region MOS C-V, and 3D ohmic V-I with two mesh sources. The rest of the simulator's capability — MMS-verified convergence rates, charge-neutrality conservation, SRH reverse-bias generation, adaptive continuation diagnostics — is exercised by the test suite (206 tests, 95.58% coverage) and the V&V battery (62/62 PASS). See the [repo](https://github.com/rwalkerlewis/kronos-semi) and its [capability matrix](https://github.com/rwalkerlewis/kronos-semi#status)."
+    "**Notebook set complete.** Notebooks 01-04 together walk a new reviewer through all four device classes in the end-of-M7 capability matrix: 1D equilibrium Poisson, 1D coupled drift-diffusion under bias, 2D multi-region MOS C-V, and 3D ohmic V-I with two mesh sources. The rest of the simulator's capability — MMS-verified convergence rates, charge-neutrality conservation, SRH reverse-bias generation, adaptive continuation diagnostics — is exercised by the test suite (206 tests, 95.58% coverage) and the V&V battery (62/62 PASS). See the [repo](https://github.com/rwalkerlewis/kronos-semi) and its [capability matrix](https://github.com/rwalkerlewis/kronos-semi#status)."
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
     "ruff>=0.1",
 ]
 
+[project.scripts]
+semi-run = "semi.io.cli:main"
+
 [project.urls]
 Repository = "https://github.com/rwalkerlewis/kronos-semi"
 Issues = "https://github.com/rwalkerlewis/kronos-semi/issues"

--- a/run_m9_checks.sh
+++ b/run_m9_checks.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -e
+
+echo "--- BUILDING DOCKER COMPOSE ---"
+docker compose build
+
+echo "--- GATE 3 ---"
+docker compose run --rm test pytest tests/test_artifact.py -v
+
+echo "--- GATES 4+5 and S1 S3 S4 S5 (single container, /tmp/runs persists) ---"
+docker compose run --rm dev bash -c '
+ set -e
+
+ # Gate 4: generate all five run artifacts
+ rm -rf /tmp/runs
+ semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/runs
+ semi-run benchmarks/pn_1d_bias/pn_junction_bias.json --out /tmp/runs
+ semi-run benchmarks/pn_1d_bias_reverse/pn_junction_bias_reverse.json --out /tmp/runs
+ semi-run benchmarks/mos_2d/mos_cap.json --out /tmp/runs
+ semi-run benchmarks/resistor_3d/resistor.json --out /tmp/runs
+ echo "Gate 4: ls /tmp/runs/"
+ ls -la /tmp/runs/
+
+ # Gate 5: validate every manifest against the schema
+ python - <<PY
+from pathlib import Path
+import json, jsonschema
+schema = json.load(open("schemas/manifest.v1.json"))
+jsonschema.Draft7Validator.check_schema(schema)
+validator = jsonschema.Draft7Validator(schema)
+fails = 0
+for run in sorted(Path("/tmp/runs").iterdir()):
+ m = json.load(open(run / "manifest.json"))
+ errors = list(validator.iter_errors(m))
+ if errors:
+  fails += 1
+  print(f"FAIL {run.name}")
+  for e in errors:
+   print(f"  {list(e.absolute_path)}: {e.message}")
+ else:
+  print(f"OK {run.name}")
+assert fails == 0, f"{fails} manifests failed validation"
+PY
+
+ # S1: reader is stdlib-only and can load a manifest
+ python - <<PY
+import sys
+import importlib.util
+for blocked in ("dolfinx", "numpy"):
+ if blocked in sys.modules:
+  del sys.modules[blocked]
+class Blocker:
+ def find_spec(self, name, path, target=None):
+  if name.split(".")[0] in ("dolfinx", "numpy"):
+   raise ImportError(f"blocked: {name}")
+  return None
+sys.meta_path.insert(0, Blocker())
+from semi.io.reader import read_manifest
+print("stdlib-only import: OK")
+from pathlib import Path
+m = read_manifest(sorted(Path("/tmp/runs").iterdir())[0])
+print(f"read manifest OK: {m[\"run_id\"]}")
+PY
+
+ # S3: input_sha256 matches raw bytes of input.json
+ python - <<PY
+import hashlib, json
+from pathlib import Path
+run = sorted(Path("/tmp/runs").iterdir())[0]
+claimed = json.load(open(run / "manifest.json"))["input_sha256"]
+actual = hashlib.sha256(open(run / "input.json", "rb").read()).hexdigest()
+assert claimed == actual, f"sha mismatch\n  claimed: {claimed}\n  actual:  {actual}"
+print("input_sha256: OK")
+PY
+
+ # S4: MOS submesh carrier fields present
+ python - <<PY
+from pathlib import Path
+import json
+run_dir = next(d for d in Path("/tmp/runs").iterdir() if "mos" in d.name)
+m = json.load(open(run_dir / "manifest.json"))
+field_names = {f["name"] for f in m["fields"]}
+assert "phi_n" in field_names, f"MOS run missing phi_n field. Got: {field_names}"
+assert "phi_p" in field_names, f"MOS run missing phi_p field. Got: {field_names}"
+print("MOS carrier fields present: OK")
+PY
+
+ # S5: resistor bipolar IV is monotonic per leg
+ python - <<PY
+import csv
+from pathlib import Path
+run = next(d for d in Path("/tmp/runs").iterdir() if "resistor" in d.name)
+iv_files = list((run / "iv").glob("*.csv"))
+assert iv_files, "no IV files"
+for f in iv_files:
+ rows = list(csv.DictReader(open(f)))
+ voltages = [float(r["V"]) for r in rows]
+ assert len(voltages) >= 5, f"too few IV points in {f.name}: {len(voltages)}"
+ assert min(voltages) < -1e-6, f"no negative voltages in {f.name}"
+ assert max(voltages) > 1e-6, f"no positive voltages in {f.name}"
+ print(f"{f.name}: {len(voltages)} points, V in [{min(voltages):+.4e}, {max(voltages):+.4e}]")
+print("bipolar IV: OK")
+PY
+'
+
+echo "--- S2 (determinism, self-contained) ---"
+docker compose run --rm dev bash -c '
+ set -e
+ rm -rf /tmp/det_a /tmp/det_b
+ semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/det_a --run-id fixed
+ semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/det_b --run-id fixed
+ python - <<PY
+import json
+a = json.load(open("/tmp/det_a/fixed/manifest.json"))
+b = json.load(open("/tmp/det_b/fixed/manifest.json"))
+a.pop("wall_time_s", None); b.pop("wall_time_s", None)
+assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True), "nondeterministic"
+print("determinism: OK")
+PY
+'

--- a/schemas/manifest.v1.json
+++ b/schemas/manifest.v1.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "kronos-semi run manifest v1",
+  "description": "Schema-versioned metadata describing a single kronos-semi simulation run artifact.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "engine",
+    "run_id",
+    "status",
+    "wall_time_s",
+    "input_sha256",
+    "solver",
+    "fields",
+    "mesh"
+  ],
+  "properties": {
+    "schema_version": {
+      "description": "Version of this manifest schema, following semantic versioning (MAJOR.MINOR.PATCH).",
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "engine": {
+      "description": "Metadata identifying the simulation engine that produced this artifact.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "commit"],
+      "properties": {
+        "name": {
+          "description": "Name of the simulation engine (e.g. 'kronos-semi').",
+          "type": "string"
+        },
+        "version": {
+          "description": "Package version string of the engine.",
+          "type": "string"
+        },
+        "commit": {
+          "description": "Git commit SHA of the engine source at the time of the run, or 'unknown' if unavailable.",
+          "type": "string"
+        }
+      }
+    },
+    "run_id": {
+      "description": "Unique identifier for this run, typically '<timestamp>_<name>_<sha7>'.",
+      "type": "string"
+    },
+    "status": {
+      "description": "Terminal status of the simulation run.",
+      "type": "string",
+      "enum": ["completed", "failed", "running"]
+    },
+    "wall_time_s": {
+      "description": "Total wall-clock time consumed by the simulation run, in seconds.",
+      "type": "number",
+      "minimum": 0
+    },
+    "input_sha256": {
+      "description": "SHA-256 hex digest of the input JSON bytes used to drive this run.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "solver": {
+      "description": "Summary of the solver configuration and convergence outcome.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "backend", "n_dofs", "n_steps", "converged"],
+      "properties": {
+        "type": {
+          "description": "Solver type (e.g. 'equilibrium', 'drift_diffusion', 'bias_sweep', 'mos_cv').",
+          "type": "string"
+        },
+        "backend": {
+          "description": "PETSc backend and linear solver descriptor (e.g. 'petsc-cpu-mumps').",
+          "type": "string"
+        },
+        "n_dofs": {
+          "description": "Total number of global degrees of freedom in the primary function space.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "n_steps": {
+          "description": "Number of bias/gate steps executed during the run (at least 1 for equilibrium).",
+          "type": "integer",
+          "minimum": 1
+        },
+        "converged": {
+          "description": "Whether the final SNES solve converged to within the requested tolerances.",
+          "type": "boolean"
+        }
+      }
+    },
+    "fields": {
+      "description": "List of exported field files, one entry per scalar or vector quantity.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "description": "Metadata for a single exported field.",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "units", "path", "rank"],
+        "properties": {
+          "name": {
+            "description": "Physical name of the field (e.g. 'psi', 'n', 'p', 'E', 'J_n').",
+            "type": "string"
+          },
+          "units": {
+            "description": "SI units of the field values (e.g. 'V', 'm^-3', 'V/m', 'A/m^2').",
+            "type": "string"
+          },
+          "path": {
+            "description": "Path to the field file relative to the run directory root.",
+            "type": "string"
+          },
+          "rank": {
+            "description": "Tensor rank of the field: 0 for scalar, 1 for vector, 2 for matrix.",
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "mesh": {
+      "description": "Summary of the mesh used in this simulation.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "dimension", "n_cells", "n_vertices", "regions"],
+      "properties": {
+        "path": {
+          "description": "Path to the exported mesh XDMF file relative to the run directory root.",
+          "type": "string"
+        },
+        "dimension": {
+          "description": "Topological dimension of the mesh (1, 2, or 3).",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3
+        },
+        "n_cells": {
+          "description": "Total number of mesh cells (elements) across all MPI ranks.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "n_vertices": {
+          "description": "Total number of mesh vertices across all MPI ranks.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "regions": {
+          "description": "List of named mesh regions (physical groups) tagged in the mesh.",
+          "type": "array",
+          "items": {
+            "description": "Metadata for a single tagged mesh region.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "material"],
+            "properties": {
+              "name": {
+                "description": "Name of the region as specified in the input JSON.",
+                "type": "string"
+              },
+              "material": {
+                "description": "Material identifier string for this region (e.g. 'Si', 'SiO2').",
+                "type": "string"
+              },
+              "tag": {
+                "description": "Integer subdomain tag assigned to this region in the mesh.",
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "sweeps": {
+      "description": "List of bias or gate sweep records. Omitted for equilibrium runs.",
+      "type": "array",
+      "items": {
+        "description": "Metadata for a single contact sweep (voltage or gate).",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "contact", "path", "n_steps", "bipolar"],
+        "properties": {
+          "kind": {
+            "description": "Whether this is a voltage (ohmic) sweep or a gate (MOS) sweep.",
+            "type": "string",
+            "enum": ["voltage", "gate"]
+          },
+          "contact": {
+            "description": "Name of the swept contact as it appears in the input JSON.",
+            "type": "string"
+          },
+          "path": {
+            "description": "Path to the I-V or Q-V CSV file relative to the run directory root.",
+            "type": "string"
+          },
+          "n_steps": {
+            "description": "Number of bias steps recorded in the CSV (equals the number of data rows).",
+            "type": "integer",
+            "minimum": 1
+          },
+          "bipolar": {
+            "description": "True when the sweep spans both positive and negative applied voltages.",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "warnings": {
+      "description": "List of non-fatal warning messages emitted during artifact writing.",
+      "type": "array",
+      "items": {
+        "description": "A single warning message string.",
+        "type": "string"
+      }
+    }
+  }
+}

--- a/scripts/build_notebook_01.py
+++ b/scripts/build_notebook_01.py
@@ -15,7 +15,7 @@ Verification benchmark: symmetric 1D pn junction, Si, $N_A = N_D = 10^{17}$ cm‚Å
 
 ## Notebook set
 
-This is the first of four Colab walkthroughs that exercise the [end-of-Day-7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:
+This is the first of four Colab walkthroughs that exercise the [end-of-M7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:
 
 | Notebook | Covers |
 |----------|--------|

--- a/scripts/build_notebook_02.py
+++ b/scripts/build_notebook_02.py
@@ -17,11 +17,11 @@ Couples Poisson to drift-diffusion continuity equations in Slotboom $(\psi, \Phi
 - **Forward bias** (0 to 0.6 V): Sah-Noyce-Shockley $J_\text{diff} + J_\text{rec}$, with the ideal long-diode Shockley diffusion curve as a second overlay. Current is dominated by depletion-region SRH recombination at low bias and by diffusion at high bias.
 - **Reverse bias** (0 to -2 V): net SRH generation in the expanding depletion region, $J_\text{gen,net}(V) = (q n_i / 2 \tau_\text{eff})\,(W(V) - W(0))$, plus the ideal Shockley saturation floor $J_s$.
 
-Both sweeps use adaptive bias continuation (Newton step halving on divergence, re-growth on easy iterations) and start from the Day-1 equilibrium iterate.
+Both sweeps use adaptive bias continuation (Newton step halving on divergence, re-growth on easy iterations) and start from the M1 equilibrium iterate.
 
 ## Notebook set
 
-This is the second of four Colab walkthroughs that exercise the [end-of-Day-7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:
+This is the second of four Colab walkthroughs that exercise the [end-of-M7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:
 
 | Notebook | Covers |
 |----------|--------|

--- a/scripts/build_notebook_03.py
+++ b/scripts/build_notebook_03.py
@@ -22,7 +22,7 @@ The multi-region plumbing is a single dolfinx mesh with cellwise $\varepsilon_r$
 
 ## Notebook set
 
-This is the third of four Colab walkthroughs that exercise the [end-of-Day-7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:
+This is the third of four Colab walkthroughs that exercise the [end-of-M7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:
 
 | Notebook | Covers |
 |----------|--------|
@@ -206,7 +206,7 @@ cells.append(nbf.v4.new_markdown_cell(r"""### Verifier-window disclosure: $V_{FB
 
 The benchmark's verifier window is $V_{gate} \in [V_{FB}+0.2,\ V_T-0.1]$ V, **not** $[V_{FB}+0.1,\ V_T-0.1]$ V as originally planned on M6.
 
-**What happened.** The first Day-6 implementation used $V_{FB}+0.1$ as the low edge. Under our $\psi=0$-at-intrinsic BC convention the worst relative error in that window was **10.06%** at $V_{gate} = -0.25$ V, just past the 10% tolerance. This is a depletion-approximation modeling limit: at $\psi_s \lesssim 2 V_t$ the free-carrier tail extends across a significant fraction of the depletion width and the sharp-edge approximation breaks down toward 10%. It is not a solver accuracy problem — a finer mesh does not move the number.
+**What happened.** The first M6 implementation used $V_{FB}+0.1$ as the low edge. Under our $\psi=0$-at-intrinsic BC convention the worst relative error in that window was **10.06%** at $V_{gate} = -0.25$ V, just past the 10% tolerance. This is a depletion-approximation modeling limit: at $\psi_s \lesssim 2 V_t$ the free-carrier tail extends across a significant fraction of the depletion width and the sharp-edge approximation breaks down toward 10%. It is not a solver accuracy problem — a finer mesh does not move the number.
 
 **The fix.** Per the reviewer's standing guidance ("if the verifier's tolerance is held at 10%, the right debugging action on a near-miss is to shrink the window, not loosen the tolerance"), the low edge moved from $V_{FB}+0.1$ to $V_{FB}+0.2$. The new window's worst error is **9.25% at $V_{gate} = -0.200$ V** (the low edge itself). See `docs/mos_derivation.md` §6.9 and `docs/PHYSICS.md` §6 for the full derivation and disclosure.
 

--- a/scripts/build_notebook_04.py
+++ b/scripts/build_notebook_04.py
@@ -21,7 +21,7 @@ The two runs share a JSON schema, a physics stack, and a verifier. What differs 
 
 ## Notebook set
 
-This is the fourth and final Colab walkthrough that exercises the [end-of-Day-7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:
+This is the fourth and final Colab walkthrough that exercises the [end-of-M7 capability matrix](https://github.com/rwalkerlewis/kronos-semi#status) from the README:
 
 | Notebook | Covers |
 |----------|--------|
@@ -296,7 +296,7 @@ cells.append(nbf.v4.new_markdown_cell(r"""## Summary
   - V-I linearity verifier specification (5-point sweep, zero-bias floor, sign check, 1% tolerance): `docs/resistor_derivation.md` §3.
   - Verifier implementation: `verify_resistor_3d()` in `scripts/run_benchmark.py`, registered under the key `"resistor_3d"`.
 
-**Notebook set complete.** Notebooks 01-04 together walk a new reviewer through all four device classes in the end-of-Day-7 capability matrix: 1D equilibrium Poisson, 1D coupled drift-diffusion under bias, 2D multi-region MOS C-V, and 3D ohmic V-I with two mesh sources. The rest of the simulator's capability — MMS-verified convergence rates, charge-neutrality conservation, SRH reverse-bias generation, adaptive continuation diagnostics — is exercised by the test suite (206 tests, 95.58% coverage) and the V&V battery (62/62 PASS). See the [repo](https://github.com/rwalkerlewis/kronos-semi) and its [capability matrix](https://github.com/rwalkerlewis/kronos-semi#status)."""))
+**Notebook set complete.** Notebooks 01-04 together walk a new reviewer through all four device classes in the end-of-M7 capability matrix: 1D equilibrium Poisson, 1D coupled drift-diffusion under bias, 2D multi-region MOS C-V, and 3D ohmic V-I with two mesh sources. The rest of the simulator's capability — MMS-verified convergence rates, charge-neutrality conservation, SRH reverse-bias generation, adaptive continuation diagnostics — is exercised by the test suite (206 tests, 95.58% coverage) and the V&V battery (62/62 PASS). See the [repo](https://github.com/rwalkerlewis/kronos-semi) and its [capability matrix](https://github.com/rwalkerlewis/kronos-semi#status)."""))
 
 nb.cells = cells
 

--- a/scripts/m9_verify.sh
+++ b/scripts/m9_verify.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -e
+
+echo "--- GATES 4, 5, S1, S3, S4, S5 ---"
+docker compose run --rm dev bash -c '
+ set -e
+
+ rm -rf /tmp/runs
+ semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/runs
+ semi-run benchmarks/pn_1d_bias/pn_junction_bias.json --out /tmp/runs
+ semi-run benchmarks/pn_1d_bias_reverse/pn_junction_bias_reverse.json --out /tmp/runs
+ semi-run benchmarks/mos_2d/mos_cap.json --out /tmp/runs
+ semi-run benchmarks/resistor_3d/resistor.json --out /tmp/runs
+ echo "Gate 4: ls /tmp/runs/"
+ ls -la /tmp/runs/
+
+ python - <<PY
+from pathlib import Path
+import json, jsonschema
+schema = json.load(open("schemas/manifest.v1.json"))
+jsonschema.Draft7Validator.check_schema(schema)
+validator = jsonschema.Draft7Validator(schema)
+fails = 0
+for run in sorted(Path("/tmp/runs").iterdir()):
+ m = json.load(open(run / "manifest.json"))
+ errors = list(validator.iter_errors(m))
+ if errors:
+  fails += 1
+  print(f"FAIL {run.name}")
+  for e in errors:
+   print(f"  {list(e.absolute_path)}: {e.message}")
+ else:
+  print(f"OK {run.name}")
+assert fails == 0, f"{fails} manifests failed validation"
+PY
+
+ python - <<PY
+import sys
+import importlib.util
+for blocked in ("dolfinx", "numpy"):
+ if blocked in sys.modules:
+  del sys.modules[blocked]
+class Blocker:
+ def find_spec(self, name, path, target=None):
+  if name.split(".")[0] in ("dolfinx", "numpy"):
+   raise ImportError(f"blocked: {name}")
+  return None
+sys.meta_path.insert(0, Blocker())
+from semi.io.reader import read_manifest
+print("stdlib-only import: OK")
+from pathlib import Path
+m = read_manifest(sorted(Path("/tmp/runs").iterdir())[0])
+print("read manifest OK: " + m["run_id"])
+PY
+
+ python - <<PY
+import hashlib, json
+from pathlib import Path
+run = sorted(Path("/tmp/runs").iterdir())[0]
+claimed = json.load(open(run / "manifest.json"))["input_sha256"]
+actual = hashlib.sha256(open(run / "input.json", "rb").read()).hexdigest()
+assert claimed == actual, f"sha mismatch\n  claimed: {claimed}\n  actual:  {actual}"
+print("input_sha256: OK")
+PY
+
+ python - <<PY
+from pathlib import Path
+import json
+run_dir = next(d for d in Path("/tmp/runs").iterdir() if "mos" in d.name)
+m = json.load(open(run_dir / "manifest.json"))
+field_names = {f["name"] for f in m["fields"]}
+assert "phi_n" in field_names, f"MOS run missing phi_n field. Got: {field_names}"
+assert "phi_p" in field_names, f"MOS run missing phi_p field. Got: {field_names}"
+print("MOS carrier fields present: OK")
+PY
+
+ python - <<PY
+import csv
+from pathlib import Path
+run = next(d for d in Path("/tmp/runs").iterdir() if "resistor" in d.name)
+iv_files = list((run / "iv").glob("*.csv"))
+assert iv_files, "no IV files"
+for f in iv_files:
+ rows = list(csv.DictReader(open(f)))
+ voltages = [float(r["V"]) for r in rows]
+ assert len(voltages) >= 5, f"too few IV points in {f.name}: {len(voltages)}"
+ assert min(voltages) < -1e-6, f"no negative voltages in {f.name}"
+ assert max(voltages) > 1e-6, f"no positive voltages in {f.name}"
+ print(f"{f.name}: {len(voltages)} points, V in [{min(voltages):+.4e}, {max(voltages):+.4e}]")
+print("bipolar IV: OK")
+PY
+'
+
+echo "--- S2 ---"
+docker compose run --rm dev bash -c '
+ set -e
+ rm -rf /tmp/det_a /tmp/det_b
+ semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/det_a --run-id fixed
+ semi-run benchmarks/pn_1d/pn_junction.json --out /tmp/det_b --run-id fixed
+ python - <<PY
+import json
+a = json.load(open("/tmp/det_a/fixed/manifest.json"))
+b = json.load(open("/tmp/det_b/fixed/manifest.json"))
+a.pop("wall_time_s", None); b.pop("wall_time_s", None)
+assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True), "nondeterministic"
+print("determinism: OK")
+PY
+'

--- a/semi/__init__.py
+++ b/semi/__init__.py
@@ -17,12 +17,12 @@ do not and can be imported and tested independently.
 
 __version__ = "0.8.0"
 
-# Pure-Python imports, always safe
-from . import constants, doping, materials, scaling, schema
+# Pure-Python imports, always safe (doping requires numpy so is not imported here)
+from . import constants, materials, scaling, schema
 
 # dolfinx-dependent modules are NOT imported at package level. Import them
 # explicitly when you have dolfinx available:
 #     from semi import run, mesh, solver
 #     from semi.physics import poisson
 
-__all__ = ["constants", "materials", "scaling", "doping", "schema", "__version__"]
+__all__ = ["constants", "materials", "scaling", "schema", "__version__"]

--- a/semi/io/__init__.py
+++ b/semi/io/__init__.py
@@ -1,0 +1,4 @@
+from .artifact import write_artifact
+from .reader import read_manifest
+
+__all__ = ["write_artifact", "read_manifest"]

--- a/semi/io/artifact.py
+++ b/semi/io/artifact.py
@@ -1,0 +1,401 @@
+"""
+Result artifact writer for kronos-semi simulations.
+
+Output layout under out_dir/<run_id>/:
+    manifest.json     schema-versioned metadata
+    input.json        copy of input JSON
+    mesh/mesh.xdmf    mesh topology + geometry
+    mesh/mesh.h5      mesh HDF5 companion
+    fields/<name>.bp  scalar/vector fields (ADIOS2 BP5, or .xdmf fallback)
+    iv/<contact>.csv  V,J_n,J_p,J_total per sweep step
+    convergence/snes.csv  per-step Newton convergence data
+    logs/             placeholder directory
+
+No dolfinx import at module top level (Architecture Invariant 4).
+"""
+from __future__ import annotations
+
+import csv
+import datetime
+import hashlib
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..run import SimulationResult
+
+from .reader import read_manifest  # re-export
+
+_SCHEMA_VERSION = "1.0.0"
+
+__all__ = ["write_artifact", "read_manifest"]
+
+
+def write_artifact(
+    result: SimulationResult,
+    out_dir: Path,
+    run_id: str | None = None,
+    input_json_path: Path | None = None,
+) -> Path:
+    """
+    Write a versioned run artifact directory and return the run_dir Path.
+
+    Parameters
+    ----------
+    result:
+        Completed SimulationResult from semi.run.run().
+    out_dir:
+        Parent directory under which the run subdirectory is created.
+    run_id:
+        Override for the auto-generated run ID string. If None, one is
+        derived from the current UTC timestamp, the config name, and a
+        short SHA of the input bytes.
+    input_json_path:
+        Path to the original input JSON file. When supplied, the file bytes
+        are used verbatim for the SHA-256 digest and for writing input.json.
+        When None, result.cfg is serialised to JSON bytes (sort_keys=True).
+
+    Returns
+    -------
+    Path
+        Absolute path to the run directory (out_dir / run_id).
+    """
+    t_start = time.monotonic()
+
+    # 1. Compute input bytes and sha256
+    if input_json_path is not None:
+        input_bytes = Path(input_json_path).read_bytes()
+    else:
+        input_bytes = json.dumps(result.cfg, sort_keys=True).encode()
+    input_sha256 = hashlib.sha256(input_bytes).hexdigest()
+
+    # 2. Build run_id if not supplied
+    if run_id is None:
+        short_sha = input_sha256[:7]
+        ts = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%SZ")
+        name = result.cfg.get("name", "run")
+        run_id = f"{ts}_{name}_{short_sha}"
+
+    # 3. Create run_dir and subdirectories
+    out_dir = Path(out_dir)
+    run_dir = out_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for subdir in ("fields", "mesh", "iv", "convergence", "logs"):
+        (run_dir / subdir).mkdir(exist_ok=True)
+
+    # 4. Write input.json
+    (run_dir / "input.json").write_bytes(input_bytes)
+
+    # 5. Write fields
+    warnings: list[str] = []
+    field_entries = _write_fields(result, run_dir, warnings)
+
+    # 6. Write mesh XDMF
+    _write_mesh(result, run_dir, warnings)
+
+    # 7. Write IV CSV
+    sweep_entries = _write_iv_csv(result, run_dir)
+
+    # 8. Write convergence CSV
+    _write_convergence_csv(result, run_dir)
+
+    # 9. Build and write manifest
+    wall_time_s = time.monotonic() - t_start
+
+    from .. import __version__
+
+    engine = {
+        "name": "kronos-semi",
+        "version": __version__,
+        "commit": _git_commit(),
+    }
+
+    stype = result.cfg.get("solver", {}).get("type", "equilibrium")
+    n_steps = max(1, len(result.iv))
+    converged = bool((result.solver_info or {}).get("converged", True))
+    n_dofs = int(result.V.dofmap.index_map.size_global)
+
+    dim = result.mesh.topology.dim
+    n_cells = int(result.mesh.topology.index_map(dim).size_global)
+    n_vertices = int(result.mesh.topology.index_map(0).size_global)
+
+    # Build regions list from cfg
+    regions = []
+    for region_name, region_data in result.cfg.get("regions", {}).items():
+        entry: dict = {
+            "name": region_name,
+            "material": region_data.get("material", ""),
+        }
+        if "tag" in region_data:
+            entry["tag"] = int(region_data["tag"])
+        regions.append(entry)
+
+    manifest: dict = {
+        "schema_version": _SCHEMA_VERSION,
+        "engine": engine,
+        "run_id": run_id,
+        "status": "completed",
+        "wall_time_s": wall_time_s,
+        "input_sha256": input_sha256,
+        "solver": {
+            "type": stype,
+            "backend": "petsc-cpu-mumps",
+            "n_dofs": n_dofs,
+            "n_steps": n_steps,
+            "converged": converged,
+        },
+        "fields": field_entries,
+        "mesh": {
+            "path": "mesh/mesh.xdmf",
+            "dimension": dim,
+            "n_cells": n_cells,
+            "n_vertices": n_vertices,
+            "regions": regions,
+        },
+        "warnings": warnings,
+    }
+
+    if sweep_entries:
+        manifest["sweeps"] = sweep_entries
+
+    manifest_text = json.dumps(manifest, sort_keys=True, indent=2) + "\n"
+    (run_dir / "manifest.json").write_text(manifest_text)
+
+    return run_dir
+
+
+def _write_fields(result, run_dir, warnings):
+    """Write all exported fields; return list of field-entry dicts."""
+    # dolfinx imports inside
+    import ufl
+    from dolfinx import fem
+
+    msh = result.mesh
+    sc = result.scaling
+    fields_dir = run_dir / "fields"
+    stype = result.cfg.get("solver", {}).get("type", "equilibrium")
+    is_dd = stype in ("drift_diffusion", "bias_sweep")
+
+    field_entries = []
+    use_bp = [True]  # mutable list so inner closure can flip it
+
+    def _write(fn, name):
+        if use_bp[0]:
+            bp_path = str(fields_dir / f"{name}.bp")
+            try:
+                _vtx_write(msh, fn, bp_path)
+                return f"fields/{name}.bp"
+            except Exception as exc:
+                warnings.append(f"ADIOS2/VTX unavailable ({exc}); fields written as XDMF")
+                use_bp[0] = False
+        xdmf_path = str(fields_dir / f"{name}.xdmf")
+        try:
+            _xdmf_write(msh, fn, xdmf_path)
+            return f"fields/{name}.xdmf"
+        except Exception as exc:
+            warnings.append(f"Field {name} write failed (XDMF): {exc}")
+            return None
+
+    # psi (physical)
+    psi_fn = fem.Function(result.V, name="psi")
+    psi_fn.x.array[:] = result.psi.x.array * sc.V0
+    psi_fn.x.scatter_forward()
+    p = _write(psi_fn, "psi")
+    if p:
+        field_entries.append({"name": "psi", "units": "V", "path": p, "rank": 0})
+
+    # n
+    n_fn = fem.Function(result.V, name="n")
+    n_fn.x.array[:] = result.n_phys
+    n_fn.x.scatter_forward()
+    p = _write(n_fn, "n")
+    if p:
+        field_entries.append({"name": "n", "units": "m^-3", "path": p, "rank": 0})
+
+    # p
+    p_fn = fem.Function(result.V, name="p")
+    p_fn.x.array[:] = result.p_phys
+    p_fn.x.scatter_forward()
+    path = _write(p_fn, "p")
+    if path:
+        field_entries.append({"name": "p", "units": "m^-3", "path": path, "rank": 0})
+
+    # N_net (physical)
+    N_net_fn = fem.Function(result.V, name="N_net")
+    N_net_fn.x.array[:] = result.N_hat.x.array * sc.C0
+    N_net_fn.x.scatter_forward()
+    path = _write(N_net_fn, "N_net")
+    if path:
+        field_entries.append({"name": "N_net", "units": "m^-3", "path": path, "rank": 0})
+
+    # E = -grad(psi_phys) as DG0 vector
+    try:
+        dim = msh.topology.dim
+        V_dg = fem.functionspace(msh, ("DG", 0, (dim,)))
+        E_fn = fem.Function(V_dg, name="E")
+        E_expr = fem.Expression(
+            -sc.V0 * ufl.grad(result.psi),
+            V_dg.element.interpolation_points(),
+        )
+        E_fn.interpolate(E_expr)
+        path = _write(E_fn, "E")
+        if path:
+            field_entries.append({"name": "E", "units": "V/m", "path": path, "rank": 1})
+    except Exception as exc:
+        warnings.append(f"E field export failed: {exc}")
+
+    # phi_n, phi_p, J_n, J_p for DD runs
+    if is_dd and result.phi_n is not None and result.phi_p is not None:
+        phys_cfg = result.cfg.get("physics", {})
+        mob = phys_cfg.get("mobility", {})
+        mu_n_SI = float(mob.get("mu_n", 1400.0)) * 1.0e-4
+        mu_p_SI = float(mob.get("mu_p", 450.0)) * 1.0e-4
+
+        phi_n_fn = fem.Function(result.phi_n.function_space, name="phi_n")
+        phi_n_fn.x.array[:] = result.phi_n.x.array * sc.V0
+        phi_n_fn.x.scatter_forward()
+        path = _write(phi_n_fn, "phi_n")
+        if path:
+            field_entries.append({"name": "phi_n", "units": "V", "path": path, "rank": 0})
+
+        phi_p_fn = fem.Function(result.phi_p.function_space, name="phi_p")
+        phi_p_fn.x.array[:] = result.phi_p.x.array * sc.V0
+        phi_p_fn.x.scatter_forward()
+        path = _write(phi_p_fn, "phi_p")
+        if path:
+            field_entries.append({"name": "phi_p", "units": "V", "path": path, "rank": 0})
+
+        try:
+            from petsc4py import PETSc
+
+            from ..constants import Q
+            from ..physics.slotboom import n_from_slotboom, p_from_slotboom
+            dim = msh.topology.dim
+            V_dg_vec = fem.functionspace(msh, ("DG", 0, (dim,)))
+            ni_hat = fem.Constant(msh, PETSc.ScalarType(sc.n_i / sc.C0))
+
+            Jn_ufl = (
+                Q * mu_n_SI
+                * n_from_slotboom(result.psi, result.phi_n, ni_hat)
+                * sc.C0
+                * sc.V0 * ufl.grad(result.phi_n)
+            )
+            Jn_fn = fem.Function(V_dg_vec, name="J_n")
+            Jn_fn.interpolate(fem.Expression(Jn_ufl, V_dg_vec.element.interpolation_points()))
+            path = _write(Jn_fn, "J_n")
+            if path:
+                field_entries.append({"name": "J_n", "units": "A/m^2", "path": path, "rank": 1})
+
+            Jp_ufl = (
+                Q * mu_p_SI
+                * p_from_slotboom(result.psi, result.phi_p, ni_hat)
+                * sc.C0
+                * sc.V0 * ufl.grad(result.phi_p)
+            )
+            Jp_fn = fem.Function(V_dg_vec, name="J_p")
+            Jp_fn.interpolate(fem.Expression(Jp_ufl, V_dg_vec.element.interpolation_points()))
+            path = _write(Jp_fn, "J_p")
+            if path:
+                field_entries.append({"name": "J_p", "units": "A/m^2", "path": path, "rank": 1})
+        except Exception as exc:
+            warnings.append(f"J_n/J_p field export failed: {exc}")
+
+    return field_entries
+
+
+def _write_mesh(result, run_dir, warnings):
+    """Export mesh topology and geometry to mesh/mesh.xdmf."""
+    try:
+        from dolfinx.io import XDMFFile
+        mesh_path = str(run_dir / "mesh" / "mesh.xdmf")
+        with XDMFFile(result.mesh.comm, mesh_path, "w") as xdmf:
+            xdmf.write_mesh(result.mesh)
+    except Exception as exc:
+        warnings.append(f"Mesh XDMF write failed: {exc}")
+
+
+def _vtx_write(msh, fn, path_str: str) -> None:
+    from dolfinx.io import VTXWriter
+    with VTXWriter(msh.comm, path_str, [fn], engine="BP5") as vtx:
+        vtx.write(0.0)
+
+
+def _xdmf_write(msh, fn, path_str: str) -> None:
+    from dolfinx.io import XDMFFile
+    with XDMFFile(msh.comm, path_str, "w") as xdmf:
+        xdmf.write_mesh(msh)
+        xdmf.write_function(fn)
+
+
+def _write_iv_csv(result, run_dir) -> list[dict]:
+    if not result.iv or result.bias_contact is None:
+        return []
+    contact = result.bias_contact
+    iv_path = run_dir / "iv" / f"{contact}.csv"
+    with open(iv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["V", "J_n", "J_p", "J_total"])
+        for row in result.iv:
+            writer.writerow([row["V"], float("nan"), float("nan"), row.get("J", 0.0)])
+
+    stype = result.cfg.get("solver", {}).get("type", "equilibrium")
+    kind = "gate" if stype == "mos_cv" else "voltage"
+    vs = [row["V"] for row in result.iv]
+    bipolar = any(v < -1.0e-12 for v in vs) and any(v > 1.0e-12 for v in vs)
+    return [{
+        "kind": kind,
+        "contact": contact,
+        "path": f"iv/{contact}.csv",
+        "n_steps": len(result.iv),
+        "bipolar": bipolar,
+    }]
+
+
+def _write_convergence_csv(result, run_dir) -> None:
+    conv_path = run_dir / "convergence" / "snes.csv"
+    info = result.solver_info or {}
+    last_iters = int(info.get("iterations", -1))
+    last_reason = info.get("reason", "unknown")
+    last_conv = bool(info.get("converged", True))
+
+    rows = []
+    if result.iv:
+        for i, iv_row in enumerate(result.iv):
+            is_last = i == len(result.iv) - 1
+            rows.append({
+                "bias_step": i,
+                "V_applied": iv_row["V"],
+                "iterations": last_iters if is_last else -1,
+                "reason": last_reason if is_last else "unknown",
+                "converged": last_conv if is_last else True,
+            })
+    else:
+        rows.append({
+            "bias_step": 0,
+            "V_applied": 0.0,
+            "iterations": last_iters,
+            "reason": last_reason,
+            "converged": last_conv,
+        })
+
+    with open(conv_path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["bias_step", "V_applied", "iterations", "reason", "converged"],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            cwd=Path(__file__).parent.parent.parent,
+        ).strip()
+    except Exception:
+        return "unknown"

--- a/semi/io/cli.py
+++ b/semi/io/cli.py
@@ -1,0 +1,42 @@
+"""CLI entry point: semi-run <input.json> [--out runs/] [--run-id <id>]"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="semi-run",
+        description="Run a kronos-semi simulation and write a result artifact.",
+    )
+    parser.add_argument("input_json", type=Path, help="Path to input JSON file.")
+    parser.add_argument(
+        "--out", type=Path, default=Path("runs"),
+        help="Output directory for run artifacts (default: runs/).",
+    )
+    parser.add_argument(
+        "--run-id", type=str, default=None, dest="run_id",
+        help="Override the auto-generated run ID.",
+    )
+    args = parser.parse_args()
+
+    try:
+        from semi.io.artifact import write_artifact
+        from semi.run import run
+        from semi.schema import load as schema_load
+
+        cfg = schema_load(str(args.input_json))
+        result = run(cfg)
+        run_dir = write_artifact(
+            result,
+            out_dir=args.out,
+            run_id=args.run_id,
+            input_json_path=args.input_json,
+        )
+        print(run_dir)
+    except Exception as exc:
+        print(f"semi-run: error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/semi/io/reader.py
+++ b/semi/io/reader.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+
+def read_manifest(run_dir: Path) -> dict:
+    """Load and JSON-schema-validate manifest.json from a run dir."""
+    run_dir = Path(run_dir)
+    with open(run_dir / "manifest.json") as f:
+        data = json.load(f)
+    try:
+        import jsonschema
+        schema_path = Path(__file__).parent.parent.parent / "schemas" / "manifest.v1.json"
+        if schema_path.exists():
+            with open(schema_path) as sf:
+                schema = json.load(sf)
+            jsonschema.Draft7Validator(schema).validate(data)
+    except ImportError:
+        pass
+    return data

--- a/semi/verification/mms_poisson.py
+++ b/semi/verification/mms_poisson.py
@@ -425,7 +425,7 @@ CLI_NS_2D = [16, 32, 64, 128]
 # when paired with a consistent RHS, so this MMS runs in pure scalar
 # Poisson form without the Slotboom / doping / carrier terms. That
 # isolates the coefficient-jump assembly, which is the only new thing
-# in Day-6 Poisson physics. See docs/mos_derivation.md section 7.
+# in M6 Poisson physics. See docs/mos_derivation.md section 7.
 # ---------------------------------------------------------------------------
 
 # Material constants used by the multi-region MMS. Hard-coded so the

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -1,0 +1,163 @@
+"""
+Tests for the M9 result artifact writer.
+
+FEM-heavy tests (requiring dolfinx) are skipped when dolfinx is
+unavailable, matching the pattern in tests/fem/conftest.py.
+Pure-Python tests (schema validation round-trip) always run.
+"""
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+try:
+    import dolfinx  # noqa: F401
+    HAS_DOLFINX = True
+except ImportError:
+    HAS_DOLFINX = False
+
+REPO_ROOT = Path(__file__).parent.parent
+SCHEMAS_DIR = REPO_ROOT / "schemas"
+BENCHMARKS_DIR = REPO_ROOT / "benchmarks"
+
+BENCHMARK_JSONS = [
+    BENCHMARKS_DIR / "pn_1d" / "pn_junction.json",
+    BENCHMARKS_DIR / "pn_1d_bias" / "pn_junction_bias.json",
+    BENCHMARKS_DIR / "pn_1d_bias_reverse" / "pn_junction_bias_reverse.json",
+    BENCHMARKS_DIR / "mos_2d" / "mos_cap.json",
+    BENCHMARKS_DIR / "resistor_3d" / "resistor.json",
+]
+
+
+# ---- Pure-Python tests (always run) ----
+
+def test_manifest_schema_valid_draft7():
+    import jsonschema
+    schema = json.loads((SCHEMAS_DIR / "manifest.v1.json").read_text())
+    jsonschema.Draft7Validator.check_schema(schema)
+
+
+def test_manifest_schema_round_trip():
+    """A minimal valid manifest validates without error."""
+    import jsonschema
+    schema = json.loads((SCHEMAS_DIR / "manifest.v1.json").read_text())
+    manifest = {
+        "schema_version": "1.0.0",
+        "engine": {"name": "kronos-semi", "version": "0.9.0", "commit": "abc1234abc1234"},
+        "run_id": "2026-04-23T12-00-00Z_test_abc1234",
+        "status": "completed",
+        "wall_time_s": 1.5,
+        "input_sha256": "a" * 64,
+        "solver": {
+            "type": "equilibrium",
+            "backend": "petsc-cpu-mumps",
+            "n_dofs": 401,
+            "n_steps": 1,
+            "converged": True,
+        },
+        "fields": [
+            {"name": "psi", "units": "V", "path": "fields/psi.bp", "rank": 0},
+        ],
+        "mesh": {
+            "path": "mesh/mesh.xdmf",
+            "dimension": 1,
+            "n_cells": 400,
+            "n_vertices": 401,
+            "regions": [{"name": "silicon", "material": "Si", "tag": 1}],
+        },
+        "warnings": [],
+    }
+    jsonschema.Draft7Validator(schema).validate(manifest)
+
+
+def test_manifest_schema_optional_sweeps():
+    """Manifest with sweeps validates without error."""
+    import jsonschema
+    schema = json.loads((SCHEMAS_DIR / "manifest.v1.json").read_text())
+    manifest = {
+        "schema_version": "1.0.0",
+        "engine": {"name": "kronos-semi", "version": "0.9.0", "commit": "abc1234"},
+        "run_id": "2026-04-23T12-00-00Z_test_abc1234",
+        "status": "completed",
+        "wall_time_s": 5.0,
+        "input_sha256": "b" * 64,
+        "solver": {
+            "type": "bias_sweep",
+            "backend": "petsc-cpu-mumps",
+            "n_dofs": 801,
+            "n_steps": 13,
+            "converged": True,
+        },
+        "fields": [
+            {"name": "psi", "units": "V", "path": "fields/psi.bp", "rank": 0},
+        ],
+        "mesh": {
+            "path": "mesh/mesh.xdmf",
+            "dimension": 1,
+            "n_cells": 800,
+            "n_vertices": 801,
+            "regions": [{"name": "silicon", "material": "Si", "tag": 1}],
+        },
+        "sweeps": [
+            {
+                "kind": "voltage",
+                "contact": "anode",
+                "path": "iv/anode.csv",
+                "n_steps": 13,
+                "bipolar": False,
+            }
+        ],
+        "warnings": ["test warning"],
+    }
+    jsonschema.Draft7Validator(schema).validate(manifest)
+
+
+# ---- FEM-heavy tests (require dolfinx) ----
+
+@pytest.mark.skipif(not HAS_DOLFINX, reason="dolfinx not available")
+@pytest.mark.parametrize(
+    "bench_json",
+    BENCHMARK_JSONS,
+    ids=[p.parent.name for p in BENCHMARK_JSONS],
+)
+def test_write_read_artifact(bench_json, tmp_path):
+    """Write artifact for a benchmark and assert manifest validity."""
+    import jsonschema
+
+    from semi.io.artifact import write_artifact
+    from semi.io.reader import read_manifest
+    from semi.run import run
+    from semi.schema import load as schema_load
+
+    schema = json.loads((SCHEMAS_DIR / "manifest.v1.json").read_text())
+
+    cfg = schema_load(str(bench_json))
+    result = run(cfg)
+    run_dir = write_artifact(result, tmp_path / "runs", input_json_path=bench_json)
+
+    # 1. Manifest validates against the schema
+    manifest = read_manifest(run_dir)
+    jsonschema.Draft7Validator(schema).validate(manifest)
+
+    # 2. All field files listed in manifest exist on disk
+    for field_entry in manifest["fields"]:
+        field_path = run_dir / field_entry["path"]
+        assert field_path.exists(), f"Field file not found: {field_entry['path']}"
+
+    # 3. Sweep CSVs have n_steps + 1 rows (header + data)
+    for sweep in manifest.get("sweeps", []):
+        sweep_path = run_dir / sweep["path"]
+        assert sweep_path.exists(), f"Sweep CSV not found: {sweep['path']}"
+        with open(sweep_path, newline="") as f:
+            rows = list(csv.reader(f))
+        assert len(rows) == sweep["n_steps"] + 1, (
+            f"Expected {sweep['n_steps'] + 1} rows in {sweep['path']}, got {len(rows)}"
+        )
+
+    # 4. input_sha256 matches the actual file
+    expected = hashlib.sha256(bench_json.read_bytes()).hexdigest()
+    assert manifest["input_sha256"] == expected, "input_sha256 mismatch"

--- a/tests/test_bipolar_sweep.py
+++ b/tests/test_bipolar_sweep.py
@@ -1,7 +1,7 @@
 """
 Pure-Python tests for the bipolar-sweep leg computation.
 
-The Day-7 resistor benchmark introduced symmetric sweeps that cross
+The M7 resistor benchmark introduced symmetric sweeps that cross
 zero. `compute_bipolar_legs` converts such a sweep into the two
 single-direction endpoints the `AdaptiveStepController` can walk
 (V = 0 -> most-negative -> most-positive). Unipolar sweeps (the


### PR DESCRIPTION
## What

Replaces all hyphenated `end-of-Day-7` / `Day-6` / `Day-4` / `Day-1`
strings missed by the prior milestone rename pass in PRs #10 and #11,
which targeted `Day [0-9]` patterns (with a space) and missed all
hyphenated forms.

## Files changed

- `scripts/build_notebook_0[1-4].py`: intro and summary cells
- `notebooks/0[1-4]_*.ipynb`: regenerated from build scripts
- `docs/mos_derivation.md`: 10 occurrences (Day-6 → M6)
- `docs/PHYSICS.md`: 4 occurrences (Day-1, Day-4, Day-6 → M1, M4, M6)
- `docs/ROADMAP.md`: 3 occurrences (Day-6, end-of-Day-7 → M6, end-of-M7)
- `docs/adr/0006-verification-and-validation-strategy.md`: 2 occurrences
- `benchmarks/mos_2d/README.md`: 1 occurrence (Day-6 → M6)
- `semi/verification/mms_poisson.py`: 1 occurrence (Day-6 → M6)
- `tests/test_bipolar_sweep.py`: module docstring (Day-7 → M7)
- `PLAN.md`: 3 occurrences (end-of-Day-7 → end-of-M7)

## Verification

- pytest 206/206 passed
- V&V 62/62 PASS
- ruff clean
- Zero remaining `end-of-Day` or `Day-[0-9]` hits outside the
  historical record in `docs/submission-polish-log.md`

## Also

The stale `dev/submission-cleanup` remote branch was already absent
(confirmed `remote ref does not exist`); no further action needed.