### PR TITLE
feat(M14): small-signal AC sweep runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,90 @@
 # Changelog
 
+## [0.14.0] - M14: Small-signal AC sweep
+
+### Added
+- `semi/runners/ac_sweep.py`: `run_ac_sweep(cfg, progress_callback=None)`
+  runner. Solves the linearised system `(J + jωM) δu = -dF/dV δV`
+  around a converged DC operating point at each frequency in a
+  user-specified sweep. Reports admittance Y, impedance Z, capacitance
+  C(ω) = -Im(Y) / (2π f), and conductance G(ω) = Re(Y) at the swept
+  contact. Internally:
+  * obtains the DC operating point by calling `run_bias_sweep` at the
+    requested `dc_bias.voltage` (and at V_DC + ε for the finite-
+    difference DC sensitivity);
+  * converts the Slotboom (ψ, φ_n, φ_p) DC solution to (ψ, n_hat, p_hat)
+    primary-density form via Boltzmann statistics;
+  * assembles the steady-state DD Jacobian J in primary-density form
+    and the lumped mass matrix M (carrier rows only; ψ has no time
+    derivative because the engine is quasi-electrostatic);
+  * builds and solves the **real 2×2 block reformulation** of the
+    complex linear system at each frequency, since the dolfinx-real
+    PETSc build (the one used in CI) does not support complex scalars;
+  * evaluates terminal current including the **displacement** term
+    `j ω ε grad(δψ)·n` at the contact, in addition to the linearised
+    conduction current.
+- `semi/results.py`: `AcSweepResult` dataclass with `frequencies`,
+  `Y`, `Z`, `C`, `G`, `dc_bias`, and `meta` fields. Follows the JSON-
+  as-contract invariant; complex numbers serialise as
+  `{"re": ..., "im": ...}` in the artifact writer.
+- `schemas/input.v1.json`: `solver.type` enum extended with
+  `"ac_sweep"`. New solver sub-objects: `solver.dc_bias`
+  (`{contact, voltage}`) and `solver.ac` (`{contact, amplitude,
+  frequencies}`). `frequencies` accepts an explicit `list`, a
+  `logspace` spec, or a `linspace` spec.
+- `semi/schema.py`: `SCHEMA_SUPPORTED_MINOR` bumped 1 → 2.
+- `benchmarks/rc_ac_sweep/`: M14 acceptance benchmark. 1D pn diode at
+  V_DC = -1.0 V swept 1 Hz to 1 GHz logspace 41 points. `scripts/
+  run_benchmark.py` adds a registered verifier that asserts C(f) is
+  within 5 % of the analytical depletion capacitance over [1 Hz,
+  1 MHz] and that the plateau is flat to 2 %; current measurement
+  matches to **0.41 %** worst-case.
+- `tests/mms/test_ac_consistency.py`: MMS-style AC consistency test.
+  Three checks: Y(ω = 0) is purely real; Re(Y) is stable from ω = 0
+  to ω = 2π·1e-3 Hz; C(f) is ω-independent at low frequency in the
+  depletion regime.
+- `tests/fem/test_ac_dc_limit.py`: M14 acceptance test #2. Asserts
+  C(1 Hz) matches analytical depletion C within 5 % at three reverse
+  biases (V_DC ∈ {-2.0, -1.0, -0.5} V).
+- `docs/adr/0011-ac-small-signal.md`: ADR documenting the
+  formulation, the (ψ, n, p) primary-variable choice, the real 2×2
+  block reformulation forced by the PETSc-real build, the engineering
+  sign convention for terminal Y, and the validation strategy.
+
+### Changed
+- `semi/run.py`: dispatches `solver.type == "ac_sweep"` to
+  `run_ac_sweep`.
+- `semi/runners/__init__.py`: exports `run_ac_sweep`.
+- `scripts/run_benchmark.py`: AC results (`AcSweepResult`) now print
+  ac-specific diagnostics; the `cfg` is attached to AC results so
+  verifier and plotter can recompute the analytical reference.
+  Plotter `rc_ac_sweep` writes a Bode plot of |Y|, C, and |G| with
+  the analytical C overlaid.
+- `pyproject.toml` version bumped `0.13.0 → 0.14.0`.
+- `semi/__init__.py` `__version__` bumped `0.13.0 → 0.14.0`.
+
+### Design notes
+- ADR 0011: the (ψ, n, p) primary-density form is reused from M13 to
+  share the lumped mass matrix and avoid a chain-rule mass on the
+  Slotboom variables. The real 2×2 block reformulation is the
+  PETSc-build-driven choice (no complex scalars in the CI image); a
+  complex backend is left as an M16+ upgrade.
+- The sign convention `Y = -j ω C` for an ideal capacitor is the
+  consequence of reporting "current OUT of device" (matching
+  `postprocess.evaluate_current_at_contact`); a circuit-side
+  "current INTO device" report would give `Y = +j ω C`. The runner
+  documents this in code comments and in `AcSweepResult.C`'s
+  docstring.
+
+### Out of scope (deferred)
+- Direct `dF/dV` assembly via UFL action on a BC-perturbation function
+  (cleaner than finite difference; M16).
+- Complex PETSc backend (`PETSC_USE_COMPLEX=1` Docker image).
+- Upgrading the `mos_2d` C-V benchmark to use AC admittance instead of
+  `mos_cv`'s numerical dQ/dV (listed as M14 deliverable in the
+  IMPROVEMENT_GUIDE, but `mos_cv` is left untouched in this PR;
+  tracked as M14.1).
+
 ## [0.13.0] - M13: Transient solver (BDF1/BDF2)
 
 ### Added

--- a/PLAN.md
+++ b/PLAN.md
@@ -35,51 +35,71 @@ recombination for 1D/2D/3D devices.
 
 ## Current state
 
-M1 through M13 are merged into `main`. M9 delivered the on-disk artifact
+M1 through M14 are merged into `main`. M9 delivered the on-disk artifact
 contract; M10 exposed the engine over HTTP; M11 versions the input
 schema and ships the UI-facing schema companion; M12 closes out the
 MOSFET benchmark with n+ Gaussian source/drain implants and amends the
 SNES tolerances for high-injection multi-region problems; M13 delivers
 the transient solver with BDF1/BDF2 time integration in (ψ, n, p)
-primary-density form. `CHANGELOG.md` records the `[0.13.0] - M13` entry.
+primary-density form; M14 ships the small-signal AC sweep runner with
+a real 2x2 block reformulation of the (J + jωM) δu = -dF/dV δV system,
+displacement current at the contact, and an RC depletion-capacitance
+benchmark validated to 0.4 % of the analytical model.
+`CHANGELOG.md` records the `[0.14.0] - M14` entry.
 
 The capability matrix (verified in CI) is authoritative: see `README.md`
 §Status or `docs/ROADMAP.md`.
 
 ### What works (verified in Docker on current `main`)
 
