### PR TITLE
M10: HTTP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ env/
 
 # Results and scratch
 results/
+runs/
 *.xdmf
 *.h5
 *.bp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.10.0] - M10: HTTP server
+
+### Added
+- `kronos_server/` top-level package exposing the M9 engine over HTTP.
+  FastAPI app factory (`build_app`), in-process `ProcessPoolExecutor`
+  worker pool (`JobManager`), LocalFS storage backend, file-backed
+  progress event stream (`progress.ndjson`), pydantic request/response
+  models, and CORS middleware. No dolfinx, UFL, or PETSc imports at
+  module scope in the server process; FEM-heavy imports happen only
+  inside worker subprocesses spawned with `mp_context="spawn"`.
+- HTTP endpoints: `POST /solve` (202/400), `GET /runs`,
+  `GET /runs/{id}` (returning the full manifest plus status),
+  `GET /runs/{id}/{manifest,input,fields/{name},iv/{contact},logs}`,
+  `GET /schema`, `GET /materials`, `GET /capabilities`, `GET /health`,
+  `GET /ready` (200/503).
+- WebSocket endpoint: `WS /runs/{id}/stream` tails the progress file and
+  emits `step_done` and `run_done` messages; closes with code 4404 on
+  unknown run, 1000 on completion.
+- `kronos-server` console entry point (`pyproject.toml`) with env-var
+  driven host/port/workers/runs-dir/cors-origins configuration.
+- `server` service in `docker-compose.yml`, bound to port 8000.
+- `[project.optional-dependencies]` extra `server = [fastapi, uvicorn,
+  httpx, pydantic]`.
+- Optional `progress_callback=None` parameter on
+  `semi/runners/{equilibrium,bias_sweep,mos_cv}.py`, called per bias
+  step; this is the only permitted change to `semi/` in M10.
+- `tests/test_kronos_server.py` — 15 tests covering pure-Python and
+  FEM-backed paths: health/ready, capabilities, schema, materials,
+  OpenAPI, input validation, 404 handling, CORS preflight, end-to-end
+  solve+manifest match, field download, IV download, input download,
+  WebSocket progress (≥ 5 `step_done` on `pn_1d_bias`), and concurrent
+  solves (3 simultaneous).
+
+### Changed
+- `Dockerfile`: `pip install -e ".[dev,server]"` so the baked image
+  includes the server extra.
+- `pyproject.toml` `[tool.hatch.build.targets.wheel]` packages now
+  include `kronos_server`.
+- `PLAN.md`: M10 moved to completed work log; next task set to M11.
+
 ## [0.9.0] - M9: Result artifact writer
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,14 +70,18 @@ RUN pip install --break-system-packages \
         "nbformat>=5.0" \
         "ruff>=0.1" \
         "jupyterlab>=4.0" \
-        "ipykernel>=6.0"
+        "ipykernel>=6.0" \
+        "fastapi>=0.115,<0.120" \
+        "uvicorn[standard]>=0.32,<0.40" \
+        "httpx>=0.27,<0.29" \
+        "pydantic>=2.8,<3.0"
 
 # Copy the rest of the source and install the package editable. The bind
 # mount in docker-compose will overlay /workspaces/kronos-semi at runtime,
 # but installing here ensures `import semi` works if the image is run without
 # a bind mount (e.g., CI).
 COPY . .
-RUN pip install --break-system-packages -e ".[dev]"
+RUN pip install --break-system-packages -e ".[dev,server]"
 
 RUN chown -R ${USER_UID}:${USER_GID} /workspaces
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -35,11 +35,12 @@ recombination for 1D/2D/3D devices.
 
 ## Current state
 
-M1 through M9 are merged into `main`. The most recent M9 commit is `ba5f5d9`
-(result artifact writer); follow-up commit `7e426d2` updated planning docs.
-Version `v0.9.0` is recorded in `CHANGELOG.md`. The project has delivered
-the KronosAI evaluation milestones plus the first piece of the
-production-engine track (on-disk result artifact contract).
+M1 through M10 are merged into `main`. M9 delivered the on-disk artifact
+contract; M10 now exposes the engine over HTTP via a new top-level
+`kronos_server/` package. `CHANGELOG.md` records the `[0.10.0] - M10:
+HTTP server` entry. The project has delivered the KronosAI evaluation
+milestones plus the first two pieces of the production-engine track
+(artifact writer and HTTP API).
 
 The capability matrix (verified in CI) is authoritative: see `README.md`
 §Status or `docs/ROADMAP.md`.
@@ -53,7 +54,7 @@ The capability matrix (verified in CI) is authoritative: see `README.md`
   (pn_1d, pn_1d_bias, pn_1d_bias_reverse, mos_2d, resistor_3d), MMS
   and conservation V&V suite (62/62 PASS), four Colab notebooks,
   GitHub Actions CI.
-- **M9 deliverables (new in v0.9.0):**
+- **M9 deliverables (v0.9.0):**
   - `schemas/manifest.v1.json` — JSON Schema Draft-07 for run manifests,
     `additionalProperties: false` throughout.
   - `semi/io/artifact.py` — `write_artifact(result, out_dir, run_id)`
@@ -65,17 +66,32 @@ The capability matrix (verified in CI) is authoritative: see `README.md`
     across all five benchmarks.
   - Verified in Docker: gates 3, 4, 5 and sanity checks S1–S5 all pass
     (see `scripts/m9_verify.sh`).
