### PR TITLE
fix: restore CI to green after M12 merge

### DIFF
--- a/benchmarks/pn_1d_bias/pn_junction_bias.json
+++ b/benchmarks/pn_1d_bias/pn_junction_bias.json
@@ -50,6 +50,12 @@
   },
   "solver": {
     "type": "bias_sweep",
+    "snes": {
+      "rtol": 1.0e-14,
+      "atol": 1.0e-14,
+      "stol": 1.0e-14,
+      "max_it": 60
+    },
     "continuation": {
       "min_step": 1.0e-4,
       "max_halvings": 6,

--- a/benchmarks/pn_1d_bias_reverse/pn_junction_bias_reverse.json
+++ b/benchmarks/pn_1d_bias_reverse/pn_junction_bias_reverse.json
@@ -50,6 +50,12 @@
   },
   "solver": {
     "type": "bias_sweep",
+    "snes": {
+      "rtol": 1.0e-14,
+      "atol": 1.0e-14,
+      "stol": 1.0e-14,
+      "max_it": 60
+    },
     "continuation": {
       "min_step": 1.0e-5,
       "max_halvings": 12,

--- a/schemas/input.v1.json
+++ b/schemas/input.v1.json
@@ -487,6 +487,37 @@
             }
           }
         },
+        "snes": {
+          "type": "object",
+          "title": "PETSc SNES tolerance overrides for the bias_sweep DD block",
+          "description": "Per-config overrides for the SNES nonlinear solver tolerances inside the coupled drift-diffusion block. Defaults match docs/adr/0008-snes-tolerances.md (rtol=1e-10, atol=1e-7, stol=1e-14, max_it=100). Single-region 1D pn_1d_bias{,_reverse} benchmarks override these to machine-tight values to satisfy the 5%/15% current-continuity gates.",
+          "properties": {
+            "rtol": {
+              "type": "number",
+              "exclusiveMinimum": 0.0,
+              "description": "SNES relative residual tolerance.",
+              "default": 1.0e-10
+            },
+            "atol": {
+              "type": "number",
+              "exclusiveMinimum": 0.0,
+              "description": "SNES absolute residual tolerance.",
+              "default": 1.0e-7
+            },
+            "stol": {
+              "type": "number",
+              "exclusiveMinimum": 0.0,
+              "description": "SNES step-size tolerance.",
+              "default": 1.0e-14
+            },
+            "max_it": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Maximum SNES iterations per Newton solve in the bias_sweep DD block.",
+              "default": 100
+            }
+          }
+        },
         "continuation": {
           "type": "object",
           "title": "Bias continuation controller",

--- a/semi/runners/bias_sweep.py
+++ b/semi/runners/bias_sweep.py
@@ -97,6 +97,19 @@ def run_bias_sweep(
     easy_iter_threshold = int(cont.get("easy_iter_threshold", 4))
     grow_factor = float(cont.get("grow_factor", 1.5))
 
+    # SNES tolerances for the coupled DD block solve. Defaults match the
+    # M12 close-out values documented in docs/adr/0008-snes-tolerances.md.
+    # Per-config overrides live under solver.snes so legacy benchmarks
+    # (pn_1d_bias, pn_1d_bias_reverse) can keep machine-tight convergence
+    # required to pass <5% / <15% current-continuity gates.
+    snes_opts = cfg.get("solver", {}).get("snes", {}) or {}
+    snes_petsc_options = {
+        "snes_rtol": float(snes_opts.get("rtol", 1.0e-10)),
+        "snes_atol": float(snes_opts.get("atol", 1.0e-7)),
+        "snes_stol": float(snes_opts.get("stol", 1.0e-14)),
+        "snes_max_it": int(snes_opts.get("max_it", 100)),
+    }
+
     F_list = build_dd_block_residual(
         spaces, N_hat_fn, sc, ref_mat.epsilon_r,
         mu_n_hat, mu_p_hat, tau_n_hat, tau_p_hat, E_t_over_Vt,
@@ -165,22 +178,10 @@ def run_bias_sweep(
                 bc.set(fn.x.array)
         for fn in (spaces.psi, spaces.phi_n, spaces.phi_p):
             fn.x.scatter_forward()
-        # SNES tolerances: rtol/atol are relaxed from 1e-14 to 1e-10/1e-7
-        # because the scaled Slotboom residuals span many orders of magnitude
-        # across psi, phi_n, and phi_p blocks at high injection levels, making
-        # sub-1e-10 relative convergence unachievable without sacrificing
-        # physical accuracy. stol is kept tight to enforce displacement
-        # convergence. max_it raised to 100 for robustness on fine MOSFET
-        # meshes.  See docs/adr/0008-snes-tolerances.md.
         return solve_nonlinear_block(
             F_list, [spaces.psi, spaces.phi_n, spaces.phi_p],
             bcs, prefix=f"{cfg['name']}_dd_{tag}_",
-            petsc_options={
-                "snes_rtol": 1.0e-10,
-                "snes_atol": 1.0e-7,
-                "snes_stol": 1.0e-14,
-                "snes_max_it": 100,
-            },
+            petsc_options=snes_petsc_options,
         )
 
     sweep_facet_info = None

--- a/tests/fem/test_bias_sweep_multiregion.py
+++ b/tests/fem/test_bias_sweep_multiregion.py
@@ -9,9 +9,6 @@ two-region (Si + SiO2) 1D geometry to verify:
 """
 from __future__ import annotations
 
-import numpy as np
-import pytest
-
 
 def _minimal_multiregion_bias_cfg(n_steps: int = 3, stop: float = 0.15) -> dict:
     """


### PR DESCRIPTION
## Summary

Restores `Tests` workflow on `main` to green after the M12 close-out
merge (#27, commit 7de574b). Three CI failures, two root cause categories.

- **(f) lint:** `tests/fem/test_bias_sweep_multiregion.py` had `numpy`
  and `pytest` imported but unused (`F401`).
- **(a) test regression:** the M12 SNES tolerance relaxation
  (atol 1e-14 → 1e-7, rtol 1e-14 → 1e-10) broke two benchmarks that
  the legacy `pn_1d_bias` and `pn_1d_bias_reverse` configs were
  validated against. Forward continuity drifted to **8.60%** vs the
  5% gate; reverse ramp failed to converge at V=-0.7 V after 13
  halvings.

## Fix

1. Drop the unused imports.
2. Wire `cfg["solver"]["snes"]` overrides through
   `semi/runners/bias_sweep.py`. Default tolerances stay at the
   M12 close-out values (atol=1e-7, rtol=1e-10, stol=1e-14, max_it=100).
3. Re-tighten only the two affected benchmarks via
   `solver.snes` overrides (rtol=atol=stol=1e-14, max_it=60).
4. Document `solver.snes` in `schemas/input.v1.json`.

## Constraints honored

- M12 default `atol` stays at `1e-7` — only per-config overrides
  are tighter (no further relaxation).
- `docs/adr/0008-snes-tolerances.md`, `PLAN.md`, `CHANGELOG.md`,
  version (`0.12.0`) untouched.
- 95% coverage gate untouched.
- ±20% MOSFET verifier tolerance untouched.
- No test marked `xfail` or `skip`.

## Verification

Pre-fix (CI run [24919461898](https://github.com/rwalkerlewis/kronos-semi/actions/runs/24919461898) on `main @ 47eab1a`):
- `pytest`: 236 passed, **3 failed** (`pn_1d_bias_*` continuity + artifact)
- `ruff`: **2 errors** (F401)

Post-fix (this branch, Docker):
- `pytest tests/ --cov=semi --cov-fail-under=95` → **239 passed**, coverage **95.46%**
- `ruff check semi/ tests/` → **clean**
- benchmarks: `pn_1d`, `pn_1d_bias` (1.91% J continuity), `pn_1d_bias_reverse` (0.01%), `mos_2d`, `resistor_3d` — all PASS
- `scripts/run_verification.py all` → all MMS Poisson/DD rates above threshold

## Out of scope

The `mosfet_2d` benchmark on `main` has an unrelated pre-existing schema
mismatch (`profile.donor: true` vs the schema's `profile.dopant: "donor"`).
It is not referenced by any CI test, conservation test, or artifact test,
so it does not gate CI — leaving for a separate follow-up.

## Test plan

- [x] `pytest tests/` in dolfinx Docker container → 239 passed
- [x] `--cov-fail-under=95` → 95.46%
- [x] `ruff check semi/ tests/` clean
- [x] All five CI benchmarks pass with verifier checks
- [x] V&V suite (`scripts/run_verification.py all`) all PASS
- [ ] CI Tests workflow on this branch goes green

Refs #26