### PR TITLE
fix: mosfet_2d schema validation for gaussian doping profile

### DIFF
--- a/benchmarks/mosfet_2d/mosfet_2d.json
+++ b/benchmarks/mosfet_2d/mosfet_2d.json
@@ -34,7 +34,7 @@
         "center": [0.5e-6, 2.0e-6],
         "sigma": [0.4e-6, 0.15e-6],
         "peak": 5.0e19,
-        "donor": true
+        "dopant": "donor"
       }
     },
     {
@@ -44,7 +44,7 @@
         "center": [4.5e-6, 2.0e-6],
         "sigma": [0.4e-6, 0.15e-6],
         "peak": 5.0e19,
-        "donor": true
+        "dopant": "donor"
       }
     }
   ],


### PR DESCRIPTION
## Summary

The `mosfet_2d` benchmark was failing JSON schema validation on the two Gaussian source/drain implants. The JSON used the field `"donor": true` (boolean), but the schema (`schemas/input.v1.json`) declares the gaussian profile dopant species as a string-enum field `"dopant": "donor"|"acceptor"` — which matches the engine reader at `semi/doping.py:96` (`p["dopant"] == "donor"`). This was a pre-existing M12 bug (the original M12 close-out PR shipped the JSON inconsistent with the schema and engine), surfaced during M13 work and blocking the benchmark from running.

This PR is a **single-file JSON fixture fix**: `"donor": true` → `"dopant": "donor"` in both Gaussian implants. Schema, engine, and test code are not modified.

## Validation error pre-fix

```
SchemaError: JSON schema validation failed:
  at doping.1.profile: {'type': 'gaussian', ..., 'donor': True}
    is not valid under any of the given schemas
  at doping.2.profile: {'type': 'gaussian', ..., 'donor': True}
    is not valid under any of the given schemas
```

## Diff

```diff
-        "donor": true
+        "dopant": "donor"
```

(applied to both Gaussian implants in `benchmarks/mosfet_2d/mosfet_2d.json`)

## Post-fix benchmark suite (Docker)

| benchmark | schema | runner | verifier |
|---|---|---|---|
| pn_1d | pass | pass | PASS |
| pn_1d_bias | pass | pass | PASS |
| pn_1d_bias_reverse | pass | pass | PASS |
| mos_2d | pass | pass | PASS |
| resistor_3d | pass | pass | PASS¹ |
| pn_1d_turnon | pass | pass | none registered |
| mosfet_2d | **pass** | **pass** | none registered² |

¹ Required `--input resistor.json`; pre-existing multi-JSON discovery issue, unrelated to this change.

² mosfet_2d now converges cleanly (1 SNES iter, 3.57 s, 1122 DOF) at V_DS=0.05 V. **No `±20%` I_D verifier is registered for this benchmark.** The current `bias_sweep._resolve_sweep` (`semi/runners/bias_sweep.py:333`) iterates only `ohmic` contacts, so the `gate` `voltage_sweep` is not exercised — the benchmark only solves the V_GS=0 operating point. Adding gate-sweep support and a long-channel ±20% I_D-V_GS verifier is **out of scope for this schema-only fix** and would expand into runner code that the prompt instructed me to leave alone (M12 close-out files). It should be tracked as a follow-up (M12.1 or rolled into M16 mobility/physics-completeness work).

## Post-fix MOSFET solver report

```
converged    = True
iterations   = 1
reason       = 2  (SNES_CONVERGED_FNORM_RELATIVE)
solve_time   = 3.570 s
dof_count    = 1122
scaling      = L0=5.00e-06 m, C0=5.00e+25 m^-3, V0=0.0259 V
```

## Test plan

- [x] `docker compose run --rm benchmark mosfet_2d` succeeds (no schema error)
- [x] Full benchmark suite re-run; no regressions in pn_1d, pn_1d_bias, pn_1d_bias_reverse, mos_2d, resistor_3d
- [x] Schema and engine code untouched (single-file diff)
- [ ] Reviewer to decide whether to track the missing I_D-V_GS verifier as a separate issue