+- **M10 deliverables (new in v0.10.0):**
+  - `kronos_server/` top-level package (FastAPI app, pydantic DTOs,
+    LocalFS storage, in-process `ProcessPoolExecutor` worker pool,
+    file-backed progress event stream).
+  - Endpoints: `POST /solve`, `GET /runs`, `GET /runs/{id}`, plus
+    `/runs/{id}/{manifest,input,fields/{name},iv/{contact},logs}`,
+    `WS /runs/{id}/stream`, `GET /schema`, `GET /materials`,
+    `GET /capabilities`, `GET /health`, `GET /ready`. CORS configurable
+    via `KRONOS_SERVER_CORS_ORIGINS`. OpenAPI at `/openapi.json` and
+    Swagger UI at `/docs` (auto-generated).
+  - `kronos-server` console entry point and `server` docker-compose
+    service on port 8000.
+  - Optional `progress_callback=None` threaded through
+    `semi/runners/{equilibrium,bias_sweep,mos_cv}.py` (only change to
+    `semi/` in M10).
+  - `tests/test_kronos_server.py` — 15 tests covering HTTP API,
+    WebSocket progress, and concurrent solves; all pass alongside the
+    existing suite (230 total).
 
 ### What does not work / not yet built
 
 The gaps between the current state and a production UI-backed engine
 are enumerated and sequenced in
 [`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md), milestones
-M10 through M18. Summary:
+M11 through M18. Summary:
 
-- **No HTTP server / API surface.** M9 produces a disk artifact but
-  there is no web-facing way to submit JSON and fetch results. M10
-  addresses this.
 - **No schema versioning.** Input JSON still lacks `schema_version`.
   M11.
 - **Mesh input is axis-aligned-only** except for imported gmsh files
@@ -87,38 +103,21 @@ M10 through M18. Summary:
 
 ## Next task
 
-**M10: HTTP server.** Scoped in full in
-[`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md) §4 (M10). A
-starter prompt for a coding agent is maintained separately by the
-project lead (not committed to the repo).
+**M11: Schema versioning + UI-facing schema companion.** Scoped in full
+in [`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md) §4 (M11).
 
-- **Goal:** expose the M9 engine over HTTP so a web UI (or any network
-  client) can submit JSON, poll run status, stream Newton-solver
-  progress, and fetch result artifacts without importing dolfinx.
-- **Scope, in:**
-  - New top-level package `kronos_server/` with FastAPI app, pydantic
-    request/response models, LocalFS storage backend, in-process
-    `ProcessPoolExecutor` worker pool, WebSocket progress stream.
-  - Endpoints: `POST /solve`, `GET /runs`, `GET /runs/{id}` and its
-    sub-resources, `WS /runs/{id}/stream`, `GET /schema`,
-    `GET /materials`, `GET /capabilities`, `GET /health`, `GET /ready`.
-  - `[project.optional-dependencies]` server extra
-    (`fastapi`, `uvicorn`, `httpx`, `pydantic`).
-  - `kronos-server` console entry point.
-  - Docker Compose `server` service.
-  - `tests/test_kronos_server.py` with at least 10 tests including
-    WebSocket progress and concurrent-solve coverage.
-- **Scope, out:** any physics change, any change to the M9 artifact
-  writer or manifest schema, any change to the input schema, auth,
-  rate limiting, persistence beyond the on-disk run directory.
-- **Permitted minor change to `semi/`:** adding optional
-  `progress_callback=None` parameters to the three runners
-  (`equilibrium`, `bias_sweep`, `mos_cv`) so the WebSocket stream can
-  get structured SNES progress events rather than parsing stderr.
-  Budget: ~30 lines total across all three runners.
-- **Preconditions:** M9 merged on `main` at `ba5f5d9`.
-- **Acceptance gate:** the 8 acceptance commands specified in the M10
-  starter prompt all pass in Docker.
+- **Goal:** make the input JSON schema introspectable and versioned so
+  a UI form-builder can render labels, defaults, and help text without
+  a separate config layer, and so the engine can refuse inputs from an
+  incompatible major version.
+- **Scope, in:** a required top-level `schema_version` field in every
+  input; a standalone `schemas/input.v1.json` file loaded by
+  `semi/schema.py`; `title`/`description`/`default`/`examples` added to
+  every schema node; an assertion test that every `type: object` node
+  has a `description`.
+- **Scope, out:** any physics change, M10 server surface changes,
+  manifest schema changes.
+- **Preconditions:** M10 merged on `main`.
 
 ## Roadmap
 
@@ -133,8 +132,8 @@ project lead (not committed to the repo).
 | M7: 3D doped resistor | gmsh loader, bipolar sweep, V-I 1% | Done |
 | M8: Submission polish | Notebooks, catalog, CHANGELOG, v0.8.0 tag | Done |
 | M9: Result artifact writer | manifest.json, on-disk field/IV files, semi-run CLI | Done |
-| M10: HTTP server | POST /solve, GET /runs/{id}, WebSocket progress | Next |
-| M11: Schema versioning | UI-facing schema companion, form-builder annotations | Planned |
+| M10: HTTP server | POST /solve, GET /runs/{id}, WebSocket progress | Done |
+| M11: Schema versioning | UI-facing schema companion, form-builder annotations | Next |
 | M12: Mesh beyond boxes | XDMF loader, gmsh .geo ingress, 2D MOSFET benchmark | Planned |
 | M13: Transient solver | Backward-Euler + BDF2, diode turn-on benchmark | Planned |
 | M14: AC small-signal | Complex-frequency admittance, true C-V | Planned |
@@ -234,6 +233,14 @@ items.
 ## Completed work log
 
 Append-only. Newest entries on top.
+
+- **M10 (2026-04-23):** HTTP server; new `kronos_server/` top-level package
+  (FastAPI app, `ProcessPoolExecutor` worker pool, file-backed progress
+  stream), `kronos-server` console entry, `server` docker-compose
+  service, `[server]` optional extra in `pyproject.toml`, 15 new server
+  tests (`tests/test_kronos_server.py`). Added optional
+  `progress_callback=None` to `semi/runners/{equilibrium,bias_sweep,mos_cv}.py`
+  (only permitted `semi/` change).
 
 - **M9 (2026-04-23):** Result artifact writer; `semi/io/artifact.py`, `schemas/manifest.v1.json`, `semi-run` CLI.
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 A JSON-driven finite-element semiconductor device simulator built on FEniCSx
 (dolfinx 0.10). Solves Poisson-coupled drift-diffusion with SRH recombination
-on 1D, 2D, and 3D meshes. Originally delivered as an evaluation task; the
-project is transitioning from submission artifact to a production engine
-intended to sit behind a COMSOL-Semiconductor-style web UI.
+on 1D, 2D, and 3D meshes, with an HTTP API for programmatic access.
+Originally delivered as an evaluation task; the project is now a working
+production engine suitable for web UI integration.
 
 If you're a contributor or a coding agent, start at the [Orientation](#orientation)
 section.
 
-## Status (v0.8.0, end of M8)
+## Status (v0.10.0, end of M10)
 
-Milestones M1 through M8 are merged on `main`. The capability matrix is what
-the engine actually does today, verified in CI:
+Milestones M1 through M10 are merged on `main`. The capability matrix is
+what the engine actually does today, verified in CI:
 
 | Capability                         | Dimensions    | Status  | Verifier                                                     |
 |------------------------------------|---------------|---------|--------------------------------------------------------------|
@@ -29,31 +29,32 @@ the engine actually does today, verified in CI:
 | 3D ohmic V-I linearity             | 3D            | shipped | V-I linearity within 1%                                      |
 | Benchmarks                         | 5             | shipped | pn_1d, pn_1d_bias, pn_1d_bias_reverse, mos_2d, resistor_3d   |
 | Conservation / mesh convergence    | 1D            | shipped | charge neutrality, Cauchy rates >= 1.8/doubling              |
-| Test suite                         | pure + FEM    | shipped | 206 tests, 95.58% coverage                                   |
 | V&V                                | 10 studies    | shipped | 62/62 PASS                                                   |
+| On-disk result artifact (M9)       | all           | shipped | round-trip tests on all 5 benchmarks, manifest Draft-07 validated |
+| `semi-run` CLI (M9)                | all           | shipped | end-to-end artifact writer exercised in CI                   |
+| HTTP server (M10)                  | all           | shipped | 15 server tests, end-to-end POST /solve + WebSocket progress |
+| Test suite                         | pure + FEM    | shipped | 230 tests, >=95% coverage                                    |
 | CI                                 | lint+test+FEM | shipped | green on dev and main                                        |
 
 See [CHANGELOG.md](CHANGELOG.md) for per-milestone deliverables.
 
-## Where this is going (M9+)
+## Where this is going (M11+)
 
-M1–M8 produced a numerically sound engine with good verification. The gap
-between "verified submission" and "production engine behind a web UI" is
-mostly not physics; it is integration. The roadmap for closing that gap
-lives in [docs/IMPROVEMENT_GUIDE.md](docs/IMPROVEMENT_GUIDE.md). Summary:
+M1 through M10 produced a numerically sound engine with an HTTP API. The
+remaining work is mostly additional physics and the linear-solver scaling
+needed for real 3D devices. The roadmap lives in
+[docs/IMPROVEMENT_GUIDE.md](docs/IMPROVEMENT_GUIDE.md).
 
-| Milestone | Summary                                          | Blocking for                     |
-|-----------|--------------------------------------------------|----------------------------------|
-| M9        | Result artifact writer + manifest.json           | Everything downstream            |
-| M10       | HTTP server: POST /solve, GET /runs/{id}         | Any UI integration               |
-| M11       | Schema versioning + UI-facing schema companion   | Form-builder-driven UI           |
-| M12       | Mesh input beyond axis-aligned boxes             | Real (non-rectangular) devices   |
-| M13       | Transient solver                                 | C-V transients, diode turn-on    |
-| M14       | AC small-signal analysis                         | True C-V, admittance spectroscopy|
-| M15       | GPU linear solver path                           | Anything above ~200k DOFs        |
-| M16       | Physics completeness pass (mobility, Auger, FD, Schottky, tunneling) | Real device models |
-| M17       | Heterojunctions / position-dependent band structure | HEMTs, HBTs                   |
-| M18       | UI: first cut (separate repo)                    | Shipping a product               |
+| Milestone | Summary                                                      | Blocking for                     |
+|-----------|--------------------------------------------------------------|----------------------------------|
+| M11       | Schema versioning + UI-facing schema companion               | Form-builder-driven UI           |
+| M12       | Mesh input beyond axis-aligned boxes                         | Real (non-rectangular) devices   |
+| M13       | Transient solver                                             | C-V transients, diode turn-on    |
+| M14       | AC small-signal analysis                                     | True C-V, admittance spectroscopy|
+| M15       | GPU linear solver path                                       | Anything above ~200k DOFs        |
+| M16       | Physics completeness pass (mobility, Auger, FD, Schottky, tunneling) | Real device models       |
+| M17       | Heterojunctions / position-dependent band structure          | HEMTs, HBTs                      |
+| M18       | UI: first cut (separate repo)                                | Shipping a product               |
 
 Each milestone in the guide has explicit deliverables and acceptance tests.
 
@@ -120,10 +121,62 @@ cd kronos-semi
 pip install -e ".[dev]"
 ```
 
+For HTTP server support, include the `server` extra:
+
+```bash
+pip install -e ".[dev,server]"
+```
+
 The pure-Python layer (`schema`, `materials`, `scaling`, `doping`,
 `constants`) does not need dolfinx and installs standalone via
 `pip install -e .` — useful for schema validation and unit tests in
-CI environments without a FEM toolchain.
+CI environments without a FEM toolchain. The `server` process also
+imports no dolfinx at module scope; FEM work happens in spawned worker
+subprocesses.
+
+## Running the HTTP server (M10)
+
+The `kronos-server` console entry point starts a FastAPI server that
+exposes the engine over HTTP:
+
+```bash
+kronos-server                           # 127.0.0.1:8000 by default
+KRONOS_SERVER_PORT=8080 kronos-server   # or via env vars
+```
+
+Under Docker Compose, the `server` service runs the same entry point:
+
+```bash
+docker compose up -d server
+curl http://localhost:8000/health
+curl http://localhost:8000/capabilities | python -m json.tool
+```
+
+### Example: submit a solve over HTTP
+
+```bash
+# Submit a benchmark as a JSON body
+RUN_ID=$(curl -sf -X POST http://localhost:8000/solve \
+  -H "Content-Type: application/json" \
+  -d @benchmarks/pn_1d/pn_junction.json \
+  | python -c 'import sys,json; print(json.load(sys.stdin)["run_id"])')
+
+# Poll until complete
+while true; do
+  STATUS=$(curl -sf http://localhost:8000/runs/$RUN_ID \
+    | python -c 'import sys,json; print(json.load(sys.stdin)["status"])')
+  [ "$STATUS" = "completed" ] && break
+  sleep 2
+done
+
+# Fetch the manifest and an IV CSV
+curl -sf http://localhost:8000/runs/$RUN_ID/manifest
+curl -sf http://localhost:8000/runs/$RUN_ID/iv/cathode
+```
+
+OpenAPI spec at `http://localhost:8000/openapi.json`, Swagger UI at
+`/docs`. Full endpoint reference in
+[CHANGELOG.md](CHANGELOG.md) under the `[0.10.0]` entry.
 
 ## Docker
 
@@ -131,10 +184,11 @@ Reproducible dev environment on top of `ghcr.io/fenics/dolfinx/dolfinx:stable`:
 
 ```bash
 docker compose build
-docker compose run --rm test                       # pytest
+docker compose run --rm test                       # pytest (230 tests)
 docker compose run --rm benchmark pn_1d            # run a benchmark
 docker compose up -d dev && docker compose exec dev bash
 docker compose up jupyter                          # JupyterLab on :8888
+docker compose up -d server                        # HTTP server on :8000
 ```
 
 ## Running benchmarks
@@ -147,9 +201,9 @@ docker compose run --rm benchmark mos_2d
 docker compose run --rm benchmark resistor_3d
 ```
 
-Each benchmark is a JSON file under `benchmarks/<name>/`. The CLI loads it,
+Each benchmark is a JSON file under `benchmarks/<n>/`. The CLI loads it,
 runs the solver, checks a registered verifier, and writes plots to
-`results/<name>/`.
+`results/<n>/`.
 
 From Python:
 
@@ -167,6 +221,17 @@ result = run.run(cfg)
 `result` is a `SimulationResult` dataclass; see
 [docs/WALKTHROUGH.md §11](docs/WALKTHROUGH.md) for the full schema and
 caveats about dolfinx-backed fields not being serializable.
+
+To persist a result to disk for later reading (including from an
+environment without dolfinx), use the M9 artifact writer:
+
+```bash
+semi-run benchmarks/pn_1d/pn_junction.json --out runs/
+```
+
+The resulting `runs/<run_id>/` directory contains a schema-validated
+`manifest.json`, the input JSON, mesh and field files, IV CSVs, and
+convergence logs.
 
 ## JSON input example
 
@@ -212,7 +277,7 @@ else is SI. The full schema is defined in `semi/schema.py`.
 
 kronos-semi covers the **quasi-static, steady-state** subset.
 
-**In scope (shipped, M1–M8):**
+**In scope (shipped, M1–M10):**
 
 - Poisson with multi-region dielectric (Si/SiO2)
 - Drift-diffusion in Slotboom (quasi-Fermi potential) form
@@ -221,6 +286,8 @@ kronos-semi covers the **quasi-static, steady-state** subset.
 - 1D, 2D, and 3D structured meshes (builtin); 3D unstructured meshes via gmsh
 - Bias sweeps with adaptive step-size continuation (unipolar and bipolar)
 - Method-of-Manufactured-Solutions and conservation V&V suite
+- Machine-readable on-disk result artifacts (schema-validated manifests)
+- HTTP API with solve submission, progress streaming, and artifact fetch
 
 **Out of scope today (planned for M13–M17, see [docs/IMPROVEMENT_GUIDE.md](docs/IMPROVEMENT_GUIDE.md)):**
 
@@ -266,6 +333,16 @@ The `NonlinearProblem` class in 0.10 wraps PETSc SNES directly (the old
 diagnostics, and block-system support for the coupled (ψ, Φ_n, Φ_p)
 solve. See [ADR 0003](docs/adr/0003-dolfinx-0-10-api.md).
 
+### Why no dolfinx in the server process
+
+`kronos_server/` never imports dolfinx, UFL, or PETSc at module scope.
+FEM work happens only in worker subprocesses spawned via
+`ProcessPoolExecutor(mp_context="spawn")`. A server process can start
+and serve `/health`, `/ready`, `/capabilities`, and `/schema` in a
+pure-Python environment without the FEM stack, which is useful for
+smoke-tested deployments and for UI developers who want a static mock
+server.
+
 ## Verification
 
 Analytical results are regenerated at import time by
@@ -276,20 +353,20 @@ junction.
 
 ```bash
 python tests/check_day1_math.py    # runs offline, no dolfinx required
-pytest tests/                       # 206 tests under Docker
+pytest tests/                       # 230 tests under Docker
 python scripts/run_verification.py  # V&V suite, 62 studies
 ```
 
 ## Planning documents (read order for contributors)
 
 1. [PLAN.md](PLAN.md) — current state, next task, invariants. **Single source of truth** for what to work on.
-2. [docs/IMPROVEMENT_GUIDE.md](docs/IMPROVEMENT_GUIDE.md) — M9+ roadmap, acceptance tests, anti-goals.
+2. [docs/IMPROVEMENT_GUIDE.md](docs/IMPROVEMENT_GUIDE.md) — M11+ roadmap, acceptance tests, anti-goals.
 3. [docs/PHYSICS_INTRO.md](docs/PHYSICS_INTRO.md) — physics tutorial for programmers.
 4. [docs/PHYSICS.md](docs/PHYSICS.md) — governing equations, scaling, BCs (reference).
 5. [docs/WALKTHROUGH.md](docs/WALKTHROUGH.md) — end-to-end code trace with file:line anchors.
 6. [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — five-layer component design and import rules.
 7. [docs/adr/](docs/adr/) — locked decisions. Open a new ADR before changing any invariant.
-8. [docs/ROADMAP.md](docs/ROADMAP.md) — per-milestone delivery history (M1–M8).
+8. [docs/ROADMAP.md](docs/ROADMAP.md) — per-milestone delivery history (M1–M10).
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,3 +59,17 @@ services:
         --ServerApp.token=''
         --ServerApp.password=''
         --ServerApp.root_dir=/workspaces/kronos-semi
+
+  server:
+    image: kronos-semi:dev
+    working_dir: /workspaces/kronos-semi
+    command: kronos-server
+    environment:
+      KRONOS_SERVER_HOST: "0.0.0.0"
+      KRONOS_SERVER_PORT: "8000"
+      KRONOS_SERVER_WORKERS: "2"
+      KRONOS_SERVER_RUNS_DIR: "/workspaces/kronos-semi/runs"
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/workspaces/kronos-semi:cached

--- a/kronos_server/__init__.py
+++ b/kronos_server/__init__.py
@@ -1,0 +1,11 @@
+"""
+kronos_server: HTTP API for the kronos-semi engine.
+
+This package is deliberately separate from `semi/` to preserve the pure-engine
+boundary documented in `docs/ARCHITECTURE.md`. The server process itself does
+not import dolfinx, UFL, or PETSc; all FEM-heavy work happens inside worker
+subprocesses.
+
+Public API:
+    from kronos_server.app import build_app, main
+"""

--- a/kronos_server/app.py
+++ b/kronos_server/app.py
@@ -1,0 +1,76 @@
+"""FastAPI application factory + `kronos-server` entry point.
+
+The server process deliberately does NOT import dolfinx, UFL, or PETSc at
+module scope. FEM-heavy imports happen only inside worker subprocesses
+spawned by `jobs.JobManager`, so a developer without dolfinx can still run
+`kronos-server` and get a useful 503 on `/ready` instead of an ImportError
+at startup.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .config import Settings
+from .jobs import JobManager
+from .storage import LocalStorage
+
+
+def build_app(settings: Settings | None = None) -> FastAPI:
+    if settings is None:
+        settings = Settings()
+
+    storage = LocalStorage(settings.runs_dir)
+    job_mgr = JobManager(settings, storage)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        job_mgr.start()
+        try:
+            yield
+        finally:
+            job_mgr.shutdown()
+
+    app = FastAPI(
+        title="kronos-semi HTTP server",
+        version="0.10.0",
+        description="HTTP API for the kronos-semi FEM semiconductor device simulator.",
+        lifespan=lifespan,
+    )
+
+    # TODO(M10+): add auth, rate limiting, API keys before any public deployment.
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.state.settings = settings
+    app.state.storage = storage
+    app.state.job_mgr = job_mgr
+
+    from .routes import health, runs, schema, solve, stream
+
+    app.include_router(health.router)
+    app.include_router(schema.router)
+    app.include_router(solve.router)
+    app.include_router(runs.router)
+    app.include_router(stream.router)
+
+    return app
+
+
+def main() -> None:
+    import uvicorn
+
+    settings = Settings()
+    uvicorn.run(build_app(settings), host=settings.host, port=settings.port)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/kronos_server/config.py
+++ b/kronos_server/config.py
@@ -1,0 +1,41 @@
+"""Runtime settings sourced from environment variables."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def _default_workers() -> int:
+    cpus = os.cpu_count() or 4
+    return max(1, cpus // 4)
+
+
+def _parse_origins(raw: str) -> list[str]:
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
+@dataclass
+class Settings:
+    host: str = field(
+        default_factory=lambda: os.environ.get("KRONOS_SERVER_HOST", "127.0.0.1"),
+    )
+    port: int = field(
+        default_factory=lambda: int(os.environ.get("KRONOS_SERVER_PORT", "8000")),
+    )
+    workers: int = field(
+        default_factory=lambda: int(
+            os.environ.get("KRONOS_SERVER_WORKERS", str(_default_workers())),
+        ),
+    )
+    runs_dir: Path = field(
+        default_factory=lambda: Path(os.environ.get("KRONOS_SERVER_RUNS_DIR", "runs")),
+    )
+    cors_origins: list[str] = field(
+        default_factory=lambda: _parse_origins(
+            os.environ.get(
+                "KRONOS_SERVER_CORS_ORIGINS",
+                "http://localhost:3000,http://localhost:5173",
+            ),
+        ),
+    )

--- a/kronos_server/jobs.py
+++ b/kronos_server/jobs.py
@@ -1,0 +1,209 @@
+"""Job queue + worker function.
+
+The server process never imports dolfinx. `_solve_job` runs in a fresh
+subprocess spawned by `ProcessPoolExecutor` (spawn context, so PETSc state
+is not shared across jobs, per IMPROVEMENT_GUIDE §2 P3). Progress events
+are streamed to disk via `progress.append_event`; the WebSocket route tails
+that file.
+"""
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import multiprocessing
+import subprocess
+import time
+import traceback
+from concurrent.futures import Future, ProcessPoolExecutor
+from pathlib import Path
+from typing import Any
+
+from .config import Settings
+from .progress import append_event
+from .storage import LocalStorage
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            cwd=Path(__file__).parent.parent,
+        ).strip()
+    except Exception:  # pragma: no cover
+        return "unknown"
+
+
+def _get_version() -> str:
+    try:
+        from semi import __version__
+        return str(__version__)
+    except Exception:  # pragma: no cover
+        return "unknown"
+
+
+def _status_path(run_dir: Path) -> Path:
+    return run_dir / "status.json"
+
+
+def read_status(run_dir: Path) -> dict[str, Any] | None:
+    path = _status_path(run_dir)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+
+def _utc_now_iso() -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_status(run_dir: Path, status: str, **extra: Any) -> None:
+    path = _status_path(run_dir)
+    payload = {"status": status, "updated_at": _utc_now_iso()}
+    payload.update(extra)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+
+
+def _solve_job(run_id: str, run_dir_str: str, input_path_str: str) -> dict[str, Any]:
+    """Subprocess worker entry point. Imports dolfinx only inside."""
+    run_dir = Path(run_dir_str)
+    input_path = Path(input_path_str)
+    t_start = time.monotonic()
+
+    def progress_cb(event: dict[str, Any]) -> None:
+        append_event(run_dir, event)
+
+    write_status(run_dir, "running", run_id=run_id)
+    progress_cb({"type": "run_started", "run_id": run_id})
+
+    try:
+        from semi.io import write_artifact
+        from semi.runners import run_bias_sweep, run_equilibrium, run_mos_cv
+        from semi.schema import load as schema_load
+
+        cfg = schema_load(str(input_path))
+        stype = cfg.get("solver", {}).get("type", "equilibrium")
+
+        if stype == "equilibrium":
+            result = run_equilibrium(cfg, progress_callback=progress_cb)
+        elif stype in ("drift_diffusion", "bias_sweep"):
+            result = run_bias_sweep(cfg, progress_callback=progress_cb)
+        elif stype == "mos_cv":
+            result = run_mos_cv(cfg, progress_callback=progress_cb)
+        else:
+            raise ValueError(f"Unknown solver.type {stype!r}")
+
+        final_dir = write_artifact(
+            result,
+            out_dir=run_dir.parent,
+            run_id=run_id,
+            input_json_path=input_path,
+        )
+        if str(final_dir) != str(run_dir):  # pragma: no cover
+            raise RuntimeError(
+                f"write_artifact wrote to {final_dir}, expected {run_dir}",
+            )
+
+        wall = time.monotonic() - t_start
+        write_status(run_dir, "completed", run_id=run_id, wall_time_s=wall)
+        progress_cb({"type": "run_done", "status": "completed", "wall_time_s": wall})
+        return {"status": "completed", "wall_time_s": wall}
+    except Exception as exc:
+        wall = time.monotonic() - t_start
+        tb = traceback.format_exc()
+        progress_cb({
+            "type": "run_done",
+            "status": "failed",
+            "wall_time_s": wall,
+            "error": str(exc),
+        })
+        _write_failure_manifest(run_dir, run_id, input_path, exc, tb, wall)
+        write_status(run_dir, "failed", run_id=run_id, wall_time_s=wall, error=str(exc))
+        return {"status": "failed", "error": str(exc)}
+
+
+def _write_failure_manifest(
+    run_dir: Path,
+    run_id: str,
+    input_path: Path,
+    exc: Exception,
+    tb: str,
+    wall: float,
+) -> None:
+    """Emit a best-effort manifest on failure so `GET /runs/{id}` still works."""
+    try:
+        input_bytes = input_path.read_bytes() if input_path.exists() else b""
+        sha = hashlib.sha256(input_bytes).hexdigest() if input_bytes else "0" * 64
+        manifest = {
+            "schema_version": "1.0.0",
+            "engine": {"name": "kronos-semi", "version": _get_version(), "commit": _git_commit()},
+            "run_id": run_id,
+            "status": "failed",
+            "wall_time_s": float(wall),
+            "input_sha256": sha,
+            "error": {"message": str(exc), "traceback": tb},
+        }
+        (run_dir / "manifest.json").write_text(
+            json.dumps(manifest, sort_keys=True, indent=2) + "\n",
+        )
+    except Exception:  # pragma: no cover
+        pass
+
+
+class JobManager:
+    """Process-pool-backed job dispatcher."""
+
+    def __init__(self, settings: Settings, storage: LocalStorage):
+        self.settings = settings
+        self.storage = storage
+        self.executor: ProcessPoolExecutor | None = None
+        self._futures: dict[str, Future] = {}
+
+    def start(self) -> None:
+        ctx = multiprocessing.get_context("spawn")
+        self.executor = ProcessPoolExecutor(
+            max_workers=self.settings.workers,
+            mp_context=ctx,
+        )
+
+    def shutdown(self) -> None:
+        if self.executor is not None:
+            self.executor.shutdown(wait=False, cancel_futures=True)
+            self.executor = None
+
+    def is_ready(self) -> bool:
+        return self.executor is not None
+
+    def submit(self, input_bytes: bytes, cfg: dict[str, Any]) -> str:
+        if self.executor is None:
+            raise RuntimeError("JobManager not started")
+        sha = hashlib.sha256(input_bytes).hexdigest()
+        short = sha[:7]
+        name = cfg.get("name", "run")
+        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+        # Add a short counter suffix if this exact run_id is already taken,
+        # to keep concurrent submissions from colliding within a 1-second slot.
+        base = f"{ts}_{name}_{short}"
+        run_id = base
+        suffix = 1
+        while self.storage.run_dir(run_id).exists():
+            run_id = f"{base}_{suffix}"
+            suffix += 1
+
+        run_dir = self.storage.run_dir(run_id)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "input.json").write_bytes(input_bytes)
+        write_status(run_dir, "queued", run_id=run_id, input_sha256=sha)
+
+        fut = self.executor.submit(_solve_job, run_id, str(run_dir), str(run_dir / "input.json"))
+        self._futures[run_id] = fut
+        return run_id
+
+    def future(self, run_id: str) -> Future | None:
+        return self._futures.get(run_id)

--- a/kronos_server/models.py
+++ b/kronos_server/models.py
@@ -1,0 +1,67 @@
+"""Pydantic request/response models surfaced in the OpenAPI spec."""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SolveResponse(BaseModel):
+    run_id: str = Field(..., description="Identifier for the newly-enqueued run.")
+    status: str = Field(..., description="Queued/running/completed/failed.")
+    status_url: str = Field(..., description="Relative URL for polling run status.")
+
+
+class RunSummary(BaseModel):
+    run_id: str
+    status: str
+    created_at: str = Field(..., description="ISO-8601 UTC timestamp parsed from run_id.")
+
+
+class RunListResponse(BaseModel):
+    runs: list[RunSummary]
+
+
+class HealthResponse(BaseModel):
+    status: str
+
+
+class ReadyResponse(BaseModel):
+    ready: bool
+
+
+class CapabilitiesEngine(BaseModel):
+    name: str
+    version: str
+
+
+class CapabilitiesPhysics(BaseModel):
+    boltzmann: bool
+    fermi_dirac: bool
+    srh_recombination: bool
+    auger_recombination: bool
+    field_dependent_mobility: bool
+    transient: bool
+    ac_small_signal: bool
+    schottky_contacts: bool
+    heterojunctions: bool
+    tunneling: bool
+
+
+class CapabilitiesBackends(BaseModel):
+    cpu_mumps: bool
+    gpu_amgx: bool
+    gpu_hypre: bool
+
+
+class CapabilitiesResponse(BaseModel):
+    engine: CapabilitiesEngine
+    solver_types: list[str]
+    dimensions: list[int]
+    physics: CapabilitiesPhysics
+    mesh_sources: list[str]
+    backends: CapabilitiesBackends
+
+
+class ErrorResponse(BaseModel):
+    detail: Any

--- a/kronos_server/progress.py
+++ b/kronos_server/progress.py
@@ -1,0 +1,30 @@
+"""File-backed progress event stream.
+
+The worker appends newline-delimited JSON to `<run_dir>/progress.ndjson`;
+the WebSocket route tails that file. Using the filesystem as the transport
+avoids shared-queue plumbing across a ProcessPoolExecutor boundary and keeps
+the run directory self-describing.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+from typing import Any
+
+
+def iso_now() -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
+
+
+def append_event(run_dir: Path, event: dict[str, Any]) -> None:
+    """Append a single event dict as one JSON line."""
+    run_dir = Path(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    payload = dict(event)
+    payload.setdefault("timestamp", iso_now())
+    line = json.dumps(payload, sort_keys=True)
+    path = run_dir / "progress.ndjson"
+    with open(path, "a") as f:
+        f.write(line + "\n")

--- a/kronos_server/routes/__init__.py
+++ b/kronos_server/routes/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP route modules."""

--- a/kronos_server/routes/health.py
+++ b/kronos_server/routes/health.py
@@ -1,0 +1,28 @@
+"""Liveness and readiness probes."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from ..models import HealthResponse, ReadyResponse
+
+router = APIRouter()
+
+
+@router.get("/health", response_model=HealthResponse)
+def health() -> HealthResponse:
+    return HealthResponse(status="ok")
+
+
+@router.get(
+    "/ready",
+    response_model=ReadyResponse,
+    responses={503: {"model": ReadyResponse}},
+)
+def ready(request: Request) -> JSONResponse:
+    job_mgr = request.app.state.job_mgr
+    is_ready = job_mgr.is_ready()
+    return JSONResponse(
+        content={"ready": bool(is_ready)},
+        status_code=200 if is_ready else 503,
+    )

--- a/kronos_server/routes/runs.py
+++ b/kronos_server/routes/runs.py
@@ -1,0 +1,153 @@
+"""GET /runs, GET /runs/{id}, plus field / iv / log / input / manifest downloads."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse
+
+from ..jobs import read_status
+from ..models import RunListResponse, RunSummary
+
+router = APIRouter()
+
+
+def _created_at_from_run_id(run_id: str) -> str:
+    """Parse the ISO-8601 timestamp prefix from `<ts>_<name>_<sha>` IDs.
+
+    The run_id encodes the timestamp as `YYYY-MM-DDTHH-MM-SSZ` (hyphens in
+    the time portion so the string is filename-safe). Convert back to the
+    standard ISO-8601 `YYYY-MM-DDTHH:MM:SSZ`.
+    """
+    stamp = run_id.split("_", 1)[0]
+    if "T" not in stamp:
+        return run_id
+    date_part, time_part = stamp.split("T", 1)
+    return f"{date_part}T{time_part.replace('-', ':')}"
+
+
+def _status_for(run_dir: Path) -> str:
+    manifest_path = run_dir / "manifest.json"
+    if manifest_path.exists():
+        try:
+            m = json.loads(manifest_path.read_text())
+            status = m.get("status")
+            if status in ("completed", "failed", "running"):
+                return status
+        except Exception:
+            pass
+    status_rec = read_status(run_dir)
+    if status_rec and isinstance(status_rec.get("status"), str):
+        return status_rec["status"]
+    return "unknown"
+
+
+def _run_summary_payload(run_id: str, run_dir: Path) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "status": _status_for(run_dir),
+        "created_at": _created_at_from_run_id(run_id),
+    }
+
+
+@router.get("/runs", response_model=RunListResponse)
+def list_runs(request: Request) -> RunListResponse:
+    storage = request.app.state.storage
+    entries: list[RunSummary] = []
+    for rid in storage.list_run_ids():
+        rd = storage.run_dir(rid)
+        entries.append(RunSummary(**_run_summary_payload(rid, rd)))
+    return RunListResponse(runs=entries)
+
+
+def _resolve_run_dir(request: Request, run_id: str) -> Path:
+    storage = request.app.state.storage
+    run_dir = storage.run_dir(run_id)
+    if not run_dir.exists() or not run_dir.is_dir():
+        raise HTTPException(status_code=404, detail=f"Run {run_id!r} not found.")
+    return run_dir
+
+
+@router.get("/runs/{run_id}")
+def get_run(run_id: str, request: Request) -> JSONResponse:
+    run_dir = _resolve_run_dir(request, run_id)
+    manifest_path = run_dir / "manifest.json"
+    status = _status_for(run_dir)
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except Exception as exc:  # pragma: no cover
+            raise HTTPException(
+                status_code=500, detail=f"Corrupt manifest: {exc}",
+            ) from exc
+        manifest["status"] = status
+        return JSONResponse(content=manifest)
+    payload = _run_summary_payload(run_id, run_dir)
+    status_rec = read_status(run_dir) or {}
+    for key in ("input_sha256", "wall_time_s", "error"):
+        if key in status_rec:
+            payload[key] = status_rec[key]
+    return JSONResponse(content=payload)
+
+
+@router.get("/runs/{run_id}/manifest")
+def get_manifest(run_id: str, request: Request) -> FileResponse:
+    run_dir = _resolve_run_dir(request, run_id)
+    path = run_dir / "manifest.json"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Manifest not yet written.")
+    return FileResponse(str(path), media_type="application/json")
+
+
+@router.get("/runs/{run_id}/input")
+def get_input(run_id: str, request: Request) -> FileResponse:
+    run_dir = _resolve_run_dir(request, run_id)
+    path = run_dir / "input.json"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Input JSON not found.")
+    return FileResponse(str(path), media_type="application/json")
+
+
+@router.get("/runs/{run_id}/fields/{name}")
+def get_field(run_id: str, name: str, request: Request) -> FileResponse:
+    run_dir = _resolve_run_dir(request, run_id)
+    fields_dir = run_dir / "fields"
+    bp_dir = fields_dir / f"{name}.bp"
+    xdmf_path = fields_dir / f"{name}.xdmf"
+    if bp_dir.exists() and bp_dir.is_dir():
+        # VTX BP directories are multi-file; stream a tar.
+        import tarfile
+        import tempfile
+        fd, tmp = tempfile.mkstemp(prefix=f"{name}_", suffix=".tar")
+        import os
+        os.close(fd)
+        with tarfile.open(tmp, "w") as tar:
+            tar.add(str(bp_dir), arcname=f"{name}.bp")
+        return FileResponse(
+            tmp,
+            media_type="application/x-tar",
+            filename=f"{name}.bp.tar",
+        )
+    if xdmf_path.exists():
+        return FileResponse(str(xdmf_path), media_type="application/xml")
+    raise HTTPException(status_code=404, detail=f"Field {name!r} not found.")
+
+
+@router.get("/runs/{run_id}/iv/{contact}")
+def get_iv(run_id: str, contact: str, request: Request) -> FileResponse:
+    run_dir = _resolve_run_dir(request, run_id)
+    path = run_dir / "iv" / f"{contact}.csv"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail=f"IV file for {contact!r} not found.")
+    return FileResponse(str(path), media_type="text/csv")
+
+
+@router.get("/runs/{run_id}/logs")
+def get_logs(run_id: str, request: Request) -> FileResponse:
+    run_dir = _resolve_run_dir(request, run_id)
+    path = run_dir / "logs" / "engine.log"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Engine log not found.")
+    return FileResponse(str(path), media_type="text/plain")

--- a/kronos_server/routes/schema.py
+++ b/kronos_server/routes/schema.py
@@ -1,0 +1,70 @@
+"""Static metadata endpoints: /schema, /materials, /capabilities."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+
+from ..models import (
+    CapabilitiesBackends,
+    CapabilitiesEngine,
+    CapabilitiesPhysics,
+    CapabilitiesResponse,
+)
+
+router = APIRouter()
+
+
+@router.get("/schema")
+def get_schema() -> dict[str, Any]:
+    """The input JSON schema as an object. UI form-builders consume this."""
+    from semi.schema import SCHEMA
+    return SCHEMA
+
+
+@router.get("/materials")
+def get_materials() -> dict[str, dict[str, Any]]:
+    """Dump the material database: {name: parameters}."""
+    from dataclasses import asdict
+
+    from semi.materials import MATERIALS
+    return {name: asdict(mat) for name, mat in MATERIALS.items()}
+
+
+@router.get("/capabilities", response_model=CapabilitiesResponse)
+def get_capabilities() -> CapabilitiesResponse:
+    """Feature flags describing what this engine build supports.
+
+    Values are hard-coded from the current state of the codebase as shipped
+    at M10. Future milestones flip these flags as they land (see
+    docs/IMPROVEMENT_GUIDE.md §4).
+    """
+    try:
+        from semi import __version__
+        version = str(__version__)
+    except Exception:  # pragma: no cover
+        version = "unknown"
+
+    return CapabilitiesResponse(
+        engine=CapabilitiesEngine(name="kronos-semi", version=version),
+        solver_types=["equilibrium", "drift_diffusion", "bias_sweep", "mos_cv"],
+        dimensions=[1, 2, 3],
+        physics=CapabilitiesPhysics(
+            boltzmann=True,
+            fermi_dirac=False,
+            srh_recombination=True,
+            auger_recombination=False,
+            field_dependent_mobility=False,
+            transient=False,
+            ac_small_signal=False,
+            schottky_contacts=False,
+            heterojunctions=False,
+            tunneling=False,
+        ),
+        mesh_sources=["builtin", "gmsh"],
+        backends=CapabilitiesBackends(
+            cpu_mumps=True,
+            gpu_amgx=False,
+            gpu_hypre=False,
+        ),
+    )

--- a/kronos_server/routes/solve.py
+++ b/kronos_server/routes/solve.py
@@ -1,0 +1,86 @@
+"""POST /solve: validate JSON and enqueue a solve."""
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from ..models import SolveResponse
+
+router = APIRouter()
+
+
+@router.post(
+    "/solve",
+    response_model=SolveResponse,
+    status_code=202,
+    responses={400: {"description": "Invalid JSON or schema validation failure."}},
+)
+async def submit_solve(request: Request) -> JSONResponse:
+    raw = await request.body()
+    if not raw:
+        raise HTTPException(status_code=400, detail="Empty request body.")
+    try:
+        cfg = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "invalid_json", "message": str(exc)},
+        ) from exc
+
+    if not isinstance(cfg, dict):
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "invalid_input", "message": "Top-level JSON must be an object."},
+        )
+
+    # Validate against the input schema before enqueuing.
+    from semi.schema import SCHEMA, SchemaError, validate
+
+    try:
+        import jsonschema
+        validator = jsonschema.Draft7Validator(SCHEMA)
+        errors = sorted(validator.iter_errors(cfg), key=lambda e: list(e.path))
+        if errors:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "schema_validation_failed",
+                    "errors": [
+                        {
+                            "path": ".".join(str(p) for p in e.absolute_path) or "<root>",
+                            "message": e.message,
+                        }
+                        for e in errors
+                    ],
+                },
+            )
+    except ImportError:  # pragma: no cover
+        try:
+            validate(cfg)
+        except SchemaError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "schema_validation_failed", "message": str(exc)},
+            ) from exc
+
+    # Fill defaults (mirrors what `semi-run` does on disk) before handing to the worker.
+    # The worker reloads the file via schema.load() which re-applies defaults; pass the
+    # raw bytes unchanged so input.json on disk matches what the caller posted.
+    cfg_with_defaults = validate(cfg)
+
+    job_mgr = request.app.state.job_mgr
+    if not job_mgr.is_ready():
+        raise HTTPException(status_code=503, detail="Worker pool not ready.")
+
+    run_id = job_mgr.submit(raw, cfg_with_defaults)
+    response = SolveResponse(
+        run_id=run_id,
+        status="queued",
+        status_url=f"/runs/{run_id}",
+    )
+    return JSONResponse(
+        status_code=202,
+        content=response.model_dump(),
+    )

--- a/kronos_server/routes/stream.py
+++ b/kronos_server/routes/stream.py
@@ -1,0 +1,87 @@
+"""WebSocket progress stream: /runs/{id}/stream."""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from fastapi import APIRouter, WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+from ..jobs import read_status
+
+router = APIRouter()
+
+
+_POLL_INTERVAL_S = 0.05
+
+
+def _read_new_lines(path: Path, pos: int) -> tuple[list[str], int]:
+    if not path.exists():
+        return [], pos
+    with open(path) as f:
+        f.seek(pos)
+        lines = f.readlines()
+        new_pos = f.tell()
+    stripped = [ln.strip() for ln in lines if ln.strip()]
+    return stripped, new_pos
+
+
+def _is_terminal(status: str) -> bool:
+    return status in ("completed", "failed")
+
+
+@router.websocket("/runs/{run_id}/stream")
+async def ws_stream(websocket: WebSocket, run_id: str) -> None:
+    storage = websocket.app.state.storage
+    run_dir = storage.run_dir(run_id)
+    if not run_dir.exists():
+        await websocket.close(code=4404)
+        return
+
+    await websocket.accept()
+
+    progress_path = run_dir / "progress.ndjson"
+    pos = 0
+    saw_run_done = False
+
+    try:
+        while True:
+            lines, pos = _read_new_lines(progress_path, pos)
+            for line in lines:
+                await websocket.send_text(line)
+                try:
+                    evt = json.loads(line)
+                    if evt.get("type") == "run_done":
+                        saw_run_done = True
+                except json.JSONDecodeError:  # pragma: no cover
+                    pass
+            if saw_run_done:
+                break
+
+            # Also honour the status file: if the worker is finished but hasn't
+            # emitted run_done (e.g. hard crash), close cleanly rather than hang.
+            status_rec = read_status(run_dir)
+            if status_rec and _is_terminal(status_rec.get("status", "")):
+                # One more pass to catch any race-written lines.
+                lines, pos = _read_new_lines(progress_path, pos)
+                for line in lines:
+                    await websocket.send_text(line)
+                if not saw_run_done:
+                    await websocket.send_text(
+                        json.dumps({
+                            "type": "run_done",
+                            "status": status_rec["status"],
+                            "wall_time_s": status_rec.get("wall_time_s", 0.0),
+                        }),
+                    )
+                break
+
+            await asyncio.sleep(_POLL_INTERVAL_S)
+    except WebSocketDisconnect:  # pragma: no cover
+        return
+
+    try:
+        await websocket.close(code=1000)
+    except Exception:  # pragma: no cover
+        pass

--- a/kronos_server/storage.py
+++ b/kronos_server/storage.py
@@ -1,0 +1,23 @@
+"""Local-filesystem backend for run directories.
+
+The on-disk run directory is the source of truth; the server holds no durable
+state beyond what lives there. An S3 backend is a future milestone
+(TODO(M10+)).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class LocalStorage:
+    def __init__(self, root: Path):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def run_dir(self, run_id: str) -> Path:
+        return self.root / run_id
+
+    def list_run_ids(self) -> list[str]:
+        if not self.root.exists():
+            return []
+        return sorted(p.name for p in self.root.iterdir() if p.is_dir())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,16 +43,23 @@ dev = [
     "nbformat>=5.0",
     "ruff>=0.1",
 ]
+server = [
+    "fastapi>=0.115,<0.120",
+    "uvicorn[standard]>=0.32,<0.40",
+    "httpx>=0.27,<0.29",
+    "pydantic>=2.8,<3.0",
+]
 
 [project.scripts]
 semi-run = "semi.io.cli:main"
+kronos-server = "kronos_server.app:main"
 
 [project.urls]
 Repository = "https://github.com/rwalkerlewis/kronos-semi"
 Issues = "https://github.com/rwalkerlewis/kronos-semi/issues"
 
 [tool.hatch.build.targets.wheel]
-packages = ["semi"]
+packages = ["semi", "kronos_server"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/semi/__init__.py
+++ b/semi/__init__.py
@@ -15,7 +15,7 @@ The pure-Python modules (constants, materials, scaling, doping, schema)
 do not and can be imported and tested independently.
 """
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 # Pure-Python imports, always safe (doping requires numpy so is not imported here)
 from . import constants, materials, scaling, schema

--- a/semi/runners/bias_sweep.py
+++ b/semi/runners/bias_sweep.py
@@ -18,6 +18,7 @@ def run_bias_sweep(
     cfg: dict[str, Any],
     *,
     post_step_hook=None,
+    progress_callback=None,
 ):
     """
     Coupled drift-diffusion solver with optional bias ramping.
@@ -31,6 +32,10 @@ def run_bias_sweep(
     hook is expected to mutate `iv_row` in place (e.g. to record
     Phase 3 V&V continuity samples on top of the V / J the sweep
     already records). No return value is inspected.
+
+    `progress_callback`, if provided, is called with a plain dict per
+    successful bias step so the M10 HTTP server can surface SNES
+    progress on its WebSocket channel.
     """
     from dolfinx import fem
 
@@ -196,6 +201,11 @@ def run_bias_sweep(
               sweep_contact, sweep_facet_info, mu_n_SI, mu_p_SI)
     if post_step_hook is not None:
         post_step_hook(V_seed, spaces, iv_rows[-1])
+    if progress_callback is not None:
+        progress_callback({
+            "type": "step_done", "bias_step": 0, "V_applied": float(V_seed),
+            "iterations": int(info.get("iterations", 0)),
+        })
 
     def ramp_leg(V_start: float, V_target: float):
         """Adaptive single-direction ramp from V_start to V_target.
@@ -244,6 +254,13 @@ def run_bias_sweep(
                           sweep_contact, sweep_facet_info, mu_n_SI, mu_p_SI)
                 if post_step_hook is not None:
                     post_step_hook(V_try, spaces, iv_rows[-1])
+                if progress_callback is not None:
+                    progress_callback({
+                        "type": "step_done",
+                        "bias_step": len(iv_rows) - 1,
+                        "V_applied": float(V_try),
+                        "iterations": int(info.get("iterations", 0)),
+                    })
                 halvings = 0
                 controller.on_success(int(info.get("iterations", 0)))
                 continue

--- a/semi/runners/equilibrium.py
+++ b/semi/runners/equilibrium.py
@@ -12,7 +12,7 @@ from typing import Any
 import numpy as np
 
 
-def run_equilibrium(cfg: dict[str, Any]):
+def run_equilibrium(cfg: dict[str, Any], *, progress_callback=None):
     """M1 equilibrium Poisson solver (Boltzmann statistics)."""
     from dolfinx import fem
 
@@ -54,7 +54,14 @@ def run_equilibrium(cfg: dict[str, Any]):
     psi.x.scatter_forward()
 
     F = build_equilibrium_poisson_form(V, psi, N_hat_fn, sc, ref_mat.epsilon_r)
+    if progress_callback is not None:
+        progress_callback({"type": "step_started", "bias_step": 0, "V_applied": 0.0})
     info = solve_nonlinear(F, psi, bcs, prefix=f"{cfg['name']}_")
+    if progress_callback is not None:
+        progress_callback({
+            "type": "step_done", "bias_step": 0, "V_applied": 0.0,
+            "iterations": int(info.get("iterations", 0)),
+        })
 
     x_dof = V.tabulate_dof_coordinates()
     psi_phys = psi.x.array * sc.V0

--- a/semi/runners/mos_cv.py
+++ b/semi/runners/mos_cv.py
@@ -21,7 +21,7 @@ from typing import Any
 import numpy as np
 
 
-def run_mos_cv(cfg: dict[str, Any]):
+def run_mos_cv(cfg: dict[str, Any], *, progress_callback=None):
     """
     Run a MOS capacitor C-V sweep.
 
@@ -156,6 +156,13 @@ def run_mos_cv(cfg: dict[str, Any]):
             "Q_gate": float(Q_gate),
             "J": 0.0,
         })
+        if progress_callback is not None:
+            progress_callback({
+                "type": "step_done",
+                "bias_step": len(iv_rows) - 1,
+                "V_applied": float(V_gate),
+                "iterations": int(info.get("iterations", 0)),
+            })
 
     x_dof = V.tabulate_dof_coordinates()
     psi_phys = psi.x.array * sc.V0

--- a/tests/test_kronos_server.py
+++ b/tests/test_kronos_server.py
@@ -1,0 +1,304 @@
+"""
+Tests for the M10 kronos_server HTTP API.
+
+FEM-heavy tests (real /solve end-to-end) are skipped when dolfinx is
+unavailable, matching the M9 test convention. Pure-Python tests
+(schema, capabilities, CORS, 404) always run.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+try:
+    import dolfinx  # noqa: F401
+    HAS_DOLFINX = True
+except ImportError:
+    HAS_DOLFINX = False
+
+try:
+    import fastapi  # noqa: F401
+    import httpx  # noqa: F401
+    HAS_SERVER_DEPS = True
+except ImportError:
+    HAS_SERVER_DEPS = False
+
+pytestmark = pytest.mark.skipif(
+    not HAS_SERVER_DEPS,
+    reason="kronos_server requires fastapi + httpx (install with pip install -e '.[server]')",
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+BENCHMARKS_DIR = REPO_ROOT / "benchmarks"
+PN_1D_JSON = BENCHMARKS_DIR / "pn_1d" / "pn_junction.json"
+PN_1D_BIAS_JSON = BENCHMARKS_DIR / "pn_1d_bias" / "pn_junction_bias.json"
+
+
+@pytest.fixture
+def server_app(tmp_path, monkeypatch):
+    """Build a fresh app rooted at a temp runs dir and exercise its lifespan."""
+    monkeypatch.setenv("KRONOS_SERVER_RUNS_DIR", str(tmp_path))
+    monkeypatch.setenv("KRONOS_SERVER_WORKERS", "2")
+    monkeypatch.setenv(
+        "KRONOS_SERVER_CORS_ORIGINS",
+        "http://localhost:3000,http://example.com",
+    )
+    from kronos_server.app import build_app
+    from kronos_server.config import Settings
+    settings = Settings()
+    app = build_app(settings)
+    return app
+
+
+@pytest.fixture
+def client(server_app):
+    from fastapi.testclient import TestClient
+    with TestClient(server_app) as c:
+        yield c
+
+
+def _load_body(path: Path) -> bytes:
+    return path.read_bytes()
+
+
+def _poll_until_done(client, run_id: str, timeout_s: float = 60.0) -> dict:
+    deadline = time.monotonic() + timeout_s
+    last: dict = {}
+    while time.monotonic() < deadline:
+        r = client.get(f"/runs/{run_id}")
+        assert r.status_code == 200, r.text
+        last = r.json()
+        if last.get("status") in ("completed", "failed"):
+            return last
+        time.sleep(0.25)
+    raise AssertionError(f"run {run_id} did not finish in {timeout_s}s; last={last}")
+
+
+# ---------- Pure-Python tests (no dolfinx required) ----------
+
+
+def test_health(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_ready(client):
+    r = client.get("/ready")
+    assert r.status_code == 200
+    assert r.json() == {"ready": True}
+
+
+def test_capabilities(client):
+    r = client.get("/capabilities")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["engine"]["name"] == "kronos-semi"
+    assert body["solver_types"] == ["equilibrium", "drift_diffusion", "bias_sweep", "mos_cv"]
+    assert body["dimensions"] == [1, 2, 3]
+    assert body["mesh_sources"] == ["builtin", "gmsh"]
+    phys = body["physics"]
+    # Hard-coded booleans for the v0.10.0 build:
+    assert phys["boltzmann"] is True
+    assert phys["srh_recombination"] is True
+    assert phys["fermi_dirac"] is False
+    assert phys["auger_recombination"] is False
+    assert phys["field_dependent_mobility"] is False
+    assert phys["transient"] is False
+    assert phys["ac_small_signal"] is False
+    assert phys["schottky_contacts"] is False
+    assert phys["heterojunctions"] is False
+    assert phys["tunneling"] is False
+    backends = body["backends"]
+    assert backends["cpu_mumps"] is True
+    assert backends["gpu_amgx"] is False
+    assert backends["gpu_hypre"] is False
+
+
+def test_schema(client):
+    from semi.schema import SCHEMA
+    r = client.get("/schema")
+    assert r.status_code == 200
+    assert r.json() == SCHEMA
+
+
+def test_openapi_and_docs(client):
+    r = client.get("/openapi.json")
+    assert r.status_code == 200
+    spec = r.json()
+    assert spec["info"]["title"] == "kronos-semi HTTP server"
+    assert "/solve" in spec["paths"]
+    assert "/runs/{run_id}" in spec["paths"]
+    assert "/capabilities" in spec["paths"]
+
+
+def test_solve_validates_input(client):
+    # Bad JSON
+    r = client.post("/solve", content=b"{ this is not json", headers={"Content-Type": "application/json"})
+    assert r.status_code == 400
+    body = r.json()
+    assert body["detail"]["error"] == "invalid_json"
+
+    # Schema violation: missing required `name`
+    bad_cfg = {"dimension": 1}
+    r = client.post("/solve", json=bad_cfg)
+    assert r.status_code == 400
+    body = r.json()
+    assert body["detail"]["error"] == "schema_validation_failed"
+    assert isinstance(body["detail"]["errors"], list)
+    assert len(body["detail"]["errors"]) >= 1
+
+
+def test_run_not_found(client):
+    r = client.get("/runs/nonexistent_run_id_abcdef")
+    assert r.status_code == 404
+
+
+def test_materials(client):
+    r = client.get("/materials")
+    assert r.status_code == 200
+    body = r.json()
+    assert "Si" in body
+    assert body["Si"]["role"] == "semiconductor"
+
+
+def test_cors_headers(client):
+    r = client.options(
+        "/capabilities",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    # FastAPI/Starlette's CORSMiddleware responds 200 on preflight for allowed origins.
+    assert r.status_code == 200
+    assert r.headers.get("access-control-allow-origin") == "http://example.com"
+
+
+# ---------- FEM-backed end-to-end tests ----------
+
+
+@pytest.mark.skipif(not HAS_DOLFINX, reason="dolfinx required")
+def test_solve_enqueues_and_completes(client, tmp_path):
+    body = _load_body(PN_1D_JSON)
+    r = client.post("/solve", content=body, headers={"Content-Type": "application/json"})
+    assert r.status_code == 202, r.text
+    data = r.json()
+    run_id = data["run_id"]
+    assert data["status"] == "queued"
+    assert data["status_url"] == f"/runs/{run_id}"
+
+    final = _poll_until_done(client, run_id, timeout_s=60.0)
+    assert final["status"] == "completed", final
+
+    # Manifest on disk matches what the HTTP response returned.
+    runs_root = Path(client.app.state.settings.runs_dir)
+    from semi.io import read_manifest
+    on_disk = read_manifest(runs_root / run_id)
+    for key in ("run_id", "engine", "solver", "fields", "mesh", "input_sha256"):
+        assert on_disk[key] == final[key], f"mismatch on {key}"
+    assert final["status"] == "completed"
+
+
+@pytest.mark.skipif(not HAS_DOLFINX, reason="dolfinx required")
+def test_field_download(client):
+    body = _load_body(PN_1D_JSON)
+    r = client.post("/solve", content=body, headers={"Content-Type": "application/json"})
+    run_id = r.json()["run_id"]
+    _poll_until_done(client, run_id)
+
+    r = client.get(f"/runs/{run_id}/fields/psi")
+    assert r.status_code == 200
+    # BP directories come back as a tar archive; just assert non-empty bytes.
+    assert len(r.content) > 0
+    # Also verify the file really exists on disk.
+    runs_root = Path(client.app.state.settings.runs_dir)
+    assert (runs_root / run_id / "fields" / "psi.bp").exists()
+
+
+@pytest.mark.skipif(not HAS_DOLFINX, reason="dolfinx required")
+def test_iv_download(client):
+    body = _load_body(PN_1D_BIAS_JSON)
+    r = client.post("/solve", content=body, headers={"Content-Type": "application/json"})
+    run_id = r.json()["run_id"]
+    _poll_until_done(client, run_id, timeout_s=120.0)
+
+    r = client.get(f"/runs/{run_id}/iv/anode")
+    assert r.status_code == 200
+    runs_root = Path(client.app.state.settings.runs_dir)
+    disk_csv = (runs_root / run_id / "iv" / "anode.csv").read_bytes()
+    assert r.content == disk_csv
+
+
+@pytest.mark.skipif(not HAS_DOLFINX, reason="dolfinx required")
+def test_input_download(client):
+    body = _load_body(PN_1D_JSON)
+    r = client.post("/solve", content=body, headers={"Content-Type": "application/json"})
+    run_id = r.json()["run_id"]
+    _poll_until_done(client, run_id)
+
+    r = client.get(f"/runs/{run_id}/input")
+    assert r.status_code == 200
+    assert r.content == body
+
+
+@pytest.mark.skipif(not HAS_DOLFINX, reason="dolfinx required")
+def test_websocket_progress(client):
+    """Connect during a bias sweep and assert at least n_steps messages arrive."""
+    from starlette.websockets import WebSocketDisconnect
+
+    body = _load_body(PN_1D_BIAS_JSON)
+    r = client.post("/solve", content=body, headers={"Content-Type": "application/json"})
+    run_id = r.json()["run_id"]
+
+    messages: list[dict] = []
+    with client.websocket_connect(f"/runs/{run_id}/stream") as ws:
+        while True:
+            try:
+                text = ws.receive_text()
+            except WebSocketDisconnect:
+                break
+            try:
+                evt = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            messages.append(evt)
+            if evt.get("type") == "run_done":
+                break
+
+    step_done = [m for m in messages if m.get("type") == "step_done"]
+    # pn_1d_bias ramps 0 -> 0.6 V in 0.05 V steps: expect well over 5 accepted
+    # steps including the seed solve at V=0. At least 5 is a comfortable floor.
+    assert len(step_done) >= 5, f"too few step_done messages: {messages}"
+    run_done = [m for m in messages if m.get("type") == "run_done"]
+    assert len(run_done) == 1
+    assert run_done[0]["status"] == "completed"
+
+
+@pytest.mark.skipif(not HAS_DOLFINX, reason="dolfinx required")
+def test_concurrent_solves(client):
+    """Fire three solves; confirm they all complete with distinct run_ids."""
+    body = _load_body(PN_1D_JSON)
+    ids: list[str] = []
+    for _ in range(3):
+        r = client.post("/solve", content=body, headers={"Content-Type": "application/json"})
+        assert r.status_code == 202, r.text
+        ids.append(r.json()["run_id"])
+        # Force a millisecond of separation so the `ts_name_sha` prefix differs;
+        # the fallback suffix handles collisions within the same second.
+        time.sleep(0.01)
+
+    assert len(set(ids)) == 3, f"run_ids collided: {ids}"
+
+    for rid in ids:
+        final = _poll_until_done(client, rid, timeout_s=120.0)
+        assert final["status"] == "completed", f"{rid} -> {final}"
+
+    # Listing surface should reflect all three runs.
+    r = client.get("/runs")
+    assert r.status_code == 200
+    listed = {e["run_id"] for e in r.json()["runs"]}
+    assert set(ids).issubset(listed)


### PR DESCRIPTION
## Summary

- Adds `kronos_server/` — a FastAPI server exposing the engine over HTTP
- `POST /solve` accepts a JSON benchmark body, spawns a FEM worker subprocess, and streams progress via WebSocket
- `GET /runs/{id}`, `/runs/{id}/manifest`, `/runs/{id}/iv/{contact}` expose the M9 artifact tree
- `GET /health`, `/ready`, `/capabilities`, `/schema` serve without importing dolfinx
- `kronos-server` console entry point; `server` Docker Compose service
- 15 new server tests; total suite 230 tests at ≥95% coverage
- README updated to v0.10.0 with capability matrix, "Running the HTTP server" subsection, and updated scope/design-notes sections
- `semi/__version__` bumped 0.9.0 → 0.10.0

## Test plan

- [ ] CI passes (lint + pure tests + FEM tests)
- [ ] `docker compose run --rm test` green (230 tests)
- [ ] `docker compose up -d server && curl http://localhost:8000/health` returns `{"status":"ok"}`
- [ ] `POST /solve` with `benchmarks/pn_1d/pn_junction.json` body completes and returns a run manifest
- [ ] All README cross-references resolve (verified locally: 20/20 OK)