-- Everything from M1–M12 (see CHANGELOG.md for details).
-- **M13 deliverables (new in v0.13.0):**
-  - `semi/timestepping.py` — `BDFCoefficients` class (BDF1 and BDF2).
-  - `semi/fem/mass.py` — `assemble_lumped_mass` for n and p spaces.
-  - `semi/results.py` — `TransientResult` dataclass.
-  - `semi/runners/transient.py` — `run_transient(cfg)` in (ψ, n, p) form.
-  - `semi/postprocess.py` — `evaluate_partial_currents` helper.
-  - `schemas/input.v1.json` — `solver.type` extended with `"transient"`.
-  - `semi/schema.py` — `SCHEMA_SUPPORTED_MINOR = 1`.
-  - `benchmarks/pn_1d_turnon/` — 1D pn diode transient turn-on benchmark.
-  - `tests/fem/test_transient_steady_state.py` — steady-state limit test.
-  - `tests/mms/test_transient_convergence.py` — temporal MMS convergence.
-  - `docs/adr/0009-transient-formulation.md` and `0010-bdf-time-integration.md`.
-  - ADR 0009: (n, p) primary form for transient continuity.
-  - ADR 0010: BDF1/BDF2 selection; consistent mass in UFL forms.
+- Everything from M1–M13 (see CHANGELOG.md for details).
+- **M14 deliverables (new in v0.14.0):**
+  - `semi/runners/ac_sweep.py` — `run_ac_sweep(cfg)` in (ψ, n, p) primary
+    density form. Real 2x2 block reformulation of the complex linear
+    system, MUMPS direct LU per frequency. Includes both linearised
+    conduction and displacement current at the swept contact.
+  - `semi/results.py` — `AcSweepResult` dataclass with frequencies, Y,
+    Z, C, G, dc_bias, and meta.
+  - `schemas/input.v1.json` — `solver.type` extended with `"ac_sweep"`,
+    plus `solver.dc_bias` and `solver.ac` (frequency sweep spec).
+  - `semi/schema.py` — `SCHEMA_SUPPORTED_MINOR = 2`; schema_version 1.2.0.
+  - `benchmarks/rc_ac_sweep/` — 1D pn diode at V_DC = -1 V, AC sweep
+    1 Hz to 1 GHz, 41 logspace; verifier matches analytical depletion C
+    within 0.4 % over [1 Hz, 1 MHz].
+  - `tests/mms/test_ac_consistency.py` — three MMS-style AC consistency
+    invariants (Y(0) real, Re(Y) stable at low ω, C(f) ω-independent).
+  - `tests/fem/test_ac_dc_limit.py` — depletion-C agreement within 5 %
+    at three reverse biases.
+  - `docs/adr/0011-ac-small-signal.md` — formulation, primary-variable
+    choice, real 2x2 block reformulation rationale, sign convention.
 
 ### What does not work / not yet built
 
 The gaps between the current state and a production UI-backed engine
 are enumerated and sequenced in
 [`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md), milestones
-M14 through M18. Summary:
+M15 through M18. Summary:
 
-- **No AC small-signal.** M14.
 - **Linear solver is CPU-LU only.** Unusable above ~200k DOFs. M15.
 - **Physics gaps:** no field-dependent mobility, Auger, Fermi-Dirac,
   Schottky contacts, tunneling, heterojunctions. M16, M17.
+- **Heterojunctions:** position-dependent χ and Eg not yet supported.
+  M17.
+- **Open M14.1:** the `mos_2d` C-V benchmark still uses `mos_cv`
+  numerical dQ/dV; switching it to AC admittance is listed as M14
+  deliverable in IMPROVEMENT_GUIDE but is left to M14.1.
 
 ## Next task
 
-**M14: AC small-signal analysis** (see
-[`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md) §M14).
+**M13.1 / M14.1 cleanup** (small follow-ups before M15) —
+- M13.1: re-enable the xfailed `test_transient_steady_state.py` once
+  the SRH-coupled steady-state limit is investigated (see ADR 0009
+  "Known limitation").
+- M14.1: rewire `benchmarks/mos_2d` to use the AC admittance for true
+  C(V) rather than the `mos_cv` runner's numerical dQ/dV.
+
+After both, **M15: GPU linear solver path** (see
+[`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md) §M15).
 
 ## Roadmap
 
@@ -98,7 +118,7 @@ M14 through M18. Summary:
 | M11: Schema versioning | UI-facing schema companion, form-builder annotations | Done |
 | M12: MOSFET n+ + SNES amendment | Gaussian implants, relaxed SNES tols, ADR 0008 | Done |
 | M13: Transient solver | Backward-Euler + BDF2, diode turn-on benchmark | Done |
-| M14: AC small-signal | Complex-frequency admittance, true C-V | Planned |
+| M14: AC small-signal | Linearised (J + jωM) δu = -dF/dV δV; rc_ac_sweep verifier within 0.4% of analytical C_dep; ADR 0011 | Done |
 | M15: GPU linear solver | PETSc CUDA/HIP, AMGX preconditioner, 500k-DOF 3D benchmark | Planned |
 | M16: Physics completeness | Caughey-Thomas, Lombardi, Auger, FD, Schottky, tunneling | Planned |
 | M17: Heterojunctions | Position-dependent chi, Eg; HEMT or HBT benchmark | Planned |
@@ -195,6 +215,28 @@ items.
 ## Completed work log
 
 Append-only. Newest entries on top.
+
+- **M14 (2026-04-26):** Small-signal AC sweep runner. Added
+  `semi/runners/ac_sweep.py` solving the linearised system
+  (J + jωM) δu = -dF/dV δV around a converged DC operating point. The
+  Jacobian J is the steady-state DD operator at u_0 in (ψ, n_hat,
+  p_hat) primary-density form; M is the lumped diagonal carrier-density
+  mass shipped with M13 (`semi/fem/mass.py`); -dF/dV is obtained via
+  finite-difference DC sensitivity (eps_V = 1e-3 V) under the hood.
+  PETSc-real build forces a real 2x2 block reformulation
+  ([[J, -ωM], [ωM, J]] [[Re δu], [Im δu]] = [[Re b], [Im b]]); ADR
+  0011 documents the decision and lists complex PETSc as deferred
+  M16+ work. Terminal admittance includes the displacement current
+  jω·ε·grad(δψ)·n at the contact in addition to the linearised
+  conduction current. Added `AcSweepResult` to `semi/results.py`,
+  bumped `schemas/input.v1.json` to 1.2.0 and `SCHEMA_SUPPORTED_MINOR`
+  to 2 (new `solver.dc_bias` and `solver.ac` sub-objects). Acceptance
+  benchmark `benchmarks/rc_ac_sweep/` matches analytical pn depletion
+  C within 0.41 % worst-case at V_DC = -1 V across [1 Hz, 1 MHz];
+  `tests/fem/test_ac_dc_limit.py` matches within 5 % at V_DC ∈
+  {-2.0, -1.0, -0.5} V; `tests/mms/test_ac_consistency.py` checks
+  three internal AC-formulation invariants. Version bumped to
+  0.14.0.
 
 - **M12 (2026-04-25):** MOSFET n+ doping + SNES tolerance amendment.
   Added `benchmarks/mosfet_2d/mosfet_2d.json` with three doping entries:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ production engine suitable for web UI integration.
 If you're a contributor or a coding agent, start at the [Orientation](#orientation)
 section.
 
-## Status (v0.13.0, end of M13)
+## Status (v0.14.0, end of M14)
 
-Milestones M1 through M12 are merged on `main`. The capability matrix is
+Milestones M1 through M14 are merged on `main`. The capability matrix is
 what the engine actually does today, verified in CI:
 
 | Capability                         | Dimensions    | Status  | Verifier                                                     |
@@ -27,7 +27,7 @@ what the engine actually does today, verified in CI:
 | File-sourced gmsh .msh meshes      | 3D            | shipped | builtin vs gmsh R-match within 1%                            |
 | Adaptive bias continuation         | uni + bipolar | shipped | pn junction forward + reverse, 3D resistor                   |
 | 3D ohmic V-I linearity             | 3D            | shipped | V-I linearity within 1%                                      |
-| Benchmarks                         | 6             | shipped | pn_1d, pn_1d_bias, pn_1d_bias_reverse, mos_2d, resistor_3d, mosfet_2d |
+| Benchmarks                         | 8             | shipped | pn_1d, pn_1d_bias, pn_1d_bias_reverse, mos_2d, resistor_3d, mosfet_2d, pn_1d_turnon, rc_ac_sweep |
 | Conservation / mesh convergence    | 1D            | shipped | charge neutrality, Cauchy rates >= 1.8/doubling              |
 | V&V                                | 10 studies    | shipped | 62/62 PASS                                                   |
 | On-disk result artifact (M9)       | all           | shipped | round-trip tests on all 5 benchmarks, manifest Draft-07 validated |
@@ -35,6 +35,8 @@ what the engine actually does today, verified in CI:
 | HTTP server (M10)                  | all           | shipped | 15 server tests, end-to-end POST /solve + WebSocket progress |
 | Schema versioning + UI form-builder annotations (M11) | all | shipped | every object node has description; schema extracted to JSON file |
 | 2D MOSFET with n+ implants (M12)   | 2D            | shipped | Gaussian source/drain doping; SNES tolerance ADR 0008        |
+| Transient (BDF1/BDF2) solver (M13) | 1D / 2D       | shipped | pn_1d_turnon; lumped mass infrastructure; ADRs 0009 / 0010   |
+| Small-signal AC sweep (M14)        | 1D / 2D       | shipped | rc_ac_sweep within 0.4 % of analytical depletion C; ADR 0011 |
 | Test suite                         | pure + FEM    | shipped | 239+ tests, >=95% coverage                                    |
 | CI                                 | lint+test+FEM | shipped | green on dev and main                                        |
 

--- a/benchmarks/rc_ac_sweep/README.md
+++ b/benchmarks/rc_ac_sweep/README.md
@@ -1,0 +1,38 @@
+# rc_ac_sweep
+
+M14 small-signal AC validation benchmark.
+
+The device is a **1D pn junction** identical to `pn_1d_bias_reverse`:
+20 µm symmetric step junction (N_A = N_D = 1e17 cm^-3), τ = 1e-8 s,
+800 cells. The runner is configured with `solver.type = "ac_sweep"` at
+DC bias V_DC = -1.0 V and a 41-point logspace frequency sweep from
+1 Hz to 1 GHz.
+
+At reverse bias the diode is depletion-dominated, so the small-signal
+admittance Y(ω) is approximately Y(ω) ≈ -j ω C_dep(V_DC) over the
+swept range (no measurable conduction at this bias, well below the
+1/(R_bulk·C_dep) cross-over which is in the 10 GHz range for this
+device).
+
+## Verifier
+
+`benchmarks/rc_ac_sweep/verify.py` checks:
+
+1. **Capacitance plateau matches analytical depletion C within 5%** at
+   every frequency in [1 Hz, 1 MHz]. The analytical reference is
+
+       C_dep(V_DC) = sqrt(q * eps_Si * N_eff / (2 * (V_bi - V_DC)))
+       N_eff = N_A * N_D / (N_A + N_D)
+       V_bi  = V_t * ln(N_A * N_D / n_i^2)
+
+2. **Frequency flatness**: max(C) / min(C) over [1 Hz, 1 MHz] must be
+   within 2%. Captures the depletion regime: no carrier-transport
+   dispersion is expected below ~10 MHz for this device.
+
+3. **High-frequency cap roll-off** is allowed: C above 100 MHz may
+   drift modestly as carrier transit times start to enter the picture.
+   This is informational, not asserted.
+
+## Run
+
+    docker compose run --rm benchmark rc_ac_sweep

--- a/benchmarks/rc_ac_sweep/rc_ac_sweep.json
+++ b/benchmarks/rc_ac_sweep/rc_ac_sweep.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "1.2.0",
+  "name": "rc_ac_sweep",
+  "description": "1D pn junction reverse-biased at -1.0 V, swept by AC small-signal from 1 Hz to 1 GHz (41 logspace points). Validates the M14 ac_sweep runner against the analytical depletion capacitance C_dep(V) = sqrt(q*eps*N_eff/(2(V_bi-V))). Geometry and device match pn_1d_bias_reverse: 20 um symmetric step junction, N_A = N_D = 1e17 cm^-3, tau = 1e-8 s, 800 cells. The depletion C dominates the admittance below ~10 GHz so C(omega) is approximately constant over the swept range; the verifier checks both the magnitude (within 5% of C_dep_analytical) and the flatness across the sweep.",
+  "dimension": 1,
+  "mesh": {
+    "source": "builtin",
+    "extents": [[0.0, 2.0e-5]],
+    "resolution": [800],
+    "regions_by_box": [
+      {"name": "silicon", "tag": 1, "bounds": [[0.0, 2.0e-5]]}
+    ],
+    "facets_by_plane": [
+      {"name": "anode",   "tag": 1, "axis": 0, "value": 0.0},
+      {"name": "cathode", "tag": 2, "axis": 0, "value": 2.0e-5}
+    ]
+  },
+  "regions": {
+    "silicon": {"material": "Si", "tag": 1, "role": "semiconductor"}
+  },
+  "doping": [
+    {
+      "region": "silicon",
+      "profile": {
+        "type": "step",
+        "axis": 0,
+        "location": 1.0e-5,
+        "N_D_left": 0.0, "N_A_left": 1.0e17,
+        "N_D_right": 1.0e17, "N_A_right": 0.0
+      }
+    }
+  ],
+  "contacts": [
+    {"name": "anode",   "facet": "anode",   "type": "ohmic", "voltage": 0.0},
+    {"name": "cathode", "facet": "cathode", "type": "ohmic", "voltage": 0.0}
+  ],
+  "physics": {
+    "temperature": 300.0,
+    "statistics": "boltzmann",
+    "mobility": {"mu_n": 1400.0, "mu_p": 450.0},
+    "recombination": {"srh": true, "tau_n": 1.0e-8, "tau_p": 1.0e-8, "E_t": 0.0}
+  },
+  "solver": {
+    "type": "ac_sweep",
+    "snes": {"rtol": 1.0e-14, "atol": 1.0e-14, "stol": 1.0e-14, "max_it": 60},
+    "continuation": {"min_step": 1.0e-5, "max_step": 0.1, "max_halvings": 14},
+    "dc_bias": {"contact": "anode", "voltage": -1.0},
+    "ac": {
+      "contact": "anode",
+      "amplitude": 1.0,
+      "frequencies": {"type": "logspace", "start": 1.0, "stop": 1.0e9, "n_points": 41}
+    }
+  },
+  "output": {"directory": "./results/rc_ac_sweep", "fields": []}
+}

--- a/docs/adr/0011-ac-small-signal.md
+++ b/docs/adr/0011-ac-small-signal.md
@@ -1,0 +1,248 @@
+# ADR 0011: Small-signal AC sweep — formulation, primary variables, and PETSc-real 2x2 block reformulation
+
+- **Status:** Accepted
+- **Date:** 2026-04-26
+- **Milestone:** M14 — small-signal AC analysis
+
+---
+
+## Context
+
+`docs/IMPROVEMENT_GUIDE.md` §M14 lists small-signal AC analysis as the
+next solver-type addition after the M13 transient runner. The user-
+facing motivation:
+
+- **Capacitance-voltage extraction.** True C(V) curves require either a
+  transient ramp + numerical differentiation of Q(V) or a small-signal
+  AC measurement of -Im(Y)/omega at each V. The latter is ~10x cheaper
+  per V-point (one linear solve per frequency vs hundreds of nonlinear
+  time-steps) and is what every commercial DD simulator exposes.
+- **Admittance / S-parameter prediction.** RF MOSFETs and HEMTs
+  characterise the device by Y- (or S-) parameters at GHz frequencies.
+  The DD-level AC sweep is the engine that produces these.
+- **Noise analysis groundwork.** Small-signal noise ((1/f), shot,
+  generation-recombination) reduces to a related linear AC system
+  driven by stochastic sources at each frequency. Standing up the AC
+  infrastructure now positions us for that analysis later (M16+).
+
+The math reuses the steady-state Jacobian J of the bias_sweep solver
+and the lumped mass matrix M shipped with the M13 transient runner.
+
+## Decision
+
+### Formulation
+
+Around a converged DC operating point u_0 = (psi_0, n_0, p_0) at a
+chosen contact bias V_DC, the small-signal perturbation u(t) = u_0 +
+delta_u * exp(j*omega*t) under V(t) = V_DC + delta_V * exp(j*omega*t)
+satisfies the linear frequency-domain system
+
+    (J + j*omega*M) * delta_u = -dF/dV * delta_V
+
+where:
+
+- **J** is the steady-state DD Jacobian dF/du at u_0, in primary-density
+  form (psi, n_hat, p_hat).
+- **M** is the lumped mass matrix on the carrier-density rows. The
+  Poisson row has no time derivative (Maxwell's equations are quasi-
+  electrostatic in the DD model used throughout this engine), so
+  M_psi = 0 and only M_n and M_p are nonzero. The lumped diagonal is
+  the same construct shipped with M13 (`semi/fem/mass.py`).
+- **dF/dV** is the right-hand side arising from the small change in the
+  contact's Dirichlet BC. The runner forms it implicitly via finite
+  difference of the DC operating point: solving the steady-state DD
+  problem at V_DC and at V_DC + eps_V, the difference of the two
+  solutions delta_u_DC = (u(V_DC + eps_V) - u(V_DC)) / eps_V satisfies
+  J * delta_u_DC = -dF/dV at u_0 by Newton's lemma. The AC RHS is then
+  b = J * delta_u_DC (one mat-vec).
+
+### Primary unknowns: (psi, n, p) primary-density
+
+The bias_sweep runner solves in Slotboom variables (psi, phi_n, phi_p)
+because steady-state DD is coercive in that form (see ADR 0004). The
+transient runner switched to (psi, n_hat, p_hat) primary-density form
+to make the time-derivative term natural and to share a mass matrix
+with the carrier-density continuity equations (see ADR 0009).
+
+The AC runner adopts the same primary-density choice as the transient
+runner. Two reasons:
+
+1. **Mass matrix reuse.** `semi.fem.mass.assemble_lumped_mass` is
+   defined on the (n, p) spaces. Reformulating M for Slotboom variables
+   would require a chain-rule mass matrix that couples the Poisson and
+   continuity rows (since dn/dt depends on dpsi/dt and dphi_n/dt) — see
+   the discussion in ADR 0009. The (psi, n, p) form avoids this entirely.
+2. **Ecosystem coherence.** Future M14.1 (transient C-V extraction
+   matching AC C-V), M16 (Auger and field-dependent mobility) are all
+   easier to extend in (psi, n, p) form.
+
+The DC operating point is obtained by running `run_bias_sweep` (which
+gives Slotboom variables) and then converting to (n, p) via Boltzmann:
+
+    n_hat = (n_i / C_0) * exp(psi_hat - phi_n_hat)
+    p_hat = (n_i / C_0) * exp(phi_p_hat - psi_hat)
+
+This is exact under Boltzmann statistics (the only statistics M14
+supports; Fermi-Dirac is M16 work).
+
+### PETSc complex-vs-real choice — real 2x2 block reformulation
+
+The `dolfinx-real` PETSc build (the only build in the engine's CI
+Docker image) uses real `PetscScalar` (float64). Solving (J + j*omega*M)
+delta_u = b directly would require a `dolfinx-complex` build, which
+neither CI nor any benchmark environment currently has.
+
+We therefore use the standard **real 2x2 block reformulation**: write
+delta_u = x + j*y and the equation as
+
+    [   J     -omega*M ] [ x ]   [ Re(b) ]
+    [ omega*M    J     ] [ y ] = [ Im(b) ]
+
+(BC rows of J are replaced by identity by the dolfinx assembler; M is
+zeroed at BC rows so the BC perturbation is imposed identically at
+every frequency.) The block size is 2 * (3N) = 6N where N is the
+per-block DOF count. A direct LU factorisation (MUMPS) is used at each
+frequency. For the M14 benchmark mesh sizes (sub-1k DOFs in 1D, sub-
+10k in 2D MOS C-V) this is sub-second per frequency.
+
+Switching to a complex PETSc build in the future would shrink the
+solved matrix to 3N complex entries and roughly halve the per-frequency
+LU cost, but the runner contract (`AcSweepResult` shape, the
+`backend` meta tag) does not depend on this choice. Adding a complex
+backend would only require:
+
+1. A complex PETSc build in the Docker image (`PETSC_USE_COMPLEX=1`).
+2. A branch in `_solve_2x2_real_block` that builds (J + j*omega*M) as
+   a single complex matrix when `PETSc.ScalarType` is complex.
+
+Both are deferred (M16 or beyond). Documenting the build-time switch
+here keeps the option open without committing to a Docker image rebuild
+during M14.
+
+### Sign convention for terminal admittance
+
+The runner reports Y with the **"positive = current OUT of the device"**
+convention used throughout `semi/postprocess.py` for the steady-state
+runners (the `evaluate_current_at_contact` helper integrates J · n_FE
+where the FE FacetNormal points outward at boundary facets). Under
+this convention, a pure ideal capacitor terminal has
+
+    Y = -j * omega * C
+
+(because the circuit-side Y_in_into_contact = +j*omega*C; flipping to
+out-of-contact flips the sign). Therefore the runner reports
+
+    C(omega) = -Im(Y) / (2 * pi * f)
+
+so a positive physical capacitance maps to a positive C in
+`AcSweepResult.C`. The same sign convention applies to G = Re(Y).
+
+## Validation
+
+### MMS-style consistency tests
+`tests/mms/test_ac_consistency.py` checks three internal invariants of
+the formulation that do not depend on a closed-form analytical
+solution:
+
+1. Y(omega = 0) is purely real (the 2x2 block decouples; imaginary
+   solution component is identically zero).
+2. Re(Y) at omega = 0 and omega = 2*pi*1e-3 Hz agree to better than 1%
+   (linearisation-error scale of the eps_V = 1e-3 V finite-difference
+   DC sensitivity).
+3. C(f) is omega-independent at low frequency in the depletion regime
+   (tested at f = 1 Hz vs f = 2 Hz; matches to better than 1e-6).
+
+### Acceptance benchmark — RC depletion capacitance
+`benchmarks/rc_ac_sweep` runs a 1D pn diode at V_DC = -1.0 V across
+41 logspace frequencies from 1 Hz to 1 GHz. The verifier checks the
+capacitance plateau matches the analytical depletion C within 5% over
+[1 Hz, 1 MHz]; in current measurements it matches to **0.41%** worst-
+case (well under tolerance). Plateau flatness max(C)/min(C) is **1.000**
+across 27 samples in band.
+
+### Acceptance test — pn depletion-C agreement across bias
+`tests/fem/test_ac_dc_limit.py` evaluates the M14 acceptance criterion
+2 from `docs/IMPROVEMENT_GUIDE.md`: low-frequency C(omega) matches
+analytical depletion C within 5% at three biases V_DC in {-2.0, -1.0,
+-0.5} V. Current results match to within 1% at V = -1.0 V and within
+0.4% at V = -2.0 V.
+
+## Alternatives considered
+
+### Time-domain transient + FFT (rejected)
+Drive a sinusoidal small-amplitude perturbation in time, FFT the
+terminal current, extract Y(omega). Conceptually simpler — reuses the
+existing M13 transient runner verbatim — but requires hundreds to
+thousands of timesteps per frequency point and re-solves the full
+nonlinear system at every step. Per-frequency cost is two to three
+orders of magnitude higher than the M14 linear-solve approach, and
+spectral leakage / windowing introduces extra accuracy concerns.
+Rejected as the primary path; remains available as a sanity-check
+mechanism in M16.
+
+### Harmonic balance (rejected)
+Express V(t) as a Fourier series over the steady period, solve the
+coupled multi-harmonic nonlinear system. Standard for circuit
+simulators (e.g. SPECTRE), genuinely needed for large-signal AC
+behaviour. Overkill for small-signal where the linearisation is
+already exact. Rejected for M14; potentially M18+ work.
+
+### Complex PETSc build (deferred)
+See "PETSc complex-vs-real choice" above. The real-block reformulation
+is well-understood, has a known 2x condition-number penalty (the
+largest eigenvalue of the 2x2 block is sqrt(2) larger than the original
+J's), and works without a Docker rebuild. Deferred.
+
+### Slotboom-variable AC formulation (rejected)
+Could reuse the bias_sweep machinery directly without converting to
+density form. Requires a chain-rule mass matrix that couples Poisson
+with continuity blocks (see ADR 0009 §"Why density form for transient");
+mass matrix would no longer be a simple lumped diagonal on the
+continuity rows. Discarded for the same reasons that drove ADR 0009.
+
+## Consequences
+
+### Positive
+- Small-signal AC analysis becomes a first-class solver type; the
+  schema, runner, result type, and CLI driver all support it.
+- Mass matrix infrastructure shipped with M13 is exercised by a second
+  consumer (transient + AC), validating the M13 contract.
+- The runner's `backend` meta field documents the real-block path,
+  making the future complex-PETSc switch a discoverable upgrade.
+
+### Negative / risk
+- The real-block formulation doubles the linear-system size per
+  frequency. Acceptable for M14 mesh sizes; would require the M15 GPU
+  path (or a complex PETSc build) for ~100k+ DOF problems.
+- The DC sensitivity is computed by finite difference (eps_V = 1e-3 V)
+  rather than directly assembling dF/dV. This couples the AC accuracy
+  to the SNES tolerance of the bias_sweep runner. The choice of eps_V
+  trades linearisation error against finite-difference noise; 1e-3 V
+  is well below the V_t ≈ 0.026 V scale and well above the SNES atol
+  floor of 1e-7 in scaled units.
+
+### Deferred
+- Complex PETSc backend (see above).
+- Direct dF/dV assembly via UFL action on a BC-perturbation function.
+  Cleaner than finite difference; deferred to M16 along with the
+  Auger/field-mobility refresh.
+- `mos_2d` C-V upgrade to use AC admittance instead of `mos_cv`'s
+  numerical dQ/dV. Listed as M14 deliverable in `IMPROVEMENT_GUIDE.md`
+  but is **not** done in this PR — `mos_cv` is left untouched. Tracked
+  as M14.1.
+
+## References
+
+- Selberherr, S. (1984). *Analysis and Simulation of Semiconductor
+  Devices*. Springer. Chapter 7 §"Small-signal AC analysis".
+- Schenk, A. (1998). *Advanced Physical Models for Silicon Device
+  Simulation*. Springer. Chapter 5 §"Linearised continuity equations
+  for AC analysis".
+- Snowden, C. (1989). *Semiconductor Device Modelling*. Peter
+  Peregrinus. §"Small-signal extraction from drift-diffusion".
+- ADR 0004 — `docs/adr/0004-slotboom-variables-for-dd.md` (steady-state
+  variable choice).
+- ADR 0009 — `docs/adr/0009-transient-formulation.md` (primary-density
+  form for time-dependent solves).
+- ADR 0010 — `docs/adr/0010-bdf-time-integration.md` (lumped mass matrix
+  rationale).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kronos-semi"
-version = "0.13.0"
+version = "0.14.0"
 description = "JSON-driven FEM semiconductor device simulator on FEniCSx"
 readme = "README.md"
 license = {text = "MIT"}

--- a/schemas/input.v1.json
+++ b/schemas/input.v1.json
@@ -8,8 +8,8 @@
     "schema_version": {
       "type": "string",
       "pattern": "^\\d+\\.\\d+\\.\\d+$",
-      "description": "Schema version in semver form. The engine refuses inputs whose major version does not match the engine's supported major. Minor/patch skew is allowed but logged. Current schema: 1.1.0.",
-      "examples": ["1.0.0", "1.1.0"]
+      "description": "Schema version in semver form. The engine refuses inputs whose major version does not match the engine's supported major. Minor/patch skew is allowed but logged. Current schema: 1.2.0.",
+      "examples": ["1.0.0", "1.1.0", "1.2.0"]
     },
     "name": {
       "type": "string",
@@ -441,10 +441,91 @@
             "drift_diffusion",
             "bias_sweep",
             "mos_cv",
-            "transient"
+            "transient",
+            "ac_sweep"
           ],
-          "description": "Which runner to dispatch. `equilibrium` solves Poisson at zero bias; `drift_diffusion` solves the coupled system at a single bias point; `bias_sweep` ramps a contact voltage; `mos_cv` walks a gate sweep and integrates gate charge; `transient` runs BDF1/BDF2 time integration; `newton_block` is a legacy alias.",
+          "description": "Which runner to dispatch. `equilibrium` solves Poisson at zero bias; `drift_diffusion` solves the coupled system at a single bias point; `bias_sweep` ramps a contact voltage; `mos_cv` walks a gate sweep and integrates gate charge; `transient` runs BDF1/BDF2 time integration; `ac_sweep` (M14) runs small-signal AC analysis around a DC operating point; `newton_block` is a legacy alias.",
           "default": "equilibrium"
+        },
+        "dc_bias": {
+          "type": "object",
+          "title": "DC operating point for AC sweep",
+          "description": "DC operating point around which the small-signal AC linearisation is performed. Required when solver.type is `ac_sweep`. The named contact is also the contact whose terminal admittance is reported.",
+          "required": ["contact", "voltage"],
+          "properties": {
+            "contact": {
+              "type": "string",
+              "description": "Name of the contact at which the DC bias is applied and around which the AC perturbation is computed. Must match a contact in the `contacts` list."
+            },
+            "voltage": {
+              "type": "number",
+              "description": "DC bias voltage at `contact`, in volts. The AC sweep linearises around this point."
+            }
+          }
+        },
+        "ac": {
+          "type": "object",
+          "title": "AC small-signal sweep specification",
+          "description": "AC perturbation amplitude and frequency sweep. Required when solver.type is `ac_sweep`. Admittance is reported per unit perturbation voltage; the amplitude is informational only because the response is linearised.",
+          "required": ["contact", "frequencies"],
+          "properties": {
+            "contact": {
+              "type": "string",
+              "description": "Contact at which the AC perturbation is applied. Typically equal to `dc_bias.contact`."
+            },
+            "amplitude": {
+              "type": "number",
+              "exclusiveMinimum": 0.0,
+              "default": 1.0,
+              "description": "AC perturbation amplitude, V. Reported back in the result meta; the small-signal response itself is linear and is normalised to a per-unit-volt sensitivity inside the runner."
+            },
+            "frequencies": {
+              "type": "object",
+              "title": "AC frequency sweep specification",
+              "description": "Frequency points at which to evaluate Y(omega). Two forms: explicit `list`, or generative `logspace`/`linspace`.",
+              "oneOf": [
+                {
+                  "type": "object",
+                  "title": "Explicit frequency list",
+                  "description": "Use a fully specified array of frequencies (Hz). The runner evaluates Y(omega) at each entry verbatim; useful for benchmarks and for replicating a measurement instrument's preset frequency list.",
+                  "required": ["type", "values"],
+                  "properties": {
+                    "type": {"const": "list"},
+                    "values": {
+                      "type": "array",
+                      "items": {"type": "number", "minimum": 0.0},
+                      "minItems": 1,
+                      "description": "Frequencies in Hz. f=0 is permitted (DC limit; capacitance reported as 0)."
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "title": "Logarithmic frequency sweep",
+                  "description": "Generate `n_points` log-spaced frequencies between `start` and `stop` (both Hz, both strictly positive). Standard for AC characterisation since admittance varies over many decades of frequency.",
+                  "required": ["type", "start", "stop", "n_points"],
+                  "properties": {
+                    "type": {"const": "logspace"},
+                    "start": {"type": "number", "exclusiveMinimum": 0.0, "description": "Smallest frequency, Hz."},
+                    "stop": {"type": "number", "exclusiveMinimum": 0.0, "description": "Largest frequency, Hz."},
+                    "n_points": {"type": "integer", "minimum": 2, "description": "Number of log-spaced frequency points."}
+                  }
+                },
+                {
+                  "type": "object",
+                  "title": "Linear frequency sweep",
+                  "description": "Generate `n_points` linearly spaced frequencies between `start` (Hz, may be 0) and `stop` (Hz, strictly positive). Useful for narrow-band sweeps where the response shape is known to be smooth.",
+                  "required": ["type", "start", "stop", "n_points"],
+                  "properties": {
+                    "type": {"const": "linspace"},
+                    "start": {"type": "number", "minimum": 0.0, "description": "Smallest frequency, Hz."},
+                    "stop": {"type": "number", "exclusiveMinimum": 0.0, "description": "Largest frequency, Hz."},
+                    "n_points": {"type": "integer", "minimum": 2, "description": "Number of linearly spaced frequency points."}
+                  }
+                }
+              ]
+            }
+          }
         },
         "t_end": {
           "type": "number",

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -644,7 +644,7 @@ def _mos_device_params(cfg, sc, mat):
       - phi_ms from the gate contact's workfunction (or 0 for ideal gate)
       - V_t from the scaling at the config temperature
     """
-    from semi.constants import EPS0, cm3_to_m3
+    from semi.constants import cm3_to_m3
     from semi.materials import get_material
 
     N_A = cm3_to_m3(cfg["doping"][0]["profile"]["N_A"])
@@ -859,7 +859,6 @@ def plot_mos_2d(result, out_dir: Path) -> list[Path]:
     The 2D contour uses matplotlib's triangulation so it works on any
     dolfinx-produced unstructured mesh (triangles).
     """
-    from matplotlib import colors as mcolors
     from matplotlib.tri import Triangulation
 
     cfg = result.cfg
@@ -1335,6 +1334,148 @@ _PLOTTERS["resistor_3d"] = plot_resistor_3d
 
 
 # --------------------------------------------------------------------------- #
+# rc_ac_sweep verifier and plotter (M14)                                      #
+# --------------------------------------------------------------------------- #
+
+def _rc_ac_analytical_C(cfg) -> float:
+    """Analytical depletion capacitance per unit area for the rc_ac_sweep
+    fixture: a 1D step pn junction at the cfg's DC bias.
+
+    C_dep(V) = sqrt(q * eps_Si * N_eff / (2 * (V_bi - V)))
+    N_eff    = N_A * N_D / (N_A + N_D)
+    V_bi     = V_t * ln(N_A * N_D / n_i^2)
+    """
+    from semi.constants import EPS0, KB, Q, cm3_to_m3
+    from semi.materials import get_material
+
+    mat_name = cfg["regions"]["silicon"]["material"]
+    mat = get_material(mat_name)
+    eps = EPS0 * mat.epsilon_r
+    n_i = mat.n_i
+
+    prof = cfg["doping"][0]["profile"]
+    if prof.get("type") != "step":
+        raise ValueError("rc_ac_sweep verifier expects a step doping profile")
+    N_A = cm3_to_m3(float(prof["N_A_left"]))
+    N_D = cm3_to_m3(float(prof["N_D_right"]))
+    N_eff = N_A * N_D / (N_A + N_D)
+
+    T = float(cfg.get("physics", {}).get("temperature", 300.0))
+    V_t = KB * T / Q
+    V_bi = V_t * np.log(N_A * N_D / (n_i * n_i))
+
+    V_DC = float(cfg["solver"]["dc_bias"]["voltage"])
+    return float(np.sqrt(Q * eps * N_eff / (2.0 * (V_bi - V_DC))))
+
+
+@register("rc_ac_sweep")
+def verify_rc_ac_sweep(result) -> list[tuple[str, bool, str]]:
+    """RC AC-sweep verifier (M14).
+
+    Checks:
+      1. Capacitance plateau matches analytical depletion C within 5% at
+         every frequency in [1 Hz, 1 MHz].
+      2. Plateau flatness: max(C) / min(C) over [1 Hz, 1 MHz] within 2%.
+    """
+    cfg = result.cfg if hasattr(result, "cfg") else None
+    # AcSweepResult does not stash the cfg; we get it via the closure
+    # below since the runner's main() loaded it. For now the verifier
+    # accepts a result that exposes `dc_bias` and recomputes the
+    # analytical from the JSON sitting next to the result. The runner
+    # main() patches `result.cfg = cfg` for ac sweeps just below this
+    # function (see Driver section).
+    if cfg is None:
+        return [(
+            "rc_ac_sweep: result.cfg present", False,
+            "verifier needs cfg; benchmark driver did not attach it",
+        )]
+
+    freqs = np.asarray(result.frequencies, dtype=float)
+    C = np.asarray(result.C, dtype=float)
+
+    C_an = _rc_ac_analytical_C(cfg)
+
+    band_mask = (freqs >= 1.0) & (freqs <= 1.0e6)
+    if not band_mask.any():
+        return [(
+            "rc_ac_sweep: plateau band has samples", False,
+            f"no frequencies in [1 Hz, 1 MHz] of {len(freqs)} swept",
+        )]
+
+    C_band = C[band_mask]
+
+    # Check 1: every plateau-band C must be within 5% of analytical.
+    rel_err = np.abs(C_band - C_an) / abs(C_an)
+    worst_idx = int(np.argmax(rel_err))
+    worst_err = float(rel_err[worst_idx])
+    worst_f = float(freqs[band_mask][worst_idx])
+    worst_C = float(C_band[worst_idx])
+
+    # Check 2: flatness across the band.
+    flatness = float(C_band.max() / C_band.min()) if C_band.min() > 0 else float("inf")
+
+    checks = [
+        (
+            "rc_ac_sweep: C(f) within 5% of analytical depletion C in [1 Hz, 1 MHz]",
+            worst_err < 0.05,
+            (
+                f"C_an={C_an:.4e} F/m^2; worst rel err {100*worst_err:.2f}% "
+                f"at f={worst_f:.2e} Hz (C_sim={worst_C:.4e})"
+            ),
+        ),
+        (
+            "rc_ac_sweep: C(f) plateau flatness max/min within 2% in [1 Hz, 1 MHz]",
+            (flatness - 1.0) < 0.02,
+            f"max(C)/min(C) = {flatness:.4f} over {int(band_mask.sum())} samples",
+        ),
+    ]
+    return checks
+
+
+def plot_rc_ac_sweep(result, out_dir: Path) -> list[Path]:
+    """Bode-style plots: |Y|, C, G across frequency."""
+    paths: list[Path] = []
+    freqs = np.asarray(result.frequencies, dtype=float)
+    Y = np.asarray(result.Y, dtype=complex)
+    C = np.asarray(result.C, dtype=float)
+    G = np.asarray(result.G, dtype=float)
+
+    cfg = getattr(result, "cfg", None)
+    C_an = _rc_ac_analytical_C(cfg) if cfg is not None else None
+
+    # |Y|, C, G vs f
+    fig, axes = plt.subplots(3, 1, figsize=(7, 9), sharex=True)
+    axes[0].loglog(freqs[freqs > 0], np.abs(Y[freqs > 0]), "o-", color="C0")
+    axes[0].set_ylabel("|Y| (S/m^2)")
+    axes[0].grid(True, which="both", alpha=0.3)
+
+    pos = freqs > 0
+    axes[1].semilogx(freqs[pos], C[pos], "o-", color="C1", label="simulated")
+    if C_an is not None:
+        axes[1].axhline(C_an, color="k", linestyle="--", label="analytical C_dep")
+    axes[1].set_ylabel("C (F/m^2)")
+    axes[1].grid(True, which="both", alpha=0.3)
+    axes[1].legend()
+
+    axes[2].semilogx(freqs[pos], np.abs(G[pos]) + 1.0e-30, "o-", color="C2")
+    axes[2].set_ylabel("|G| (S/m^2)")
+    axes[2].set_xlabel("f (Hz)")
+    axes[2].grid(True, which="both", alpha=0.3)
+    axes[2].set_yscale("log")
+
+    fig.suptitle("rc_ac_sweep: Bode plot of admittance / capacitance / conductance")
+    fig.tight_layout()
+    p = out_dir / "ac_bode.png"
+    fig.savefig(p, dpi=130)
+    plt.close(fig)
+    paths.append(p)
+    return paths
+
+
+_PLOTTERS["rc_ac_sweep"] = plot_rc_ac_sweep
+
+
+# --------------------------------------------------------------------------- #
 # Driver                                                                      #
 # --------------------------------------------------------------------------- #
 
@@ -1392,9 +1533,39 @@ def main(argv: list[str] | None = None) -> int:
         return 3
     dt = time.perf_counter() - t0
 
-    # TransientResult exposes `meta`/`t`/`iv` instead of `solver_info`/`V`.
-    is_transient = hasattr(result, "meta") and not hasattr(result, "solver_info")
-    if is_transient:
+    # AcSweepResult exposes `frequencies`/`Y`/`Z`/`C`/`G` and `meta` but
+    # no `solver_info`. Branch first so the transient block does not
+    # mistake an AC result for a transient one.
+    is_ac = hasattr(result, "frequencies") and hasattr(result, "Y") and hasattr(result, "C")
+    is_transient = (
+        not is_ac
+        and hasattr(result, "meta")
+        and not hasattr(result, "solver_info")
+    )
+    if is_ac:
+        # AcSweepResult does not stash cfg; attach for the verifier and
+        # plotter. SimulationResult already carries cfg on the field;
+        # the AC dataclass intentionally stays minimal so we patch here.
+        try:
+            result.cfg = cfg
+        except Exception:  # noqa: BLE001
+            pass
+        meta = result.meta or {}
+        n_freqs = int(meta.get("n_freqs", len(result.frequencies)))
+        print("[run_benchmark] ac_sweep diagnostics:")
+        print(f"    backend            = {meta.get('backend')}")
+        print(f"    n_freqs            = {n_freqs}")
+        print(f"    f_min              = {min(result.frequencies):.3e} Hz")
+        print(f"    f_max              = {max(result.frequencies):.3e} Hz")
+        print(f"    dc_bias            = {result.dc_bias}")
+        print(f"    perturbation       = {meta.get('perturbation_voltage')} V")
+        print(f"    dc_solver_iter     = {meta.get('dc_solver_iterations')}")
+        print(f"    solve_time         = {dt:.3f} s")
+        if n_freqs == 0:
+            print("[run_benchmark] FAIL: ac_sweep produced no frequency points",
+                  file=sys.stderr)
+            return 4
+    elif is_transient:
         meta = result.meta or {}
         n_steps = int(meta.get("n_steps_taken", 0))
         n_failed = int(meta.get("n_failed_steps", 0))

--- a/semi/__init__.py
+++ b/semi/__init__.py
@@ -15,7 +15,7 @@ The pure-Python modules (constants, materials, scaling, doping, schema)
 do not and can be imported and tested independently.
 """
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 # Pure-Python imports, always safe (doping requires numpy so is not imported here)
 from . import constants, materials, scaling, schema

--- a/semi/results.py
+++ b/semi/results.py
@@ -1,10 +1,13 @@
 """
-Result types for transient simulation runs.
+Result types for transient and AC small-signal simulation runs.
 
-TransientResult is the public output type for :func:`run_transient`. It
-follows the JSON-as-contract invariant: no PETSc or UFL types appear in
-the public API fields; only plain Python scalars, lists, dicts, and numpy
-arrays are exposed.
+TransientResult is the public output type for :func:`run_transient`.
+AcSweepResult is the public output type for :func:`run_ac_sweep` (M14).
+Both follow the JSON-as-contract invariant: no PETSc or UFL types appear
+in the public API fields; only plain Python scalars, lists, dicts, and
+numpy arrays are exposed. Complex numbers in AcSweepResult are
+serialized to JSON as ``{"re": <float>, "im": <float>}`` by the
+artifact writer (see :mod:`semi.io.artifact`).
 """
 from __future__ import annotations
 
@@ -48,3 +51,61 @@ class TransientResult:
     fields: dict[str, list[np.ndarray]] = field(default_factory=dict)
     meta: dict[str, Any] = field(default_factory=dict)
     x_dof: np.ndarray | None = None
+
+
+@dataclass
+class AcSweepResult:
+    """
+    Output of :func:`semi.runners.ac_sweep.run_ac_sweep` (M14).
+
+    Small-signal AC analysis. The system is linearised around a DC
+    operating point u_0 = (psi_0, n_0, p_0); the perturbation
+    delta_u(omega) satisfies (J + j*omega*M) * delta_u = -dF/dV * delta_V.
+    Terminal current and admittance are evaluated per unit perturbation
+    voltage at the swept contact.
+
+    Attributes
+    ----------
+    frequencies : list of float
+        Frequency points (Hz).
+    Y : list of complex
+        Small-signal admittance per unit voltage perturbation at the
+        swept contact, in S/m^2 (1D), S/m (2D), or S (3D), matching the
+        per-unit-area convention of the conduction current evaluator.
+    Z : list of complex
+        Small-signal impedance, 1/Y, with the same per-unit-area
+        convention. Entries with |Y| < 1e-300 are reported as 0.0 (no
+        terminal response).
+    C : list of float
+        Effective capacitance C(omega) = -Im(Y) / (2*pi*f). The runner
+        reports Y with the "positive = current OUT of the device"
+        convention used by ``postprocess.evaluate_current_at_contact``.
+        In that convention a pure capacitor has Y = -j*omega*C, so a
+        positive physical capacitance maps to negative Im(Y) and the
+        leading minus in the formula recovers a positive C. Same
+        per-unit convention as Y. Entries at f=0 are reported as 0.0.
+    G : list of float
+        Effective conductance G(omega) = Re(Y). Same per-unit convention.
+    dc_bias : dict
+        DC operating point used. Keys: ``contact`` (str), ``voltage``
+        (float). Mirrors the relevant slice of ``cfg["solver"]``.
+    meta : dict
+        Run metadata. Keys include:
+        - ``n_freqs`` (int): number of frequency points.
+        - ``perturbation_voltage`` (float): finite-difference epsilon
+          used for the DC sensitivity (V).
+        - ``ac_amplitude`` (float): AC amplitude (V) reported back from
+          the cfg; admittance is per unit volt regardless.
+        - ``dc_solver_iterations`` (int): SNES iterations of the DC
+          solve (max over the V_DC and V_DC+eps solves).
+        - ``backend`` (str): ``"real-2x2-block"`` (always, until M16
+          enables a complex PETSc build).
+        - ``displacement_current_included`` (bool): always True for M14.
+    """
+    frequencies: list[float] = field(default_factory=list)
+    Y: list[complex] = field(default_factory=list)
+    Z: list[complex] = field(default_factory=list)
+    C: list[float] = field(default_factory=list)
+    G: list[float] = field(default_factory=list)
+    dc_bias: dict[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)

--- a/semi/run.py
+++ b/semi/run.py
@@ -8,6 +8,8 @@ Supports:
                                       voltage_sweep and solve coupled.
     solver.type == "transient"        BDF1/BDF2 time integration in
                                       (psi, n, p) primary-density form.
+    solver.type == "ac_sweep"         small-signal AC analysis around a
+                                      DC operating point (M14).
 
 Implementation note: this module is a thin dispatcher. The actual
 runners live in `semi.runners.equilibrium`, `semi.runners.bias_sweep`,
@@ -48,7 +50,13 @@ class SimulationResult:
 
 def run(cfg: dict[str, Any]):
     """Dispatch on solver.type."""
-    from .runners import run_bias_sweep, run_equilibrium, run_mos_cv, run_transient
+    from .runners import (
+        run_ac_sweep,
+        run_bias_sweep,
+        run_equilibrium,
+        run_mos_cv,
+        run_transient,
+    )
 
     stype = cfg.get("solver", {}).get("type", "equilibrium")
     if stype == "equilibrium":
@@ -59,6 +67,8 @@ def run(cfg: dict[str, Any]):
         return run_mos_cv(cfg)
     if stype == "transient":
         return run_transient(cfg)
+    if stype == "ac_sweep":
+        return run_ac_sweep(cfg)
     raise ValueError(f"Unknown solver.type {stype!r}")
 
 
@@ -83,4 +93,7 @@ def __getattr__(name: str):
     if name == "run_transient":
         from .runners.transient import run_transient
         return run_transient
+    if name == "run_ac_sweep":
+        from .runners.ac_sweep import run_ac_sweep
+        return run_ac_sweep
     raise AttributeError(f"module 'semi.run' has no attribute {name!r}")

--- a/semi/runners/__init__.py
+++ b/semi/runners/__init__.py
@@ -7,20 +7,28 @@ Each runner here owns one solver-type code path. Public modules:
     bias_sweep     Coupled Slotboom drift-diffusion with adaptive
                    continuation across an applied bias range.
     transient      BDF1/BDF2 time integration in (psi, n, p) form.
+    ac_sweep       Small-signal AC analysis around a DC operating point
+                   (M14): solves (J + j*omega*M) delta_u = -dF/dV delta_V
+                   for a frequency sweep and reports Y, Z, C, G.
 
 Both steady-state runners return the `SimulationResult` dataclass defined
 in `semi.run`; importing `SimulationResult` from `semi.run` is the
 backward-compatible path for callers that already do so. The transient
-runner returns `TransientResult` from `semi.results`.
+runner returns `TransientResult` from `semi.results`; the AC sweep
+runner returns `AcSweepResult` from `semi.results`.
 
 The `semi.run.run(cfg)` dispatcher is the public entry point and is
 unchanged in signature.
 """
 from __future__ import annotations
 
+from .ac_sweep import run_ac_sweep
 from .bias_sweep import run_bias_sweep
 from .equilibrium import run_equilibrium
 from .mos_cv import run_mos_cv
 from .transient import run_transient
 
-__all__ = ["run_equilibrium", "run_bias_sweep", "run_mos_cv", "run_transient"]
+__all__ = [
+    "run_equilibrium", "run_bias_sweep", "run_mos_cv", "run_transient",
+    "run_ac_sweep",
+]

--- a/semi/runners/ac_sweep.py
+++ b/semi/runners/ac_sweep.py
@@ -1,0 +1,830 @@
+"""
+Small-signal AC sweep runner (M14).
+
+Linearises the steady-state drift-diffusion system around a converged
+DC operating point and solves the complex linear system
+
+    (J + j*omega*M) * delta_u(omega) = -dF/dV * delta_V
+
+at each frequency in a user-specified sweep. The Jacobian J is the
+steady-state DD operator at u_0; the mass matrix M is the lumped P1
+diagonal on the carrier-density rows (psi has no time derivative —
+Poisson's equation is instantaneous in the quasi-electrostatic limit
+used throughout this engine; see ADR 0011).
+
+Primary unknowns (matching the M13 transient runner): (psi, n_hat, p_hat).
+The DC operating point is obtained by running :func:`run_bias_sweep`
+in Slotboom variables (psi, phi_n, phi_p) and converting via Boltzmann
+statistics. See ADR 0011 for the design choices and ADR 0009 for why
+the primary-density form is used in time-dependent contexts.
+
+PETSc complex-vs-real-block: the dolfinx-real PETSc build (the only
+build available in CI today) uses real scalars. M14 therefore
+implements the standard real 2x2 block reformulation:
+
+    [  J   -omega*M  ] [ Re delta_u ]   [ Re b ]
+    [ omega*M   J    ] [ Im delta_u ] = [ Im b ]
+
+The block size is 2 * (3N) = 6N where N is the per-block DOF count.
+A direct LU (MUMPS) factorisation is used at each frequency. For the
+benchmark mesh sizes shipped with M14 (~80-200 cells in 1D), this is
+sub-second per frequency. M16+ may switch to a complex-PETSc build,
+which would shrink the matrix to 3N complex entries; the runner
+contract (the AcSweepResult shape) does not depend on this choice.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def _resolve_frequencies(freq_spec: dict) -> np.ndarray:
+    """Expand the schema's frequency-sweep object to a numpy array of Hz."""
+    kind = freq_spec["type"]
+    if kind == "list":
+        return np.asarray(freq_spec["values"], dtype=float)
+    if kind == "logspace":
+        start = float(freq_spec["start"])
+        stop = float(freq_spec["stop"])
+        n = int(freq_spec["n_points"])
+        return np.logspace(np.log10(start), np.log10(stop), n)
+    if kind == "linspace":
+        start = float(freq_spec["start"])
+        stop = float(freq_spec["stop"])
+        n = int(freq_spec["n_points"])
+        return np.linspace(start, stop, n)
+    raise ValueError(f"Unknown ac.frequencies.type {kind!r}")
+
+
+def _build_dc_subcfg(cfg: dict, contact_name: str, voltage: float) -> dict:
+    """Build a bias_sweep cfg pinned at a single DC bias point.
+
+    Returns a deep copy of `cfg` with solver.type set to "bias_sweep" and
+    a single-point voltage_sweep on `contact_name` at `voltage`. Any
+    pre-existing voltage_sweep on other contacts is removed (the sweep
+    runner picks the first ohmic contact with a voltage_sweep, so we
+    have to be the only one).
+    """
+    import copy
+
+    sub = copy.deepcopy(cfg)
+    # Inherit the user's solver options (snes, continuation) but switch
+    # the type to bias_sweep and pin the sweep at the AC operating point.
+    # We must override max_step / min_step to a sane pair: the AC-side
+    # eps_V perturbation can drive the nominal_step far below the user's
+    # min_step default (1e-4 V), which would trip the AdaptiveStepController
+    # min_step >= max_step guard.
+    snes_overrides = (cfg.get("solver", {}).get("snes") or {})
+    user_cont = (cfg.get("solver", {}).get("continuation") or {})
+    target_abs = abs(float(voltage))
+    # Cap nominal_step so the DC ramp from V=0 to V_DC uses several
+    # continuation steps rather than one giant jump (essential for high
+    # reverse bias on diodes; see pn_1d_bias_reverse benchmark, which
+    # uses voltage_sweep.step = 0.1 V for a -2 V endpoint). 0.1 V is a
+    # safe upper bound for SRH-limited DD; the user can override
+    # cfg.solver.continuation.max_step to grow it.
+    nominal_step = max(min(target_abs, 0.1), 1.0e-3)
+    cont = dict(user_cont)
+    cont["max_step"] = max(float(cont.get("max_step", nominal_step)), nominal_step)
+    # min_step must not exceed max_step.  Cap at nominal_step * 0.1 so a
+    # tiny eps_V perturbation can subdivide aggressively if needed.
+    cont["min_step"] = min(
+        float(cont.get("min_step", 1.0e-4)),
+        cont["max_step"] * 0.1,
+        max(nominal_step * 0.01, 1.0e-7),
+    )
+    cont.setdefault("max_halvings", 10)
+    cont.setdefault("easy_iter_threshold", 4)
+    cont.setdefault("grow_factor", 1.5)
+    sub["solver"] = {
+        "type": "bias_sweep",
+        "continuation": cont,
+    }
+    if snes_overrides:
+        sub["solver"]["snes"] = dict(snes_overrides)
+    found = False
+    for c in sub["contacts"]:
+        if c["name"] == contact_name:
+            c["voltage"] = float(voltage)
+            c["voltage_sweep"] = {
+                "start": float(voltage),
+                "stop": float(voltage),
+                "step": nominal_step,
+            }
+            found = True
+        else:
+            c.pop("voltage_sweep", None)
+    if not found:
+        raise ValueError(
+            f"ac_sweep dc_bias.contact {contact_name!r} not found in cfg.contacts"
+        )
+    return sub
+
+
+def run_ac_sweep(cfg: dict[str, Any], *, progress_callback=None):
+    """
+    Small-signal AC sweep around a DC operating point.
+
+    Parameters
+    ----------
+    cfg : dict
+        Validated config dict. ``solver.type`` must be ``"ac_sweep"`` and
+        ``solver.dc_bias`` and ``solver.ac`` must be provided per the
+        schema (see ``schemas/input.v1.json``).
+    progress_callback : callable or None
+        If provided, called with ``{"type": "ac_step", "freq_index": k,
+        "frequency": f}`` after each frequency point.
+
+    Returns
+    -------
+    AcSweepResult
+        See :class:`semi.results.AcSweepResult`.
+    """
+    import math
+
+    import ufl
+    from dolfinx import fem
+    from dolfinx.fem.petsc import assemble_matrix
+
+    from ..doping import build_profile
+    from ..fem.mass import assemble_lumped_mass
+    from ..mesh import build_mesh
+    from ..physics.drift_diffusion import make_dd_block_spaces
+    from ..postprocess import resolve_contact_facets
+    from ..results import AcSweepResult
+    from ..runners.bias_sweep import run_bias_sweep
+    from ..scaling import make_scaling_from_config
+    from ._common import reference_material
+
+    solver_cfg = cfg.get("solver", {})
+    if solver_cfg.get("type") != "ac_sweep":
+        raise ValueError("run_ac_sweep requires solver.type == 'ac_sweep'")
+    dc_cfg = solver_cfg["dc_bias"]
+    ac_cfg = solver_cfg["ac"]
+    contact_name = dc_cfg["contact"]
+    V_DC = float(dc_cfg["voltage"])
+    ac_amplitude = float(ac_cfg.get("amplitude", 1.0))
+    frequencies = _resolve_frequencies(ac_cfg["frequencies"])
+
+    # ------------------------------------------------------------------
+    # 1. Solve the DC operating point at V_DC and at V_DC + eps_V.
+    #    The pair lets us form the DC sensitivity delta_u_DC by finite
+    #    difference, which gives J * delta_u_DC = -dF/dV at u_0 (since
+    #    F is zero at both points and the linearisation is exact to
+    #    O(eps_V) in the steady-state response). The bias_sweep runner
+    #    is reused so we do not duplicate the multi-region BC and SNES
+    #    plumbing.
+    # ------------------------------------------------------------------
+    # Fixed-magnitude perturbation. Smaller than V_t = 0.026 V (so the
+    # response is genuinely small-signal) but large enough to stay well
+    # above the SNES tolerance floor (atol ~1e-7 in scaled units).
+    eps_V = 1.0e-3
+
+    dc_sub = _build_dc_subcfg(cfg, contact_name, V_DC)
+    res_dc = run_bias_sweep(dc_sub)
+    dc_iter = int(res_dc.solver_info.get("iterations", 0))
+
+    dc_sub_eps = _build_dc_subcfg(cfg, contact_name, V_DC + eps_V)
+    res_dc_eps = run_bias_sweep(dc_sub_eps)
+    dc_iter = max(dc_iter, int(res_dc_eps.solver_info.get("iterations", 0)))
+
+    # ------------------------------------------------------------------
+    # 2. Build a fresh (psi, n, p) function-space stack on the same
+    #    mesh and project the Slotboom DC solution into primary-density
+    #    form. We keep our own mesh build so the runner is independent
+    #    of the dc-subcfg's plotter / artifact side effects.
+    # ------------------------------------------------------------------
+    ref_mat = reference_material(cfg)
+    sc = make_scaling_from_config(cfg, ref_mat)
+    msh, _cell_tags, facet_tags = build_mesh(cfg)
+
+    N_raw_fn = build_profile(cfg["doping"])
+    N_hat_fn = fem.Function(make_dd_block_spaces(msh).V_psi, name="N_net_hat")
+    N_hat_fn.interpolate(lambda x: N_raw_fn(x) / sc.C0)
+
+    spaces = make_dd_block_spaces(msh)
+    V_psi = spaces.V_psi
+    V_n = spaces.V_phi_n
+    V_p = spaces.V_phi_p
+
+    psi = spaces.psi
+    n_hat = fem.Function(V_n, name="n_hat")
+    p_hat = fem.Function(V_p, name="p_hat")
+
+    ni_over_C0 = sc.n_i / sc.C0
+
+    def _slotboom_to_density(res):
+        psi_arr = res.psi.x.array
+        phi_n_arr = res.phi_n.x.array
+        phi_p_arr = res.phi_p.x.array
+        n_arr = ni_over_C0 * np.exp(psi_arr - phi_n_arr)
+        p_arr = ni_over_C0 * np.exp(phi_p_arr - psi_arr)
+        return psi_arr.copy(), n_arr, p_arr
+
+    psi_0, n_0, p_0 = _slotboom_to_density(res_dc)
+    psi_eps, n_eps, p_eps = _slotboom_to_density(res_dc_eps)
+
+    psi.x.array[:] = psi_0
+    n_hat.x.array[:] = n_0
+    p_hat.x.array[:] = p_0
+    for fn in (psi, n_hat, p_hat):
+        fn.x.scatter_forward()
+
+    # DC sensitivity delta_u_DC per unit dV (concatenated [psi, n, p]).
+    delta_psi_DC = (psi_eps - psi_0) / eps_V
+    delta_n_DC = (n_eps - n_0) / eps_V
+    delta_p_DC = (p_eps - p_0) / eps_V
+
+    N_psi = psi.x.array.size
+    N_n = n_hat.x.array.size
+
+    # ------------------------------------------------------------------
+    # 3. Material constants and physics-model coefficients (same as
+    #    bias_sweep / transient).
+    # ------------------------------------------------------------------
+    phys = cfg.get("physics", {})
+    mob = phys.get("mobility", {})
+    mu_n_SI = float(mob.get("mu_n", 1400.0)) * 1.0e-4
+    mu_p_SI = float(mob.get("mu_p", 450.0)) * 1.0e-4
+    mu_n_hat = mu_n_SI / sc.mu0
+    mu_p_hat = mu_p_SI / sc.mu0
+
+    rec = phys.get("recombination", {})
+    tau_n_s = float(rec.get("tau_n", 1.0e-7))
+    tau_p_s = float(rec.get("tau_p", 1.0e-7))
+    E_t_eV = float(rec.get("E_t", 0.0))
+    tau_n_hat_v = tau_n_s / sc.t0
+    tau_p_hat_v = tau_p_s / sc.t0
+    E_t_over_Vt = E_t_eV / sc.V0
+
+    # ------------------------------------------------------------------
+    # 4. Build the steady-state (psi, n, p) residual and its Jacobian
+    #    bilinear forms a[i][j] = derivative(F[i], u[j]) for i,j in
+    #    {psi, n, p}. The 3x3 block layout is what we'll assemble below.
+    # ------------------------------------------------------------------
+    F_list = _build_steady_density_residual(
+        psi, n_hat, p_hat, N_hat_fn,
+        spaces, sc, ref_mat.epsilon_r,
+        mu_n_hat, mu_p_hat, tau_n_hat_v, tau_p_hat_v, E_t_over_Vt,
+    )
+    a_blocks = [
+        [ufl.derivative(F_list[i], u_j) for u_j in (psi, n_hat, p_hat)]
+        for i in range(3)
+    ]
+
+    # ------------------------------------------------------------------
+    # 5. Build BCs at the DC operating point. The block Jacobian is
+    #    assembled with these BCs so BC rows are zeroed with diag=1
+    #    (standard PETSc lifting). Carrier BCs are V-independent for
+    #    ohmic contacts (n_bc, p_bc are set by the local doping); only
+    #    psi shifts with the applied bias.
+    # ------------------------------------------------------------------
+    static_voltages = {
+        c["name"]: float(c.get("voltage", 0.0))
+        for c in cfg["contacts"]
+        if c["type"] == "ohmic"
+    }
+    static_voltages[contact_name] = V_DC
+
+    bcs_dc = _build_npp_bcs(
+        cfg, msh, facet_tags, static_voltages, spaces, sc, ref_mat, N_raw_fn,
+    )
+
+    # Compiled forms for assembly.
+    a_forms = [[fem.form(a_blocks[i][j]) for j in range(3)] for i in range(3)]
+
+    # Block Jacobian as a single PETSc Mat (size 3N x 3N, monolithic).
+    A_J = assemble_matrix(a_forms, bcs=bcs_dc, diag=1.0)
+    A_J.assemble()
+
+    # ------------------------------------------------------------------
+    # 6. Lumped mass diagonal on the (n, p) blocks. The Poisson row has
+    #    no time derivative -> M_psi = 0. We embed M as a 3N-long
+    #    diagonal vector aligned with the same DOF ordering as A_J.
+    # ------------------------------------------------------------------
+    dx = ufl.Measure("dx", domain=msh)
+    M_n_diag, M_p_diag = assemble_lumped_mass(V_n, V_p, dx)
+
+    # Convert to numpy local arrays for the block solver. The transient
+    # residual (semi/runners/transient.py) uses the time-derivative term
+    # (alpha_0 / dt_hat) * n_hat * v dx with dt_hat = dt_phys/t0. In
+    # frequency domain d/dt -> j*omega, so (1/dt_phys) -> j*omega and the
+    # bilinear coefficient becomes j*omega*t0*M_lumped. Pre-multiplying
+    # the diagonal by t0 here lets the solver use omega in physical
+    # rad/s when forming the 2x2 real block. See ADR 0011.
+    M_n_arr = M_n_diag.array.copy() * sc.t0
+    M_p_arr = M_p_diag.array.copy() * sc.t0
+    M_psi_arr = np.zeros(N_psi, dtype=float)
+
+    # Zero-out BC rows in M (BCs are imposed as identity at all freqs;
+    # the BC perturbation is the source, not subject to dt dynamics).
+    bc_n_dofs, bc_p_dofs, bc_psi_dofs = _collect_bc_dof_indices(bcs_dc, V_psi, V_n, V_p)
+    M_n_arr[bc_n_dofs] = 0.0
+    M_p_arr[bc_p_dofs] = 0.0
+    M_psi_arr[bc_psi_dofs] = 0.0
+
+    # Concatenated 3N mass diagonal in the same block order as A_J:
+    # [psi-block | n-block | p-block].
+    M_diag_3N = np.concatenate([M_psi_arr, M_n_arr, M_p_arr])
+
+    # ------------------------------------------------------------------
+    # 7. RHS direction b = J @ delta_u_DC. delta_u_DC is the per-unit-V
+    #    DC sensitivity. By construction, J @ delta_u_DC = -dF/dV at u_0.
+    #    We use a PETSc mat-vec to stay consistent with the block
+    #    layout (same ordering as A_J).
+    # ------------------------------------------------------------------
+    delta_u_DC_3N = np.concatenate([delta_psi_DC, delta_n_DC, delta_p_DC])
+    b_RHS = np.zeros_like(delta_u_DC_3N)
+    _matvec_into(A_J, delta_u_DC_3N, b_RHS)
+
+    # At BC rows, A_J has identity, so (A_J @ delta_u_DC)[bc] = delta_u_DC[bc].
+    # That is exactly the BC perturbation per-unit-V (e.g. 1.0 at the
+    # swept-contact psi BC), which is the right RHS for the lifted
+    # AC linear system. No further patching required.
+
+    # ------------------------------------------------------------------
+    # 8. Frequency loop. At each omega build the 6N x 6N real 2x2 block
+    #    system, solve via direct LU, and compute terminal current
+    #    perturbation Y(omega).
+    # ------------------------------------------------------------------
+    Y_list: list[complex] = []
+    Z_list: list[complex] = []
+    C_list: list[float] = []
+    G_list: list[float] = []
+
+    sweep_facet_info = resolve_contact_facets(cfg, msh, facet_tags, contact_name)
+
+    psi_fn_pert = fem.Function(V_psi, name="delta_psi")
+    n_fn_pert = fem.Function(V_n, name="delta_n")
+    p_fn_pert = fem.Function(V_p, name="delta_p")
+
+    for k, f in enumerate(frequencies):
+        omega = 2.0 * math.pi * float(f)
+
+        x_real, x_imag = _solve_2x2_real_block(
+            A_J, M_diag_3N, omega, b_RHS,
+        )
+
+        delta_psi_re = x_real[:N_psi]
+        delta_n_re = x_real[N_psi:N_psi + N_n]
+        delta_p_re = x_real[N_psi + N_n:]
+        delta_psi_im = x_imag[:N_psi]
+        delta_n_im = x_imag[N_psi:N_psi + N_n]
+        delta_p_im = x_imag[N_psi + N_n:]
+
+        # Conduction current perturbation at the contact (linearised):
+        #   delta_J_n = -q*mu_n*(delta_n*grad(psi_0) + n_0*grad(delta_psi))
+        #               + q*mu_n*V_t * grad(delta_n)
+        # and similarly for J_p (with sign flip on the drift coupling).
+        # The contact-facet integral converts this to a current density
+        # in A/m^2 (per the existing per-unit-area convention).
+        I_cond_re = _eval_linearised_conduction_current(
+            psi, n_hat, p_hat,
+            delta_psi_re, delta_n_re, delta_p_re,
+            psi_fn_pert, n_fn_pert, p_fn_pert,
+            sc, mu_n_SI, mu_p_SI, sweep_facet_info, msh,
+        )
+        I_cond_im = _eval_linearised_conduction_current(
+            psi, n_hat, p_hat,
+            delta_psi_im, delta_n_im, delta_p_im,
+            psi_fn_pert, n_fn_pert, p_fn_pert,
+            sc, mu_n_SI, mu_p_SI, sweep_facet_info, msh,
+        )
+
+        # Displacement current at the contact:
+        #   I_disp = j*omega * eps * integral(grad(delta_psi).n_outward) dS
+        # In phasor form: I_total = I_cond + j*omega*eps*Q_psi(delta_psi).
+        Q_psi_re = _eval_displacement_charge(
+            delta_psi_re, psi_fn_pert, sc, ref_mat.epsilon_r,
+            sweep_facet_info, msh,
+        )
+        Q_psi_im = _eval_displacement_charge(
+            delta_psi_im, psi_fn_pert, sc, ref_mat.epsilon_r,
+            sweep_facet_info, msh,
+        )
+
+        # delta_D = -eps * grad(delta_psi); the displacement-evaluator
+        # returns Q_psi = +eps * grad(delta_psi).n_outward, so the
+        # contact-outward displacement field is -Q_psi. Therefore
+        #   I_disp = j*omega * delta_D_outward = -j*omega * Q_psi
+        # I_total = I_cond - j*omega*(Q_re + j*Q_im)
+        #         = (I_cond_re + omega*Q_im) + j*(I_cond_im - omega*Q_re)
+        I_total_re = I_cond_re + omega * Q_psi_im
+        I_total_im = I_cond_im - omega * Q_psi_re
+
+        Y = complex(I_total_re, I_total_im)
+        Y_list.append(Y)
+
+        if abs(Y) < 1.0e-300:
+            Z_list.append(complex(0.0, 0.0))
+        else:
+            Z_list.append(1.0 / Y)
+
+        if f > 0.0:
+            # Sign convention: terminal current Y is reported with the
+            # "positive = current OUT of device" convention used by
+            # bias_sweep / postprocess.evaluate_current_at_contact. In
+            # that convention a pure capacitor has Y = -j*omega*C (the
+            # circuit-side I_into_contact has Y = +j*omega*C; flipping
+            # to OUT-of-contact flips the sign). So a positive
+            # depletion capacitance maps to negative Im(Y), and the
+            # capacitance is C = -Im(Y) / (2*pi*f).
+            C_list.append(-Y.imag / (2.0 * math.pi * float(f)))
+        else:
+            C_list.append(0.0)
+        G_list.append(Y.real)
+
+        if progress_callback is not None:
+            progress_callback({
+                "type": "ac_step",
+                "freq_index": k,
+                "frequency": float(f),
+            })
+
+    return AcSweepResult(
+        frequencies=[float(f) for f in frequencies],
+        Y=Y_list,
+        Z=Z_list,
+        C=C_list,
+        G=G_list,
+        dc_bias={"contact": contact_name, "voltage": V_DC},
+        meta={
+            "n_freqs": len(frequencies),
+            "perturbation_voltage": float(eps_V),
+            "ac_amplitude": ac_amplitude,
+            "dc_solver_iterations": int(dc_iter),
+            "backend": "real-2x2-block",
+            "displacement_current_included": True,
+        },
+    )
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _build_steady_density_residual(
+    psi, n_hat, p_hat, N_hat_fn,
+    spaces, sc, eps_r,
+    mu_n_over_mu0: float,
+    mu_p_over_mu0: float,
+    tau_n_hat: float,
+    tau_p_hat: float,
+    E_t_over_Vt: float,
+):
+    """Steady-state DD residual in (psi, n_hat, p_hat) primary-density form.
+
+    Identical to the spatial part of `_build_transient_residual` from
+    `semi.runners.transient`, with the time-derivative term dropped.
+    The Jacobian of this form (taken below via ufl.derivative) is the
+    operator J that drives the AC solve.
+    """
+    import math as _math
+
+    import ufl
+    from dolfinx import fem
+    from petsc4py import PETSc
+
+    V_psi = spaces.V_psi
+    V_n = spaces.V_phi_n
+    V_p = spaces.V_phi_p
+    msh = V_psi.mesh
+
+    v_psi = ufl.TestFunction(V_psi)
+    v_n = ufl.TestFunction(V_n)
+    v_p = ufl.TestFunction(V_p)
+
+    L_D2 = fem.Constant(msh, PETSc.ScalarType(sc.lambda2 * sc.L0 ** 2))
+    L0_sq = fem.Constant(msh, PETSc.ScalarType(sc.L0 ** 2))
+    if isinstance(eps_r, (int, float)):
+        eps_r_ufl = fem.Constant(msh, PETSc.ScalarType(float(eps_r)))
+    else:
+        eps_r_ufl = eps_r
+
+    ni_hat_c = fem.Constant(msh, PETSc.ScalarType(sc.n_i / sc.C0))
+    mu_n_c = fem.Constant(msh, PETSc.ScalarType(mu_n_over_mu0))
+    mu_p_c = fem.Constant(msh, PETSc.ScalarType(mu_p_over_mu0))
+    tau_n_c = fem.Constant(msh, PETSc.ScalarType(tau_n_hat))
+    tau_p_c = fem.Constant(msh, PETSc.ScalarType(tau_p_hat))
+
+    n1 = ni_hat_c * _math.exp(E_t_over_Vt)
+    p1 = ni_hat_c * _math.exp(-E_t_over_Vt)
+    R = (n_hat * p_hat - ni_hat_c * ni_hat_c) / (
+        tau_p_c * (n_hat + n1) + tau_n_c * (p_hat + p1)
+    )
+
+    rho_hat = p_hat - n_hat + N_hat_fn
+
+    F_psi = (
+        L_D2 * eps_r_ufl * ufl.inner(ufl.grad(psi), ufl.grad(v_psi)) * ufl.dx
+        - rho_hat * v_psi * ufl.dx
+    )
+    F_n = (
+        L0_sq * mu_n_c * (
+            ufl.inner(ufl.grad(n_hat), ufl.grad(v_n))
+            - n_hat * ufl.inner(ufl.grad(psi), ufl.grad(v_n))
+        ) * ufl.dx
+        + R * v_n * ufl.dx
+    )
+    F_p = (
+        L0_sq * mu_p_c * (
+            ufl.inner(ufl.grad(p_hat), ufl.grad(v_p))
+            + p_hat * ufl.inner(ufl.grad(psi), ufl.grad(v_p))
+        ) * ufl.dx
+        - R * v_p * ufl.dx
+    )
+    return [F_psi, F_n, F_p]
+
+
+def _build_npp_bcs(cfg, msh, facet_tags, voltages: dict[str, float],
+                   spaces, sc, ref_mat, N_raw_fn) -> list:
+    """Build Dirichlet BCs for (psi, n_hat, p_hat) at every ohmic contact.
+
+    Mirrors the BC builder inside the transient runner. The carrier BC
+    values are V-independent (n_bc, p_bc come from the local doping at
+    the contact); psi shifts by V_hat = V/V_t.
+    """
+    from dolfinx import fem as _fem
+    from petsc4py import PETSc
+
+    from ..bcs import _evaluate_doping_at_facet, resolve_contacts
+
+    V_psi = spaces.V_psi
+    V_n = spaces.V_phi_n
+    V_p = spaces.V_phi_p
+
+    contacts = resolve_contacts(cfg, facet_tags=facet_tags, voltages=voltages)
+    bcs: list = []
+    fdim = msh.topology.dim - 1
+    two_ni = 2.0 * ref_mat.n_i
+    ni_hat_val = sc.n_i / sc.C0
+
+    for c in contacts:
+        if c.kind != "ohmic":
+            continue
+        facets = facet_tags.find(c.facet_tag)
+        if len(facets) == 0:
+            continue
+        N_net = _evaluate_doping_at_facet(msh, facets, fdim, N_raw_fn)
+        psi_eq_hat = float(np.arcsinh(N_net / two_ni))
+        V_hat = c.V_applied / sc.V0
+        psi_bc = psi_eq_hat + V_hat
+        n_bc = ni_hat_val * float(np.exp(psi_eq_hat))
+        p_bc = ni_hat_val * float(np.exp(-psi_eq_hat))
+
+        dofs_psi = _fem.locate_dofs_topological(V_psi, fdim, facets)
+        dofs_n = _fem.locate_dofs_topological(V_n, fdim, facets)
+        dofs_p = _fem.locate_dofs_topological(V_p, fdim, facets)
+
+        bcs.append(_fem.dirichletbc(PETSc.ScalarType(psi_bc), dofs_psi, V_psi))
+        bcs.append(_fem.dirichletbc(PETSc.ScalarType(n_bc), dofs_n, V_n))
+        bcs.append(_fem.dirichletbc(PETSc.ScalarType(p_bc), dofs_p, V_p))
+    return bcs
+
+
+def _collect_bc_dof_indices(bcs, V_psi, V_n, V_p):
+    """Pull the local DOF indices each Dirichlet BC constrains, by space."""
+    psi_dofs: list[int] = []
+    n_dofs: list[int] = []
+    p_dofs: list[int] = []
+    for bc in bcs:
+        space_id = id(bc.function_space)
+        if space_id == id(V_psi):
+            psi_dofs.extend(bc._cpp_object.dof_indices()[0].tolist())
+        elif space_id == id(V_n):
+            n_dofs.extend(bc._cpp_object.dof_indices()[0].tolist())
+        elif space_id == id(V_p):
+            p_dofs.extend(bc._cpp_object.dof_indices()[0].tolist())
+    return (
+        np.asarray(n_dofs, dtype=np.int64),
+        np.asarray(p_dofs, dtype=np.int64),
+        np.asarray(psi_dofs, dtype=np.int64),
+    )
+
+
+def _matvec_into(A, x_arr: np.ndarray, out_arr: np.ndarray) -> None:
+    """y = A @ x for monolithic block PETSc Mats, via local arrays."""
+    x_vec = A.createVecRight()
+    y_vec = A.createVecLeft()
+    x_vec.array[:] = x_arr
+    A.mult(x_vec, y_vec)
+    out_arr[:] = y_vec.array
+    x_vec.destroy()
+    y_vec.destroy()
+
+
+def _solve_2x2_real_block(A_J, M_diag_3N: np.ndarray,
+                          omega: float, b_RHS: np.ndarray):
+    """Solve the real 2x2 block AC system [J -wM; wM J][x;y]=[b;0].
+
+    A_J is a PETSc Mat (3N x 3N) representing the steady-state Jacobian
+    with BC rows replaced by identity. M_diag_3N is a numpy diagonal of
+    length 3N, zero on BC rows and on the psi block. omega is the
+    angular frequency in rad/s scaled to be consistent with J (M was
+    pre-divided by t0 in run_ac_sweep, so omega is in physical rad/s).
+
+    Returns a tuple (x_arr, y_arr) of length-3N numpy arrays, the real
+    and imaginary parts of the solution. Uses a direct LU solve via
+    PETSc's nested KSP. For the M14 benchmark mesh sizes (sub-1k DOF
+    in 1D) this is sub-second per frequency.
+    """
+    from petsc4py import PETSc
+
+    N3 = b_RHS.size
+    n_local = N3
+    big_size = 2 * N3
+
+    # Build a 6N x 6N CSR matrix in PETSc by extracting J as CSR and
+    # composing. For benchmark-sized meshes a Python-level CSR build is
+    # cheap; the dominant cost is the per-frequency LU below.
+    J_csr = A_J.getValuesCSR()
+    J_indptr, J_indices, J_data = J_csr
+
+    # Top-left and bottom-right blocks: J. Top-right: -omega*M (diag).
+    # Bottom-left: +omega*M (diag).
+    # Build COO triples then CSR.
+    from scipy.sparse import bmat, csr_matrix, diags
+
+    J_sp = csr_matrix((J_data, J_indices, J_indptr), shape=(N3, N3))
+    wM = diags(omega * M_diag_3N, 0, shape=(N3, N3), format="csr")
+
+    # bmat builds the big block matrix.
+    big = bmat([[J_sp, -wM], [wM, J_sp]], format="csr")
+
+    # Build PETSc Mat from CSR.
+    A_big = PETSc.Mat().createAIJ(
+        size=(big_size, big_size),
+        csr=(big.indptr.astype(PETSc.IntType),
+             big.indices.astype(PETSc.IntType),
+             big.data.astype(PETSc.RealType)),
+        comm=A_J.getComm(),
+    )
+    A_big.assemble()
+
+    b_big = A_big.createVecLeft()
+    x_big = A_big.createVecRight()
+    b_big.array[:n_local] = b_RHS
+    b_big.array[n_local:] = 0.0
+
+    ksp = PETSc.KSP().create(A_big.getComm())
+    ksp.setOperators(A_big)
+    ksp.setType("preonly")
+    pc = ksp.getPC()
+    pc.setType("lu")
+    pc.setFactorSolverType("mumps")
+    ksp.solve(b_big, x_big)
+
+    x_arr_full = x_big.array.copy()
+    x_real = x_arr_full[:N3].copy()
+    x_imag = x_arr_full[N3:].copy()
+
+    ksp.destroy()
+    A_big.destroy()
+    b_big.destroy()
+    x_big.destroy()
+
+    return x_real, x_imag
+
+
+def _eval_linearised_conduction_current(
+    psi, n_hat, p_hat,
+    delta_psi_arr, delta_n_arr, delta_p_arr,
+    psi_pert_fn, n_pert_fn, p_pert_fn,
+    sc, mu_n_SI, mu_p_SI, facet_info, msh,
+) -> float:
+    """Evaluate delta_I_conduction at the contact for one part (real or imag).
+
+    Linearised current density (per the n,p primary-variable form, with
+    Einstein relation D = mu*V_t):
+        delta_J_n = q*mu_n*V_t*grad(delta_n) - q*mu_n*(delta_n*grad(psi_0)
+                                                        + n_0*grad(delta_psi))
+        delta_J_p = -q*mu_p*V_t*grad(delta_p) - q*mu_p*(delta_p*grad(psi_0)
+                                                          + p_0*grad(delta_psi))
+
+    All density-like quantities are scaled internally; the final result
+    is multiplied back by C_0 to recover physical A/m^2.
+    """
+    import ufl
+    from dolfinx import fem
+    from dolfinx.mesh import meshtags
+    from mpi4py import MPI
+
+    from ..constants import Q
+
+    psi_pert_fn.x.array[:] = delta_psi_arr
+    n_pert_fn.x.array[:] = delta_n_arr
+    p_pert_fn.x.array[:] = delta_p_arr
+    for fn in (psi_pert_fn, n_pert_fn, p_pert_fn):
+        fn.x.scatter_forward()
+
+    tag = int(facet_info["tag"])
+    facets = facet_info["facets"]
+    fdim = msh.topology.dim - 1
+    if len(facets) == 0:
+        return 0.0
+    values = np.full(len(facets), tag, dtype=np.int32)
+    indices = np.asarray(facets, dtype=np.int32)
+    sort = np.argsort(indices)
+    facet_mt = meshtags(msh, fdim, indices[sort], values[sort])
+    ds = ufl.Measure("ds", domain=msh, subdomain_data=facet_mt, subdomain_id=tag)
+    n_vec = ufl.FacetNormal(msh)
+
+    # Convert to physical units inside the form. n_hat -> n_phys = n_hat*C_0,
+    # grad(n_hat) -> grad(n_hat) since the mesh is in meters (Invariant 3).
+    grad_psi_phys = sc.V0 * ufl.grad(psi)
+    grad_dpsi_phys = sc.V0 * ufl.grad(psi_pert_fn)
+    n_phys = n_hat * sc.C0
+    p_phys = p_hat * sc.C0
+    dn_phys = n_pert_fn * sc.C0
+    dp_phys = p_pert_fn * sc.C0
+    grad_dn_phys = sc.C0 * ufl.grad(n_pert_fn)
+    grad_dp_phys = sc.C0 * ufl.grad(p_pert_fn)
+
+    V_t = sc.V0  # k_B T / q in V
+
+    # Conduction current density (linearised) dotted with the FE
+    # FacetNormal, which already points OUT of the computational domain
+    # at boundary facets. This matches the sign convention used by
+    # postprocess.evaluate_current_at_contact (no outward_sign factor).
+    Jn_lin = (
+        Q * mu_n_SI * V_t * ufl.dot(grad_dn_phys, n_vec)
+        - Q * mu_n_SI * (
+            dn_phys * ufl.dot(grad_psi_phys, n_vec)
+            + n_phys * ufl.dot(grad_dpsi_phys, n_vec)
+        )
+    )
+    Jp_lin = (
+        - Q * mu_p_SI * V_t * ufl.dot(grad_dp_phys, n_vec)
+        - Q * mu_p_SI * (
+            dp_phys * ufl.dot(grad_psi_phys, n_vec)
+            + p_phys * ufl.dot(grad_dpsi_phys, n_vec)
+        )
+    )
+
+    form_J = fem.form((Jn_lin + Jp_lin) * ds)
+    form_A = fem.form(1.0 * ds)
+    I_local = fem.assemble_scalar(form_J)
+    A_local = fem.assemble_scalar(form_A)
+    I_val = msh.comm.allreduce(I_local, op=MPI.SUM)
+    A_val = msh.comm.allreduce(A_local, op=MPI.SUM)
+    if A_val == 0.0:
+        A_val = 1.0
+    return float(I_val / A_val)
+
+
+def _eval_displacement_charge(
+    delta_psi_arr, psi_pert_fn, sc, eps_r,
+    facet_info, msh,
+) -> float:
+    """Evaluate Q_psi = eps * integral(grad(delta_psi) . n) dS / area.
+
+    The displacement-current contribution at frequency omega is
+    j*omega*Q_psi (in A/m^2 when divided by the contact area, as is
+    done here for consistency with the conduction-current evaluator).
+    """
+    import ufl
+    from dolfinx import fem
+    from dolfinx.mesh import meshtags
+    from mpi4py import MPI
+
+    from ..constants import EPS0
+
+    psi_pert_fn.x.array[:] = delta_psi_arr
+    psi_pert_fn.x.scatter_forward()
+
+    tag = int(facet_info["tag"])
+    facets = facet_info["facets"]
+    fdim = msh.topology.dim - 1
+    if len(facets) == 0:
+        return 0.0
+    values = np.full(len(facets), tag, dtype=np.int32)
+    indices = np.asarray(facets, dtype=np.int32)
+    sort = np.argsort(indices)
+    facet_mt = meshtags(msh, fdim, indices[sort], values[sort])
+    ds = ufl.Measure("ds", domain=msh, subdomain_data=facet_mt, subdomain_id=tag)
+    n_vec = ufl.FacetNormal(msh)
+
+    # eps_r may be a Function or a float; either is fine in UFL.
+    if isinstance(eps_r, (int, float)):
+        eps_r_v = float(eps_r)
+    else:
+        eps_r_v = eps_r
+
+    grad_dpsi_phys = sc.V0 * ufl.grad(psi_pert_fn)
+    # D_n = eps0 * eps_r * grad(psi).n_FE. n_FE = FacetNormal points
+    # outward from the computational domain at boundary facets, so the
+    # sign matches the conduction-current evaluator (which also uses
+    # n_FE without an outward_sign correction; see
+    # postprocess.evaluate_current_at_contact).
+    D_n_form = EPS0 * eps_r_v * ufl.dot(grad_dpsi_phys, n_vec)
+    form_Q = fem.form(D_n_form * ds)
+    form_A = fem.form(1.0 * ds)
+    Q_local = fem.assemble_scalar(form_Q)
+    A_local = fem.assemble_scalar(form_A)
+    Q_val = msh.comm.allreduce(Q_local, op=MPI.SUM)
+    A_val = msh.comm.allreduce(A_local, op=MPI.SUM)
+    if A_val == 0.0:
+        A_val = 1.0
+    return float(Q_val / A_val)

--- a/semi/schema.py
+++ b/semi/schema.py
@@ -45,8 +45,11 @@ _SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "input.v1.json"
 ENGINE_SUPPORTED_SCHEMA_MAJOR = 1
 
 # Minor version tracking. Bumped when a backward-compatible schema addition
-# is made (M13: added transient solver type and schema_version 1.1.0).
-SCHEMA_SUPPORTED_MINOR = 1
+# is made.
+#   M13 (1.1.0): added the `transient` solver type.
+#   M14 (1.2.0): added the `ac_sweep` solver type plus solver.dc_bias and
+#                solver.ac sub-objects (frequency sweep specification).
+SCHEMA_SUPPORTED_MINOR = 2
 
 
 @lru_cache(maxsize=1)

--- a/tests/fem/test_ac_dc_limit.py
+++ b/tests/fem/test_ac_dc_limit.py
@@ -1,0 +1,111 @@
+"""
+M14 acceptance test: low-frequency AC capacitance matches the analytical
+depletion capacitance of a 1D pn junction within 5%.
+
+Runs the AC sweep at f = 1 Hz on the same device configured by
+`benchmarks/pn_1d_bias_reverse` and compares C(1 Hz) to the closed-form
+junction capacitance
+
+    C_dep(V) = sqrt(q * eps_Si * N_eff / (2 * (V_bi - V)))
+    N_eff    = N_A * N_D / (N_A + N_D)
+    V_bi     = V_t * ln(N_A * N_D / n_i^2)
+
+at three reverse biases: V_DC in {-2.0, -1.0, -0.5} V.
+
+This is the M14 acceptance criterion #2 from
+`docs/IMPROVEMENT_GUIDE.md`. A failure here means the AC formulation,
+the displacement-current evaluator, or the (J + j*omega*M) assembly is
+wrong; in that case the rc_ac_sweep benchmark verifier will also fail
+with the same root cause.
+"""
+from __future__ import annotations
+
+
+def _diode_cfg(V_DC: float) -> dict:
+    return {
+        "schema_version": "1.2.0",
+        "name": f"ac_dc_limit_{V_DC:+.3f}",
+        "description": "AC depletion-C limit test fixture (1D pn).",
+        "dimension": 1,
+        "mesh": {
+            "source": "builtin",
+            "extents": [[0.0, 2.0e-5]],
+            "resolution": [800],
+            "regions_by_box": [
+                {"name": "silicon", "tag": 1, "bounds": [[0.0, 2.0e-5]]},
+            ],
+            "facets_by_plane": [
+                {"name": "anode",   "tag": 1, "axis": 0, "value": 0.0},
+                {"name": "cathode", "tag": 2, "axis": 0, "value": 2.0e-5},
+            ],
+        },
+        "regions": {
+            "silicon": {"material": "Si", "tag": 1, "role": "semiconductor"},
+        },
+        "doping": [
+            {
+                "region": "silicon",
+                "profile": {
+                    "type": "step", "axis": 0, "location": 1.0e-5,
+                    "N_D_left": 0.0, "N_A_left": 1.0e17,
+                    "N_D_right": 1.0e17, "N_A_right": 0.0,
+                },
+            },
+        ],
+        "contacts": [
+            {"name": "anode",   "facet": "anode",   "type": "ohmic", "voltage": 0.0},
+            {"name": "cathode", "facet": "cathode", "type": "ohmic", "voltage": 0.0},
+        ],
+        "physics": {
+            "temperature": 300.0, "statistics": "boltzmann",
+            "mobility": {"mu_n": 1400.0, "mu_p": 450.0},
+            "recombination": {"srh": True, "tau_n": 1.0e-8, "tau_p": 1.0e-8, "E_t": 0.0},
+        },
+        "solver": {
+            "type": "ac_sweep",
+            "snes": {"rtol": 1.0e-14, "atol": 1.0e-14, "stol": 1.0e-14, "max_it": 60},
+            "continuation": {"min_step": 1.0e-5, "max_step": 0.1, "max_halvings": 14},
+            "dc_bias": {"contact": "anode", "voltage": V_DC},
+            "ac": {
+                "contact": "anode", "amplitude": 1.0,
+                "frequencies": {"type": "list", "values": [1.0]},
+            },
+        },
+        "output": {"directory": "/tmp/ac_dc_limit", "fields": []},
+    }
+
+
+def _analytical_C_dep(V_DC: float) -> float:
+    import numpy as np
+
+    from semi.constants import EPS0, KB, Q, cm3_to_m3
+    from semi.materials import get_material
+
+    mat = get_material("Si")
+    eps = EPS0 * mat.epsilon_r
+    n_i = mat.n_i
+    N_A = cm3_to_m3(1.0e17)
+    N_D = cm3_to_m3(1.0e17)
+    N_eff = N_A * N_D / (N_A + N_D)
+    V_t = KB * 300.0 / Q
+    V_bi = V_t * np.log(N_A * N_D / (n_i * n_i))
+    return float(np.sqrt(Q * eps * N_eff / (2.0 * (V_bi - V_DC))))
+
+
+def test_ac_dc_limit_pn_depletion_capacitance():
+    """C(1 Hz) matches analytical depletion capacitance within 5%."""
+    from semi import schema
+    from semi.runners.ac_sweep import run_ac_sweep
+
+    rel_tol = 0.05
+    for V_DC in (-2.0, -1.0, -0.5):
+        cfg = schema.validate(_diode_cfg(V_DC=V_DC))
+        result = run_ac_sweep(cfg)
+        C_sim = float(result.C[0])
+        C_an = _analytical_C_dep(V_DC)
+        rel_err = abs(C_sim - C_an) / abs(C_an)
+        assert rel_err < rel_tol, (
+            f"AC depletion C at V_DC={V_DC:+.2f} V outside {100*rel_tol:.0f}% "
+            f"tolerance: C_sim={C_sim:.4e} F/m^2, "
+            f"C_an={C_an:.4e} F/m^2, rel_err={100*rel_err:.2f}%"
+        )

--- a/tests/mms/test_ac_consistency.py
+++ b/tests/mms/test_ac_consistency.py
@@ -1,0 +1,152 @@
+"""
+M14 MMS-style consistency test: AC at omega=0 must equal DC sensitivity.
+
+The AC small-signal runner solves
+
+    (J + j*omega*M) * delta_u(omega) = -dF/dV * delta_V
+
+around a converged DC operating point u_0. At omega = 0 the linear
+system collapses to
+
+    J * delta_u(0) = -dF/dV * delta_V
+
+which is exactly the DC sensitivity equation. Any consistent runner
+implementation must therefore produce, at omega = 0, an admittance Y(0)
+that matches the finite-difference DC differential conductance dI/dV at
+the same operating point.
+
+This test is the M14 analogue of the MMS spatial / temporal convergence
+tests in `tests/mms/`: it does not depend on a closed-form analytical
+solution, only on internal self-consistency of the AC linearisation.
+A failure here points at the AC formulation, not the physics.
+"""
+from __future__ import annotations
+
+
+def _diode_cfg(V_DC: float, freqs: list[float]) -> dict:
+    """Minimal 1D pn diode AC sweep cfg (matches the rc_ac_sweep device)."""
+    return {
+        "schema_version": "1.2.0",
+        "name": f"mms_ac_consistency_{V_DC:+.3f}",
+        "description": "MMS DC-limit consistency test fixture (1D pn).",
+        "dimension": 1,
+        "mesh": {
+            "source": "builtin",
+            "extents": [[0.0, 2.0e-5]],
+            "resolution": [200],
+            "regions_by_box": [
+                {"name": "silicon", "tag": 1, "bounds": [[0.0, 2.0e-5]]},
+            ],
+            "facets_by_plane": [
+                {"name": "anode",   "tag": 1, "axis": 0, "value": 0.0},
+                {"name": "cathode", "tag": 2, "axis": 0, "value": 2.0e-5},
+            ],
+        },
+        "regions": {
+            "silicon": {"material": "Si", "tag": 1, "role": "semiconductor"},
+        },
+        "doping": [
+            {
+                "region": "silicon",
+                "profile": {
+                    "type": "step", "axis": 0, "location": 1.0e-5,
+                    "N_D_left": 0.0, "N_A_left": 1.0e17,
+                    "N_D_right": 1.0e17, "N_A_right": 0.0,
+                },
+            },
+        ],
+        "contacts": [
+            {"name": "anode",   "facet": "anode",   "type": "ohmic", "voltage": 0.0},
+            {"name": "cathode", "facet": "cathode", "type": "ohmic", "voltage": 0.0},
+        ],
+        "physics": {
+            "temperature": 300.0, "statistics": "boltzmann",
+            "mobility": {"mu_n": 1400.0, "mu_p": 450.0},
+            "recombination": {"srh": True, "tau_n": 1.0e-8, "tau_p": 1.0e-8, "E_t": 0.0},
+        },
+        "solver": {
+            "type": "ac_sweep",
+            "snes": {"rtol": 1.0e-14, "atol": 1.0e-14, "stol": 1.0e-14, "max_it": 60},
+            "continuation": {"min_step": 1.0e-5, "max_step": 0.1, "max_halvings": 14},
+            "dc_bias": {"contact": "anode", "voltage": V_DC},
+            "ac": {
+                "contact": "anode", "amplitude": 1.0,
+                "frequencies": {"type": "list", "values": freqs},
+            },
+        },
+        "output": {"directory": "/tmp/mms_ac_consistency", "fields": []},
+    }
+
+
+def test_ac_at_omega_zero_is_pure_real():
+    """At f = 0 the AC admittance must be purely real.
+
+    The 2x2 real-block system at omega = 0 decouples into two copies of
+    the steady-state Jacobian solve, and the imaginary part of the
+    solution is identically zero.
+    """
+    from semi import schema
+    from semi.runners.ac_sweep import run_ac_sweep
+
+    cfg = schema.validate(_diode_cfg(V_DC=-1.0, freqs=[0.0]))
+    result = run_ac_sweep(cfg)
+    assert len(result.Y) == 1
+    Y0 = result.Y[0]
+    # Pure-real DC sensitivity: imaginary part is identically zero up to
+    # finite-precision noise from the LU factorisation.
+    assert abs(Y0.imag) < 1.0e-12, (
+        f"Y(omega=0) must be purely real; got Y={Y0}"
+    )
+    # The reported capacitance at f=0 is reported as 0 by definition.
+    assert result.C[0] == 0.0
+
+
+def test_ac_low_freq_y_is_stable_in_real_part():
+    """Re(Y) at omega = 0 and at the lowest non-zero frequency must
+    agree at the linearisation-error scale.
+
+    For a depletion-dominated reverse-biased diode, the small-signal
+    admittance is dominated by Y ≈ -j*omega*C at low omega, so Re(Y)
+    is small and only weakly dependent on omega until frequencies
+    approach the carrier-transit cut-off. Here we check the REAL part
+    of Y is stable across omega = 0 and omega = 2*pi*1e-3 Hz to the
+    1% level, which is well within the finite-difference perturbation
+    error of the runner's DC sensitivity (eps_V = 1e-3 V).
+    """
+    from semi import schema
+    from semi.runners.ac_sweep import run_ac_sweep
+
+    cfg = schema.validate(_diode_cfg(V_DC=-1.0, freqs=[0.0, 1.0e-3]))
+    result = run_ac_sweep(cfg)
+
+    Y0 = result.Y[0]
+    Y_low = result.Y[1]
+
+    rel_re = abs(Y_low.real - Y0.real) / max(abs(Y0.real), 1.0e-12)
+    assert rel_re < 1.0e-2, (
+        "AC conductance Re(Y) at omega=0 and omega=2*pi*1e-3 disagree by "
+        f"rel={rel_re:.3e}: Y0={Y0}, Y_low={Y_low}"
+    )
+
+
+def test_ac_im_y_scales_linearly_with_omega_at_low_freq():
+    """In the depletion-capacitance regime, Im(Y) is proportional to
+    omega.  Doubling the frequency doubles |Im(Y)| within 1e-6 because
+    the underlying linear system is exact-affine in omega.
+    """
+    from semi import schema
+    from semi.runners.ac_sweep import run_ac_sweep
+
+    cfg = schema.validate(_diode_cfg(V_DC=-1.0, freqs=[1.0, 2.0]))
+    result = run_ac_sweep(cfg)
+
+    # The C(f) reported by the runner is Im(Y)/(2*pi*f) (signed).
+    # Linearity in omega ==> C(f1) == C(f2).
+    C_f1 = result.C[0]
+    C_f2 = result.C[1]
+    rel_C = abs(C_f1 - C_f2) / max(abs(C_f1), 1.0e-14)
+    assert rel_C < 1.0e-6, (
+        "Capacitance must be omega-independent in the linear depletion "
+        f"regime; got C(1Hz)={C_f1:.4e}, C(2Hz)={C_f2:.4e}, "
+        f"rel diff={rel_C:.3e}"
+    )


### PR DESCRIPTION
## Summary

Adds the M14 small-signal AC analysis runner. Linearises the steady-state DD system around a converged DC operating point and solves

> (J + j·ω·M) · δu(ω) = -∂F/∂V · δV

at each frequency in a user-specified sweep. Reports admittance Y(ω), impedance Z(ω), capacitance C(ω) = -Im(Y) / (2πf), and conductance G(ω) = Re(Y) at the swept contact, including the j·ω·ε·grad(δψ)·n displacement term in addition to the linearised conduction current.

Branched from main at v0.13.0; **isolated from the WI1 schema-fix PR (#36)**.

## Backend choice — real 2x2 block reformulation

The dolfinx-real PETSc build (the only one in the CI Docker image) does not support complex scalars (confirmed: `PETSc.ScalarType == numpy.float64`). M14 therefore uses the standard real 2x2 block reformulation:

```
[   J     -ω·M ] [Re δu]   [Re b]
[ ω·M       J  ] [Im δu] = [Im b]
```

with a per-frequency MUMPS direct LU. Block size 2·(3N) = 6N where N is the per-block DOF count; sub-second per frequency at the benchmark mesh sizes shipped here. **ADR 0011** documents the choice and lists complex PETSc as a deferred M16+ upgrade.

## Primary unknowns

(ψ, n_hat, p_hat) primary-density form, matching the M13 transient runner so the M13 lumped mass infrastructure (`semi/fem/mass.py`, ADR 0010) is reused unchanged. The DC operating point is obtained by calling `run_bias_sweep` (Slotboom form) at V_DC and at V_DC + ε_V (ε_V = 1e-3 V), then converting to densities via Boltzmann; the difference is the finite-difference DC sensitivity that drives the AC RHS.

## Acceptance metrics

### RC benchmark — `benchmarks/rc_ac_sweep/`
1D pn diode, V_DC = -1.0 V, 41 logspace freqs from 1 Hz to 1 GHz.

| Check | Target | Measured |
|---|---|---|
| Worst rel err in C(f) over [1 Hz, 1 MHz] | <5% | **0.41%** |
| Plateau flatness max(C)/min(C) over band | <1.02 | **1.0000** |

### pn depletion-C agreement — `tests/fem/test_ac_dc_limit.py`

| V_DC | C_sim/C_an | Status |
|---|---|---|
| -2.0 V | 0.996 | ✅ within 5% |
| -1.0 V | 1.000 | ✅ within 5% |
| -0.5 V | 1.007 | ✅ within 5% |

### MMS DC limit — `tests/mms/test_ac_consistency.py`

| Check | Target | Measured |
|---|---|---|
| Y(ω = 0) imaginary part | machine zero | 0.0 |
| Re(Y) drift from ω=0 to ω=2π·1e-3 Hz | rel <1e-2 | satisfied |
| C(f1) vs C(f2) at low freq (linearity) | rel <1e-6 | satisfied |

## Suite status

- **Tests:** 252 passed, 1 xfailed (M13 known limit, untouched).
- **Coverage:** **95.1%** (gate ≥95%).
- **Lint:** ruff clean.
- **Benchmarks:** pn_1d, pn_1d_bias, pn_1d_bias_reverse, mos_2d, pn_1d_turnon, rc_ac_sweep all OK.

## Constraints honored (per prompt)

- `semi/runners/bias_sweep.py` — not modified.
- `benchmarks/mosfet_2d/` — not touched (orthogonal to PR #36's schema fix).
- `docs/adr/0008-snes-tolerances.md` — not touched.
- `semi/runners/transient.py` — not modified; AC reuses `semi.fem.mass.assemble_lumped_mass` directly.
- `semi/fem/mass.py` — not modified.
- M13 xfail and ADR 0009 — untouched.

## Schema additions (semver MINOR bump 1.1.0 → 1.2.0)

- `solver.type` enum gains `"ac_sweep"`.
- `solver.dc_bias = {contact, voltage}`.
- `solver.ac = {contact, amplitude, frequencies}`.
- `frequencies` accepts an explicit `list`, a `logspace`, or a `linspace` spec.
- `SCHEMA_SUPPORTED_MINOR` bumped 1 → 2.

## Deferred (NOT in this PR)

- **M14.1**: rewire `benchmarks/mos_2d` to use AC admittance for true C(V) instead of `mos_cv`'s numerical dQ/dV. Listed as M14 deliverable in IMPROVEMENT_GUIDE but kept out of scope to keep this PR focused on the runner + acceptance benchmarks.
- Direct ∂F/∂V assembly via UFL action on a BC-perturbation function (cleaner than finite difference; M16).
- Complex PETSc backend (PETSC_USE_COMPLEX=1; would shrink the matrix to 3N complex entries; M16+).

## Test plan

- [x] `docker compose run --rm benchmark rc_ac_sweep` → PASS within 0.41%
- [x] `docker compose run --rm test python -m pytest tests/` → 252 passed, 1 xfailed, 95.1% coverage
- [x] `docker compose run --rm test python -m ruff check semi/ tests/ scripts/` → all checks passed
- [x] Full benchmark suite re-run: no regressions in pn_1d, pn_1d_bias, pn_1d_bias_reverse, mos_2d, pn_1d_turnon
- [ ] Reviewer to consider M14.1 (mos_2d AC C-V) as a follow-up