### PR TITLE
M13.1 (DRAFT): Scharfetter-Gummel transient — primitives + scaffold (1D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## [Unreleased] - M13.1: Scharfetter-Gummel transient (in flight)
+
+### Added (on `dev/m13.1-scharfetter-gummel`, not yet on main)
+- `docs/adr/0012-scharfetter-gummel.md`: ADR superseding the (n, p)
+  Galerkin convection-diffusion choice in ADR 0009 with Scharfetter-Gummel
+  edge-flux assembly. Sign convention: Sandia / Farrell-et-al. Open
+  sources cited and read end-to-end: arXiv 1911.00377 Eq (30), Sandia
+  OSTI 2011-3865 Eq (18), Spevak TU Wien thesis Section 3.2.6. Cites
+  Scharfetter-Gummel 1969, Bank-Rose 1987, Brezzi-Marini-Pietra 1989,
+  Selberherr 1984 ch. 4.4 with explanations of why open reproductions
+  cover what each paywalled source contains.
+- `semi/fem/scharfetter_gummel.py`: Bernoulli function `B(x) = x/(exp(x)-1)`
+  with four-regime stable evaluation (Taylor for `|x| < 1e-3`,
+  `x*exp(-x)/(1-exp(-x))` for `x > 30`, closed form elsewhere).
+  1D SG edge fluxes for electrons and holes in Sandia / Farrell convention.
+  UFL Bernoulli (tanh-blended, no conditionals) for the modified-diffusion
+  form. Midpoint-Galerkin reference for the small-Peclet sign / scaling
+  guard (different derivation than SG, so it catches sign errors that the
+  Slotboom 2-node closed form would miss).
+- `semi/fem/sg_assembly.py`: per-edge SG residual assembler for 1D
+  meshes. Computes the per-cell flux from the DOF arrays, scatters into
+  per-vertex residuals with the correct divergence sign convention.
+  Plus the `solve_sg_block_1d` SNES wrapper scaffold (marked
+  `# pragma: no cover`, in flight pending dolfinx-0.10 block API debug).
+- `tests/test_scharfetter_gummel.py` (64 tests): mpmath cross-check at
+  1000 log-uniform points to 1e-12 relative; the corrected identity
+  `B(x) - B(-x) = -x` (the prompt's first-draft `B(x) + B(-x) = -x`
+  was wrong, the sum is `x*coth(x/2)`); two-direction sign tests for
+  electrons and holes; hole-flux device-equation symmetry guard 2b
+  to 1e-10 relative; midpoint-Galerkin agreement at small Peclet to
+  5 % relative; UFL Bernoulli matches NumPy reference at sample points.
+- `tests/fem/test_sg_assembly.py` (5 tests): per-cell vertex ordering
+  by x-coordinate, zero residual at zero state, zero at uniform-n
+  zero-field equilibrium, per-vertex scatter matches scalar fluxes,
+  divergence-of-constant-flux is zero at interior vertices to 1e-12
+  relative.
+
+### Status (not yet ready for merge)
+- The transient runner does NOT yet incorporate the SG flux. The
+  steady-state agreement test at V=0.5 V across N={100,200,400,1000}
+  on `pn_1d_bias` (the 1e-4 hard merge gate per the M13.1 prompt) is
+  NOT yet exercised. The xfail in `tests/fem/test_transient_steady_state.py`
+  documents this status.
+- 2D simplicial assembly: explicitly raises `NotImplementedError` per
+  the "1D before 2D, hard" guard.
+
+### Decisions surfaced and resolved during this work
+- **Bernoulli identity correction**: the prompt's `B(x) + B(-x) = -x`
+  is wrong; the correct identity is `B(x) - B(-x) = -x` (the sum is
+  `x*coth(x/2)`). Verified algebraically and numerically; the corrected
+  identity is in the unit tests.
+- **SG sign convention**: the prompt's first-draft formula
+  `F = (mu V_t/h)[B(-dpsi) n_j - B(+dpsi) n_i]` had B-arguments swapped
+  relative to the standard convention; caught by the midpoint-Galerkin
+  cross-check guard (27 % disagreement at small Peclet) before any
+  residual code was wired. Corrected to `(mu V_t/h)[n_j B(+dpsi) - n_i B(-dpsi)]`
+  matching arXiv 1911.00377 Eq (30) and Sandia OSTI 2011-3865 Eq (18);
+  agreement vs MG drops to 0.35 %.
+
 ## [0.14.0] - M14: Small-signal AC sweep
 
 ### Added

--- a/PLAN.md
+++ b/PLAN.md
@@ -35,17 +35,29 @@ recombination for 1D/2D/3D devices.
 
 ## Current state
 
-M1 through M14 are merged into `main`. M9 delivered the on-disk artifact
+M1 through M14.1 are merged into `main`. M9 delivered the on-disk artifact
 contract; M10 exposed the engine over HTTP; M11 versions the input
 schema and ships the UI-facing schema companion; M12 closes out the
 MOSFET benchmark with n+ Gaussian source/drain implants and amends the
 SNES tolerances for high-injection multi-region problems; M13 delivers
-the transient solver with BDF1/BDF2 time integration in (ψ, n, p)
+the transient solver with BDF1/BDF2 time integration in (psi, n, p)
 primary-density form; M14 ships the small-signal AC sweep runner with
-a real 2x2 block reformulation of the (J + jωM) δu = -dF/dV δV system,
-displacement current at the contact, and an RC depletion-capacitance
-benchmark validated to 0.4 % of the analytical model.
-`CHANGELOG.md` records the `[0.14.0] - M14` entry.
+a real 2x2 block reformulation of the (J + j*omega*M) delta_u = -dF/dV delta_V
+system, displacement current at the contact, and an RC depletion-capacitance
+benchmark validated to 0.4 % of the analytical model. M14.1 rewires the
+mos_2d C-V benchmark to an analytic-AC differential-capacitance runner
+(`mos_cap_ac`); worst error 6.79 % vs theory in the depletion window.
+`CHANGELOG.md` records the `[0.14.0] - M14` entry; M14.1 ships under
+the same minor version (PR #38).
+
+**M13.1 is in flight on `dev/m13.1-scharfetter-gummel`** (Scharfetter-Gummel
+edge-flux discretisation for the transient continuity, ADR 0012). The
+SG residual primitives (Bernoulli, 1D edge fluxes, per-edge assembler)
+are implemented and unit-tested at 64 + 5 tests. The custom SNES wrapper
+that injects the SG residual into the dolfinx block solve is scaffolded
+but needs follow-up to land cleanly against the dolfinx-0.10 block API;
+the steady-state agreement gate at 1e-4 across N={100,200,400,1000} is
+not yet exercised. Issue #34 stays open until the integration lands.
 
 The capability matrix (verified in CI) is authoritative: see `README.md`
 §Status or `docs/ROADMAP.md`.

--- a/docs/adr/0009-transient-formulation.md
+++ b/docs/adr/0009-transient-formulation.md
@@ -1,7 +1,7 @@
 # ADR 0009: Transient Continuity Formulation — Density (n, p) vs Slotboom (φ_n, φ_p)
 
 **Date:** 2026-04-25
-**Status:** Accepted
+**Status:** Partially superseded by ADR 0012 — the (psi, n, p) primary-unknowns choice stands; the Galerkin discretisation of the convection-diffusion blocks is replaced by Scharfetter-Gummel edge-flux assembly.
 **Milestone:** M13 — Transient solver
 
 ---

--- a/docs/adr/0012-scharfetter-gummel.md
+++ b/docs/adr/0012-scharfetter-gummel.md
@@ -1,0 +1,179 @@
+# ADR 0012: Scharfetter-Gummel edge-flux discretisation for transient continuity
+
+**Date:** 2026-04-26
+**Status:** Accepted (supersedes the (n, p) Galerkin choice in ADR 0009)
+**Milestone:** M13.1 — Transient solver close-out
+
+---
+
+## Context
+
+ADR 0009 selected the (psi, n_hat, p_hat) primary-density formulation for the transient continuity equations and discretised the convection-diffusion blocks with **standard P1 Galerkin** (the same form builders the steady-state Slotboom runner uses, with `n_hat` substituted for `n_i exp(psi - phi_n)`).
+
+That combination ships in M13 (PR #30) and fails. The merged transient runner reproduces issue #34's "Bug #2": at tight SNES atol the Newton iterates blow up to ~1e24 m^-3 carrier densities, the SRH denominator collapses, and the iterate locks at a non-physical fixed point. Mesh refinement does not change the failure mode; loosening atol does, by stopping Newton before the blow-up. The M13 close-out (PR #35) xfail'd `tests/fem/test_transient_steady_state.py` with a pointer to this ADR.
+
+The structural problem is the same one Scharfetter and Gummel diagnosed in 1969: standard Galerkin (or central-difference FD) on the convection-diffusion drift term `mu_n n grad psi` is unstable when the cell Peclet number `|grad psi * h| / (2 V_t)` exceeds 1, which is almost everywhere in a real device. The 1D Read-diode paper (Scharfetter & Gummel 1969, IEEE TED ED-16(1):64-77) absorbs the exponential carrier-density variation along an edge into the basis function itself. The result is unconditionally stable in the cell Peclet number and recovers the correct upwind limit at high field.
+
+The 2D extension is non-trivial: the natural construction lives on the edges of simplicial elements with Nedelec H(curl) edge basis functions, and the per-edge SG flux scatters into two stiffness-matrix entries per edge. Brezzi, Marini, and Pietra (1989, SIAM J. Numer. Anal. 26:1342-1355) gave the first rigorous treatment; Bochev et al. (Sandia 2011-3865) wrote the open implementation note that this ADR draws from for the multi-dimensional construction.
+
+The earlier sibling-branch attempt (commit `323d30a` on `dev/m13-mesh-and-slotboom-test`) tried to fix M13 by switching the unknowns to Slotboom (psi, phi_n, phi_p) with a chain-rule time term. That formulation guarantees positivity of `n` and `p` by construction (they are `n_i exp(...)`) but introduces a Jacobian that is ill-conditioned by ~25 orders of magnitude across the device, and MUMPS LU fails with `DIVERGED_LINEAR_SOLVE`. The attempt was abandoned with a note that the textbook fix is SG. This ADR is that fix.
+
+## Decision
+
+Discretise the transient continuity convection-diffusion operator in `semi/runners/transient.py` with **Scharfetter-Gummel edge fluxes**, while keeping the (psi, n_hat, p_hat) primary unknowns from ADR 0009 unchanged. Carrier densities remain the primary unknowns (no chain-rule time term, no Slotboom transform). Newton's positivity-of-(n, p) failure mode is addressed by the SG flux, which is the upwind scheme that Galerkin failed to be: it does not amplify negative excursions into a divergent fixed point because the edge flux is a convex combination weighted by `B(+- dpsi)` rather than a centred difference. SRH source/sink terms remain as quadrature on cell vertices (lumped-mass) and are unchanged.
+
+### Bernoulli function
+
+```
+B(x) = x / (exp(x) - 1)        for x != 0
+B(0) = 1                       (Taylor series, exact)
+```
+
+Identity: `B(x) - B(-x) = -x` (algebraic; numerator `2 cosh(x) - 2`, denominator `-(2 cosh(x) - 2)`, ratio `-1`). The earlier draft of this prompt stated `B(x) + B(-x) = -x`, which is wrong; the sum is `x coth(x/2)`. The corrected identity is the one used in the unit tests.
+
+Stable evaluation in four regimes:
+
+- `x == 0`: return 1.0 exactly.
+- `|x| < eps_taylor` (default 1e-3): degree-4 Taylor, `1 - x/2 + x*x/12 - x**4/720`.
+- `x >> 0` (default `x > 30`): rewrite as `x exp(-x) / (1 - exp(-x))`, where `1 - exp(-x)` is bounded away from zero and `x exp(-x)` underflows benignly.
+- `x << 0` (default `x < -30`): rewrite as `x / (exp(x) - 1)` directly is fine because `exp(x) -> 0` and the denominator `-> -1`, so `B(x) -> -x` as `x -> -inf`.
+- Mid-range `1e-3 <= |x| <= 30`: closed form `x / (exp(x) - 1)`.
+
+### 1D edge flux
+
+For an edge connecting nodes `i, j` with edge length `h_ij` and scaled potential difference `dpsi = psi_hat_j - psi_hat_i`, the SG electron flux on the edge, in the **Sandia / Farrell-et-al convention** (the same convention the existing `evaluate_partial_currents` resolves to once the kronos-semi `phi_n` sign convention is unwound):
+
+```
+F_n_ij = (mu_n * V_t / h_ij) * ( n_j * B(+dpsi) - n_i * B(-dpsi) )
+```
+
+`F_n_ij` is the electron contribution to the conventional current density on the edge from i to j. At `dpsi = 0` with `n_j > n_i`, `F > 0` (diffusion in the `+grad(n)` direction). At uniform `n` with `dpsi > 0`, `F < 0` (electrons drift toward j; conventional current opposite).
+
+The hole flux in the same convention:
+
+```
+F_p_ij = (mu_p * V_t / h_ij) * ( p_i * B(+dpsi) - p_j * B(-dpsi) )
+```
+
+The (i, j) positions in the hole expression are swapped relative to the electron expression. Starting from the electron form `[n_j B(+dpsi) - n_i B(-dpsi)]`, the device-equation symmetry `(n <-> p, psi -> -psi)` yields, after re-grouping by the i, j positions of the swapped flux, the hole spelling above. Cross-checked against Spevak Section 3.2.6 (which uses the opposite *electron-particle-flux* convention `B_S(x) = -B(-x)`): Spevak's `phi_p` equals `-F_p_ij` here, sign-flip exactly as expected. Guard 2b verifies the symmetry numerically to 1e-10 relative.
+
+### Sign convention (Sandia / Farrell-et-al)
+
+The SG flux defined above represents the **electron contribution to the conventional current density** along the edge from i to j (similarly for holes). This is the same convention used in:
+
+- arXiv 1911.00377 Eq (30) (Farrell, Doan, Hopf, Koprucki, Glitzky 2019).
+- Sandia OSTI 2011-3865 Eq (18) (Bochev et al. 2011), after substituting `a_ij = -(psi_j - psi_i) / (2 beta)`.
+
+Spevak's TU Wien thesis Section 3.2.6 uses the **opposite** convention (electron *particle* flux, in the direction of electron motion). The relation `B_Spevak(x) = -B(-x)` maps between the two; the underlying physics is identical, just the sign of the reported flux flips. Future readers should not interpret the Spevak sign as a disagreement with Sandia/arxiv on physics.
+
+### Consistency with `evaluate_partial_currents`
+
+The existing `semi/postprocess.py::evaluate_partial_currents` computes
+`J_n = q mu_n n grad(phi_n) . n_outward` (Slotboom form). Unwinding the
+kronos-semi `phi_n` sign convention (the BC sets `phi_n = +V_applied` at
+ohmic contacts, which is sign-flipped from the textbook
+`phi_n = -V_applied`):
+
+- `phi_n_kronos = -phi_n_textbook`
+- `grad(phi_n_kronos) = -grad(phi_n_textbook)`
+- `J_n_kronos = +q mu_n n grad(phi_n_kronos) = -q mu_n n grad(phi_n_textbook) = J_n_textbook`
+
+So `evaluate_partial_currents` returns the textbook conventional electron current density. At zero field with `n_j > n_i` along the outward direction, this is `+q D_n grad(n) > 0`. The SG flux above also gives `> 0` at the same configuration. They agree on sign. M13.1 changes the IV recorder in `transient.py` to use the SG edge fluxes directly instead of recomputing from `(n, psi)` via the Slotboom intermediate; the terminal-current sign at ohmic contacts remains the M12 / ADR 0008 sign convention end-to-end.
+
+### 2D simplicial edge-flux assembly (lumped-mass approximation)
+
+For each simplicial element, iterate over its edges. For each edge `e_ij` of length `h_ij` connecting nodes `i, j`:
+
+1. Compute `dpsi = psi_hat_j - psi_hat_i` from the per-element vertex DOFs.
+2. Compute the SG flux scalar `F_n_ij` per the 1D formula above.
+3. Scale by the dual-side length `|partial C_ij|`. For a P1 simplicial mesh in the lumped-mass approximation this equals `area(K) / 3` in 2D for each of the three element edges (area-share of the dual control volume around vertex i contributed by element K, attributed equally to each of the two edges incident at i within K). In 3D the analogous fraction is `volume(K) / 4` per edge per tet, but kronos-semi does not target 3D transient before M16 so this is documented for future work, not implemented.
+4. Scatter `F_n_ij * |partial C_ij|` into the residual entry for vertex `i` with sign `-` (efflux from i) and into vertex `j` with sign `+` (influx into j). Hole flux mirror this.
+
+**This is an approximation.** The full Brezzi-Marini-Pietra / Bochev construction weights the per-edge SG flux by the lowest-order Nedelec H(curl) edge basis function projected onto the dual control-volume side; for P1 simplicial elements with the lumped-mass / nearest-neighbour control volume the weight collapses to the dual-side length `|partial C_ij|` exactly only for isotropic, well-shaped elements. For higher-order elements, anisotropic meshes, or curved control volumes the full Nedelec weighting (Sandia 2011-3865 Eqs 22-29) is required. M13.1 ships the lumped approximation; if a future benchmark exposes an anisotropic-mesh failure the fix is to swap in the full edge-element weighting without changing the per-edge flux scalar. This deferred work is captured in the **Forward notes** section below.
+
+### Issue #34 "Bug #3" sign-convention fix
+
+Issue #34's "Bug #3" notes that the existing `evaluate_partial_currents` reconstructs `phi_n` from `(n, psi)` and feeds the Slotboom flux formula, which has opposite sign from the natural `(n, p)` flux. The M13.1 fix is to switch the transient runner's IV recorder to call directly into the SG edge-flux assembler using the `(n, p)` primary unknowns, with the Sandia / Farrell convention above. Because the SG convention agrees with `evaluate_partial_currents`'s sign (see "Consistency with `evaluate_partial_currents`" above), the post-merge artefact is one terminal-current sign convention used end-to-end in the transient runner and the IV recorder; the steady-state runner (`bias_sweep.py`) keeps the existing Slotboom path and same sign.
+
+## Consequences
+
+**Positive:**
+
+- The (n, p) blow-up failure mode of M13 / ADR 0009's Galerkin choice is structurally eliminated. The SG flux is upwind by construction; carrier densities cannot diverge to 1e24 m^-3 because the per-edge flux is bounded by `min(n_i, n_j) * exp(|dpsi|) * mu_n V_t / h` regardless of central-difference oscillations.
+- (psi, n, p) primary unknowns retained, so the lumped mass matrix from M13 / ADR 0010 carries over unchanged, the BDF1/BDF2 time-stepper is unchanged, and the Newton outer loop is unchanged.
+- The Slotboom-chain-rule attempt (commit 323d30a)'s 25-OOM Jacobian conditioning failure is avoided because (n, p) primary unknowns make the mass matrix linear and well-conditioned.
+- The reuse path for steady-state DD is open: the SG edge-flux assembler can replace the Galerkin convection blocks in `bias_sweep.py` in a future PR. M13.1 only does it for the transient runner to keep the change scoped, but no architectural barrier remains.
+
+**Negative:**
+
+- Per-edge assembly is more code than UFL stiffness assembly. The SG module is pure-Python NumPy / dolfinx low-level, not UFL. Coverage on the new module needs to be >= 95% in its own right (per the project's Invariant 4), and the load-bearing piece is the Bernoulli function (~10 unit tests).
+- The lumped-mass weight collapse is a real approximation and is documented as such. Anisotropic meshes will eventually need the full Nedelec weighting.
+
+**Neutral:**
+
+- Recombination R, Poisson assembly, BCs, and IV evaluation are all unchanged in expression; only the convection-diffusion blocks of the residual change.
+- Steady-state runner (`run_bias_sweep`) is **unchanged** in this PR; it stays on Slotboom + Galerkin. SG can be ported there later without any ADR change.
+
+## Test plan (commitments)
+
+These are the gates `tests/fem/test_transient_steady_state.py` and `tests/mms/test_transient_convergence.py` will need to clear, in addition to the new SG-specific tests under `tests/fem/test_scharfetter_gummel.py`:
+
+1. **Bernoulli mpmath cross-check.** 1000 log-uniform-in-`|x|` points across `[-50, 50]`, mixed signs, 1e-12 relative tolerance vs `mpmath.mp.mpf` evaluation of `x / (exp(x) - 1)` at 50 decimal digits (with the `B(0) = 1` Taylor branch for `|x| < 1e-300`). The mpmath result is the independent reference; the `numpy` direct evaluation is excluded for `|x| > 30` because of overflow.
+
+2. **Two-direction sign test, electrons.** Edge with `n_i = 1e16`, `n_j = 1e17`, `psi_i = 0`, `psi_j = +0.1 V`. SG flux must agree with the **midpoint-Galerkin reference** `mu_n V_t (dn/h - n_mid * dpsi/(V_t h))`, `n_mid = (n_i + n_j)/2`, to 5% relative at this small cell Peclet number (`|dpsi|/(2) ~ 0.05 << 1` in scaled units). Sign error: orders of magnitude. Factor-of-2 error: 2x. Agreement to 5%: sign and scaling correct. Then swap `i` and `j`, recompute, confirm flux flips sign with the same magnitude. The Slotboom 2-node closed form is **not** used here because it derives from the same `B(x)` and only catches typos.
+
+3. **Two-direction sign test, holes (guard 2b).** Same edge but with `p_i = 1e17`, `p_j = 1e16`, `psi_i = 0`, `psi_j = +0.1 V` (field drives holes from `j` toward `i`, opposite of electrons). The hole flux must satisfy the device-equation symmetry under simultaneous `(n <-> p, psi -> -psi, anode <-> cathode)`: it must equal the negative of the corresponding electron flux configuration to 1e-10 relative. The hole sign is the most error-prone part of SG and this guard is non-negotiable.
+
+4. **1D steady-state agreement gate, 1e-4 relative, hard.** Promoted from a "soft signal" to the only hard merge gate. `transient` ramped to steady state at V = 0.5 V on the `pn_1d_bias` config must agree with `bias_sweep` terminal current to 1e-4 relative at every mesh refinement N in `{100, 200, 400, 1000}`. Coarse-mesh trap detection: error must be **monotone decreasing** in N. If error at N = 400 is lower than at N = 1000 the PR does not merge regardless of MMS rates.
+
+5. **MMS rates, soft signals.** BDF1 rate floor 0.95, BDF2 rate floor 1.90 on the existing pairwise-difference test. These are sanity checks; the steady-state agreement gate is the real one.
+
+6. **xfail flip.** `tests/fem/test_transient_steady_state.py` flips from xfail to passing without modification.
+
+7. **Coverage.** The new `semi/fem/scharfetter_gummel.py` module is gated at 95% in its own right; in particular every Bernoulli regime has a unit test.
+
+## Forward notes
+
+- **Anisotropic meshes / higher-order elements.** The lumped-mass weight `|partial C_ij|` collapse from the full Brezzi-Marini-Pietra / Bochev construction is an approximation that is exact for isotropic, well-shaped P1 simplicial elements only. If a future benchmark on an anisotropic mesh fails the steady-state agreement gate, the fix is to swap in the full Nedelec H(curl) edge-element weighting from Sandia 2011-3865 Eqs 22-29 without changing the per-edge SG flux scalar. The interface is: replace the `dual_side_length(K, e)` helper with a call into a UFL-form `nedelec_edge_weight(K, e, ds)` that integrates the Nedelec basis against the dual-side normal.
+
+- **3D extension.** The 1D and 2D paths land in M13.1. 3D simplicial transient is deferred to whenever 3D transient becomes a target (currently not on the roadmap; M15 is GPU linear-solver scaling, M16 is physics completeness). The 3D dual-side weight is `volume(K) / 4` per edge per tet under the lumped approximation.
+
+- **SG in steady-state runner.** `bias_sweep.py` keeps Slotboom + Galerkin in M13.1. The SG edge-flux assembler is general enough to drop into the steady-state convection-diffusion blocks if a future benchmark exposes a Galerkin failure there too. No ADR change required for that move.
+
+## Sources actually used
+
+### Caught-by-cross-check note
+
+The M13.1 prompt's first-draft SG formula was
+
+```
+F_n_ij_prompt = (mu_n * V_t / h_ij) * ( B(-dpsi) * n_j - B(+dpsi) * n_i )
+```
+
+with `dpsi = psi_j - psi_i`. The B-arguments were swapped relative to the standard convention. The midpoint-Galerkin cross-check guard (test plan #2) caught this before any 1D residual code was wired: at small Peclet (`dpsi=0.005V`, `Pe=0.097`) the user-prompt formula disagreed with the midpoint-Galerkin reference by 27%, all on a sign flip in the leading-order drift-term Taylor expansion. The correct formula
+
+```
+F_n_ij = (mu_n * V_t / h_ij) * ( n_j * B(+dpsi) - n_i * B(-dpsi) )
+```
+
+agrees with the midpoint-Galerkin reference to 0.35% at the same Peclet. Two open sources (arXiv 1911.00377 Eq 30 and Sandia OSTI 2011-3865 Eq 18) confirm the corrected form. Future-you will appreciate knowing this guard fired; the unit test `test_sg_edge_flux_n_agrees_with_midpoint_galerkin_at_small_peclet` is the same guard in regression form.
+
+### Open sources read
+
+Open sources read end-to-end during the M13.1 sourcing pass:
+
+- **Farrell, Doan, Hopf, Koprucki, Glitzky, "Generalized Scharfetter-Gummel schemes for electro-thermal transport in degenerate semiconductors using the Kelvin formula for the Seebeck coefficient", arXiv:1911.00377v3, https://arxiv.org/pdf/1911.00377.** Source for the standard Bernoulli function `B(x) = x / (exp(x) - 1)` (Eq 30) and the 1D edge flux in conventional-current convention `J_{n,K,L} = M_n k_B T_{K,L} [n_L B(X) - n_K B(-X)]` with `X = q (phi_L - phi_K) / (k_B T_{K,L})`. Open arXiv preprint, full PDF text-extractable.
+
+- **Spevak, Stefan, "Numerical Aspects of the Simulation of Electromigration", TU Wien doctoral thesis Section 3.2.6, https://www.iue.tuwien.ac.at/phd/spevak/node66.html.** Source for the alternate-convention electron flux `phi_n = U_th mu_n (n_i B_Spevak(-dpsi) - n_j B_Spevak(dpsi))` with `B_Spevak(x) = x / (exp(-x) - 1)` (sign-flipped from the standard `B`). Confirms the 1D form against the standard convention; under `B_Spevak(x) = -B(-x)` the two reduce to the same flux up to overall sign. Open thesis from Selberherr's TU Wien institute.
+
+- **Bochev, Lehoucq et al., "Control Volume Finite Element Method with Multidimensional Edge Element Scharfetter-Gummel upwinding. Part 1. Formulation", Sandia Report SAND2011-3865, OSTI 1020517, https://www.osti.gov/servlets/purl/1020517/.** Source for the multi-dimensional simplicial edge-flux construction. Eq (18) gives the per-edge SG flux `J_ij = (D_n / |e_ij|) [n_j B(-2 a_ij) - n_i B(2 a_ij)]` with `a_ij = -(psi_j - psi_i) / (2 beta)`. Eqs (19), (22), (24)-(29) give the per-edge to per-vertex assembly and the Nedelec H(curl) edge-element weighting. Open Sandia release.
+
+Cited but not directly read; their content is reproduced verbatim in the open sources above:
+
+- **Scharfetter, D. L. and Gummel, H. K., "Large-signal analysis of a silicon Read diode oscillator", IEEE Trans. Electron Devices ED-16(1):64-77, 1969, doi:10.1109/T-ED.1969.16566.** Original 1D SG paper. The discretisation is reproduced exactly in arXiv 1911.00377 Eq 30 and Sandia 2011-3865 Eq 18.
+
+- **Bank, R. E. and Rose, D. J., "Some error estimates for the box method", SIAM J. Numer. Anal. 24(4):777-787, 1987, JSTOR 2157588.** Box-method error analysis, paywalled. The SG flux it analyses is identical to Sandia 2011-3865 Eq 18 and a Springer chapter "On the Scharfetter-Gummel Box-Method" (located but not fully read) reproduces it.
+
+- **Brezzi, F., Marini, L. D., and Pietra, P., "Two-dimensional exponential fitting and applications to drift-diffusion models", SIAM J. Numer. Anal. 26(6):1342-1355, 1989, doi:10.1137/0726078.** The 2D simplicial extension. Paywalled; the construction is reproduced and extended to 3D in Sandia 2011-3865.
+
+- **Selberherr, S., "Analysis and Simulation of Semiconductor Devices", Springer, 1984, ch. 4.4.** Textbook reference. The box-method discretisation with `B(x) = x/(exp(x) - 1)` from this textbook is reproduced verbatim in the Spevak TU Wien thesis (same institution) and in dozens of open lecture notes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,17 @@ fem = []
 test = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    # mpmath is the independent high-precision reference for the
+    # Bernoulli-function unit tests in tests/fem/test_scharfetter_gummel.py
+    # (M13.1 / ADR 0012). Pure Python, no compiled deps.
+    "mpmath>=1.3",
 ]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "nbformat>=5.0",
     "ruff>=0.1",
+    "mpmath>=1.3",
 ]
 server = [
     "fastapi>=0.115,<0.120",

--- a/semi/fem/scharfetter_gummel.py
+++ b/semi/fem/scharfetter_gummel.py
@@ -1,0 +1,229 @@
+"""
+Scharfetter-Gummel edge-flux primitives (M13.1).
+
+This module is the load-bearing primitive for the SG transient
+discretisation specified in ADR 0012. It provides:
+
+    * `bernoulli(x)`            : numerically stable B(x) = x / (exp(x) - 1).
+    * `bernoulli_array(x)`      : vectorised B over a NumPy array.
+    * `sg_edge_flux_n(...)`     : 1D electron edge flux per ADR 0012.
+    * `sg_edge_flux_p(...)`     : 1D hole edge flux per ADR 0012.
+
+The 2D simplicial assembly is layered on top of these primitives in a
+follow-up commit; per the M13.1 plan we land 1D first, gate on
+steady-state agreement, then build 2D. This module is pure-Python /
+NumPy with no dolfinx import at module scope so it can be imported
+and unit-tested without a FEM toolchain (Invariant 4).
+
+Sign convention (ADR 0012 § "Sign convention")
+----------------------------------------------
+Sandia / Farrell-et-al convention: `F_n_ij` is the electron contribution
+to the conventional current density on the edge from i to j. At zero
+field with n_j > n_i, F > 0 (current in +∇n direction); at uniform n
+with psi_j > psi_i, F < 0 (electrons drift toward j, conventional
+current opposite). This matches the textbook
+`J_n = q mu_n n E + q D_n grad(n)` once the kronos-semi phi_n sign
+convention is unwound (see notes in `semi/postprocess.py`,
+`evaluate_partial_currents`). The user-prompt formula
+`F = (mu V_t/h)[B(-dpsi) n_j - B(+dpsi) n_i]` had the B-arguments
+swapped relative to the standard convention; the swap was caught by
+the midpoint-Galerkin cross-check guard before any 1D residual code
+was wired. See ADR 0012 "Sources actually used" for the trail.
+
+Bernoulli function regimes
+--------------------------
+- `x == 0`        : exact 1.0.
+- `|x| < taylor_eps` (default 1e-3): 4th-order Taylor 1 - x/2 + x^2/12 - x^4/720.
+- `x > big_x` (default 30): rewrite as `x exp(-x) / (1 - exp(-x))` to keep
+                            the denominator bounded away from zero and let
+                            `x exp(-x)` underflow benignly to 0.
+- `x < -big_x` (default -30): closed form `x / (exp(x) - 1)` is fine; `exp(x)`
+                              underflows to 0 and the denominator goes to -1,
+                              so `B(x) -> -x` cleanly.
+- mid-range      : closed form `x / (exp(x) - 1)`.
+
+The identity `B(x) - B(-x) = -x` is verified by unit test across the full
+sampling range. (The earlier prompt draft stated `B(x) + B(-x) = -x`, which
+is wrong; the sum is `x coth(x/2)`. The corrected identity is the one
+used in tests.)
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+_TAYLOR_EPS = 1.0e-3
+_BIG_X = 30.0
+
+
+def bernoulli(x: float) -> float:
+    """
+    Scalar Bernoulli `B(x) = x / (exp(x) - 1)` with numerically stable
+    branches in all four regimes.
+
+    Parameters
+    ----------
+    x : float
+        Argument (dimensionless; for SG flux this is the scaled potential
+        difference `psi_j - psi_i`).
+
+    Returns
+    -------
+    float
+        `B(x)`. `B(0) = 1.0` exactly.
+    """
+    if x == 0.0:
+        return 1.0
+    ax = abs(x)
+    if ax < _TAYLOR_EPS:
+        x2 = x * x
+        return 1.0 - 0.5 * x + x2 / 12.0 - (x2 * x2) / 720.0
+    if x > _BIG_X:
+        ex = math.exp(-x)
+        return (x * ex) / (1.0 - ex)
+    return x / (math.expm1(x))
+
+
+def bernoulli_array(x: np.ndarray) -> np.ndarray:
+    """
+    Vectorised Bernoulli over a NumPy array of arguments.
+
+    Same regimes as :func:`bernoulli`; uses `np.where` rather than Python
+    branching so it composes with vectorised edge assembly without a
+    Python-level loop.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    out = np.empty_like(x)
+
+    is_zero = x == 0.0
+    ax = np.abs(x)
+    is_taylor = (ax < _TAYLOR_EPS) & ~is_zero
+    is_big_pos = x > _BIG_X
+    is_big_neg = x < -_BIG_X
+    is_mid = ~(is_zero | is_taylor | is_big_pos | is_big_neg)
+
+    # Zero branch.
+    out[is_zero] = 1.0
+
+    # Taylor branch.
+    if is_taylor.any():
+        xt = x[is_taylor]
+        xt2 = xt * xt
+        out[is_taylor] = 1.0 - 0.5 * xt + xt2 / 12.0 - (xt2 * xt2) / 720.0
+
+    # Large positive branch.
+    if is_big_pos.any():
+        xp = x[is_big_pos]
+        ex = np.exp(-xp)
+        out[is_big_pos] = (xp * ex) / (1.0 - ex)
+
+    # Large negative branch and mid-range branch share the closed form
+    # x / expm1(x); expm1 is accurate near 0 and saturates safely for
+    # large |x|.
+    if is_big_neg.any():
+        xn = x[is_big_neg]
+        out[is_big_neg] = xn / np.expm1(xn)
+    if is_mid.any():
+        xm = x[is_mid]
+        out[is_mid] = xm / np.expm1(xm)
+
+    return out
+
+
+def sg_edge_flux_n(
+    n_i: float, n_j: float, dpsi: float,
+    h_ij: float, mu_n: float, V_t: float,
+) -> float:
+    """
+    1D Scharfetter-Gummel electron flux on edge (i, j) per ADR 0012.
+
+        F_n_ij = (mu_n V_t / h_ij) * ( n_j B(+dpsi) - n_i B(-dpsi) )
+
+    with `dpsi = psi_j - psi_i` in scaled units (i.e., psi already divided
+    by V_t). All quantities in physical SI, except `dpsi` which is
+    dimensionless because the SG argument is the scaled potential drop.
+
+    Sign convention: Sandia / Farrell-et-al. F is the electron
+    contribution to the conventional current density on edge i->j.
+    F > 0 at dpsi=0 with n_j > n_i (diffusion in +grad(n) direction).
+    F < 0 at uniform n with dpsi > 0 (electrons drift to j; conventional
+    current is opposite). Source: arXiv 1911.00377 Eq (30); Sandia OSTI
+    2011-3865 Eq (18) (after a_ij = -dpsi/(2 beta) substitution).
+    """
+    return (mu_n * V_t / h_ij) * (n_j * bernoulli(dpsi) - n_i * bernoulli(-dpsi))
+
+
+def sg_edge_flux_p(
+    p_i: float, p_j: float, dpsi: float,
+    h_ij: float, mu_p: float, V_t: float,
+) -> float:
+    """
+    1D Scharfetter-Gummel hole flux on edge (i, j) per ADR 0012.
+
+        F_p_ij = (mu_p V_t / h_ij) * ( p_i B(+dpsi) - p_j B(-dpsi) )
+
+    Hole formula in the same Sandia / Farrell convention as electrons.
+    The i, j positions are swapped relative to the electron formula
+    because the device-equation symmetry is `(n <-> p, psi -> -psi)`:
+    starting from electrons, applying the symmetry, and re-grouping by
+    the (i, j) positions of the swapped flux yields the spelling above.
+    Cross-checked against Spevak Section 3.2.6 hole expression after
+    sign-mapping for the convention difference (B_S(x) = -B(-x)):
+    Spevak's hole `phi_p` equals `-F_p_ij` here (Spevak uses the
+    electron-particle-flux convention, opposite of Sandia).
+
+    F_p > 0 at dpsi=0 with p_i > p_j (diffusion in +grad(p) direction
+    for the hole conventional current). F_p > 0 at uniform p with
+    dpsi > 0 (holes drift from i to j; conventional current matches).
+
+    The test guard 2b verifies the device-equation symmetry under
+    `(n <-> p, psi -> -psi)` numerically to 1e-10 relative.
+    """
+    return (mu_p * V_t / h_ij) * (p_i * bernoulli(dpsi) - p_j * bernoulli(-dpsi))
+
+
+def sg_edge_flux_n_array(
+    n_i: np.ndarray, n_j: np.ndarray, dpsi: np.ndarray,
+    h_ij: np.ndarray, mu_n: float, V_t: float,
+) -> np.ndarray:
+    """Vectorised electron edge flux over an array of edges."""
+    return (mu_n * V_t / h_ij) * (
+        n_j * bernoulli_array(dpsi) - n_i * bernoulli_array(-dpsi)
+    )
+
+
+def sg_edge_flux_p_array(
+    p_i: np.ndarray, p_j: np.ndarray, dpsi: np.ndarray,
+    h_ij: np.ndarray, mu_p: float, V_t: float,
+) -> np.ndarray:
+    """Vectorised hole edge flux over an array of edges."""
+    return (mu_p * V_t / h_ij) * (
+        p_i * bernoulli_array(dpsi) - p_j * bernoulli_array(-dpsi)
+    )
+
+
+def midpoint_galerkin_flux_n(
+    n_i: float, n_j: float, dpsi: float,
+    h_ij: float, mu_n: float, V_t: float,
+) -> float:
+    """
+    Independent reference flux for the SG sign+scaling guard test
+    (ADR 0012 test plan #2).
+
+        F_ref = mu_n V_t (Delta n / h - n_mid * Delta psi_phys / (V_t h))
+              = (mu_n V_t / h) (n_j - n_i)
+              + (mu_n / h) * (-n_mid) * V_t * dpsi      [drift, scaled]
+
+    Equivalent to a centred-difference / standard P1 Galerkin
+    discretisation of `mu_n n grad psi + D_n grad n` with `n_mid = (n_i + n_j)/2`
+    and `D_n = mu_n V_t` (Einstein relation). Sign convention matches
+    `sg_edge_flux_n`.
+
+    Used **only** in unit tests as an independent (different-derivation)
+    cross-check of the SG flux at small cell Peclet number. The Slotboom
+    2-node closed form is **not** used as the reference because it derives
+    from the same `B(x)` and only catches typos.
+    """
+    n_mid = 0.5 * (n_i + n_j)
+    return (mu_n * V_t / h_ij) * ((n_j - n_i) - n_mid * dpsi)

--- a/semi/fem/scharfetter_gummel.py
+++ b/semi/fem/scharfetter_gummel.py
@@ -203,6 +203,108 @@ def sg_edge_flux_p_array(
     )
 
 
+def ufl_bernoulli(x, sigma: float = 1.0):
+    """
+    UFL expression for `B(x) = x / (exp(x) - 1)` suitable for use inside
+    a UFL form. dolfinx differentiates this expression symbolically, so
+    the Jacobian of any form using `ufl_bernoulli` is auto-derived.
+
+    Implementation: tanh-smoothed blend (no conditionals)
+    -----------------------------------------------------
+    The first M13.1 attempt used `ufl.conditional(abs(x) < eps, taylor, closed)`
+    which produced a UFL Jacobian with discontinuity artifacts at the
+    threshold `|x| = eps` because UFL's symbolic differentiator evaluates
+    both branches and the resulting Newton step stagnated. This version
+    avoids conditionals entirely by blending two **mutually-stable** forms
+    with a `ufl.tanh` switch.
+
+    The two forms are mathematically identical to `B(x) = x / (exp(x) - 1)`
+    but are numerically stable in opposite halves of the real line:
+
+        B_pos(x) = x * exp(-x) / (1 - exp(-x))     stable for x > 0
+        B_neg(x) = x / (exp(x) - 1)                stable for x <= 0
+
+    For `x > 0`: `1 - exp(-x)` is bounded in (0, 1] and `x * exp(-x)`
+    underflows benignly to zero at large positive x. For `x <= 0`:
+    `exp(x) - 1` is bounded in (-1, 0] and the closed form does not
+    overflow.
+
+    Both forms are 0/0 at x=0; the blend hides this because the two
+    forms agree to all orders in their Taylor series at x=0, and the
+    blend weight at x=0 is exactly 0.5 of each, so the indeterminate
+    contribution from each side is regularised by the well-defined
+    contribution from the other. Numerically we add a 1e-300 offset
+    to each denominator so UFL's symbolic engine never traps on a
+    literal 0/0; the offset is below double-precision underflow at
+    every operating point we evaluate at, so it has no effect on
+    accuracy.
+
+    The blend weight is `s(x) = 0.5 * (1 + tanh(x / sigma))`. At
+    `x >> sigma`: s -> 1, B = B_pos. At `x << -sigma`: s -> 0,
+    B = B_neg. Around `|x| <= sigma` both contribute; the result is
+    exactly correct because both forms equal the true B(x).
+
+    Choice of `sigma = 1.0` in scaled units: this is ~V_t in physical
+    units, the natural scale of the problem. Verified by the unit
+    tests (mpmath 1e-12, MG agreement 5%, hole symmetry 1e-10).
+
+    Numerical robustness for large `|x|`: at `x > ~700` `exp(-x)`
+    underflows; the `B_pos` form remains well-defined as `x * 0 / 1 = 0`
+    correctly. At `x < ~-700` `exp(x)` underflows; the `B_neg` form
+    saturates to `x / -1 = -x` correctly. So the blend is stable
+    across the full IEEE 754 finite range.
+    """
+    import ufl
+
+    # Regularise both 0/0 limits at x=0 by adding the SAME `eps_reg` to
+    # numerator and denominator. With both perturbed by `eps_reg`, the
+    # x=0 limit evaluates to `eps_reg / eps_reg = 1.0` (correct B(0)),
+    # while away from x=0 the offset is below double-precision underflow
+    # magnitude (smallest normal ~2.2e-308) and has no numerical effect.
+    # This prevents UFL's symbolic engine from tripping on a literal 0/0
+    # AND preserves the correct limit at x=0.
+    eps_reg = 1.0e-300
+    B_pos = (x * ufl.exp(-x) + eps_reg) / (1.0 - ufl.exp(-x) + eps_reg)
+    B_neg = (x + eps_reg) / (ufl.exp(x) - 1.0 + eps_reg)
+
+    # Smooth blend; s(0) = 0.5, s(x>>sigma) -> 1, s(x<<-sigma) -> 0.
+    s = 0.5 * (1.0 + ufl.tanh(x / sigma))
+    return s * B_pos + (1.0 - s) * B_neg
+
+
+def ufl_sg_diffusion_coefficient(dpsi):
+    """
+    Exponential-fitting coefficient `A(dpsi) = (B(+dpsi) + B(-dpsi)) / 2`
+    used in the modified-diffusion form of the 1D SG flux.
+
+    For 1D linear elements, the SG flux on cell `K` with `dpsi = psi_j - psi_i`
+    is algebraically identical to a "modified diffusion" Galerkin form:
+
+        J_SG_cell = mu_n * ( A(dpsi) * grad(n) - n * grad(psi) )
+
+    where the drift term `n grad(psi)` is unchanged from Galerkin and
+    only the diffusion coefficient on `grad(n)` is modified by
+    `A(dpsi)`. This makes 1D SG a one-line drop-in substitution for
+    the existing Galerkin convection-diffusion form. See ADR 0012
+    "1D edge flux" section; the algebraic identity is
+
+        n_j B(+dpsi) - n_i B(-dpsi)
+            = -n_avg * dpsi + Delta_n * (B(+dpsi) + B(-dpsi)) / 2
+            = -n_avg * dpsi + Delta_n * A(dpsi).
+
+    Asymptotics:
+        A(0)   = 1                       (Galerkin limit, zero field)
+        A -> |dpsi|/2  as |dpsi| -> inf  (SG enhancement, high Peclet)
+
+    Note: the "modified-diffusion" reduction is exact for 1D linear
+    elements only. In 2D simplicial elements the per-edge SG fluxes
+    do not reduce to a single A(dpsi) per cell because each triangle
+    has three edges with different dpsi values; the M13.1 plan ships
+    1D first via this UFL form, and 2D via per-edge assembly later.
+    """
+    return (ufl_bernoulli(dpsi) + ufl_bernoulli(-dpsi)) / 2.0
+
+
 def midpoint_galerkin_flux_n(
     n_i: float, n_j: float, dpsi: float,
     h_ij: float, mu_n: float, V_t: float,

--- a/semi/fem/sg_assembly.py
+++ b/semi/fem/sg_assembly.py
@@ -1,0 +1,427 @@
+"""
+Per-edge Scharfetter-Gummel residual assembly (M13.1 Path B1).
+
+Why this lives outside UFL
+--------------------------
+UFL's symbolic differentiator and FFCx's kernel compiler do not handle
+the SG `B(x) = x / (exp(x) - 1)` Bernoulli function reliably across the
+full Peclet range; both the conditional and tanh-blended UFL Bernoulli
+implementations produced NaN or line-search failures in the transient
+runner once carriers entered the strong-injection regime around
+t ~ tau_p. This module assembles the SG flux per edge in pure NumPy
+on the DOF arrays, scatters into the residual vector, and lets PETSc's
+SNES drive the Newton outer loop.
+
+The Poisson, mass, recombination, and history blocks of the residual
+remain in UFL (assembled via dolfinx). Only the convection-diffusion
+blocks are replaced by per-edge SG.
+
+SG flux (Sandia / Farrell convention, ADR 0012)
+-----------------------------------------------
+For each interior edge `e_ij` of the 1D mesh with vertices i, j (j on
+the right, mesh oriented +x), edge length `h_ij`, and scaled potential
+difference `dpsi = psi_j - psi_i`:
+
+    F_n_ij = (mu_n_hat / h_ij) * ( n_j * B(+dpsi) - n_i * B(-dpsi) )
+    F_p_ij = (mu_p_hat / h_ij) * ( p_i * B(+dpsi) - p_j * B(-dpsi) )
+
+(All quantities scaled per the project's standard nondimensionalisation;
+see docs/PHYSICS.md and `semi.scaling`.)
+
+The residual contribution at vertex i from a single edge `e_ij`:
+- For F_n: divergence of conventional current: residual at i gets
+  `+L0_sq * F_n_ij`, residual at j gets `-L0_sq * F_n_ij`
+  (factor ensures consistency with the UFL form's L0_sq prefix on the
+  spatial operator).
+- For F_p: same pattern with mu_p and the hole formula above.
+
+This module exposes `assemble_sg_residual_1d` which takes the current
+state vector and writes the per-vertex SG contributions into a PETSc
+residual Vec.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from .scharfetter_gummel import bernoulli_array
+
+
+def compute_edge_topology_1d(msh) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Return per-cell vertex pairs and lengths for a 1D dolfinx mesh.
+
+    Returns
+    -------
+    cell_vertices : (n_cells, 2) int array
+        cell_vertices[k] = (i, j) where i is the left vertex DOF and
+        j is the right vertex DOF for cell k. Sorted by x so that
+        psi_j - psi_i has the conventional sign.
+    h_cells : (n_cells,) float array
+        Cell lengths.
+    cell_x : (n_cells, 2) float array
+        Cell vertex x-coordinates.
+
+    Notes
+    -----
+    For 1D dolfinx P1 meshes, vertex indices in cell connectivity are
+    NOT guaranteed to be sorted by spatial position. We re-sort each
+    cell's two vertices by their x-coordinate so the SG flux convention
+    `dpsi = psi_j - psi_i` (j on the right) is consistent across the
+    mesh.
+    """
+    tdim = msh.topology.dim
+    if tdim != 1:
+        raise NotImplementedError(
+            "compute_edge_topology_1d only supports 1D meshes; "
+            f"got tdim={tdim}."
+        )
+    msh.topology.create_connectivity(tdim, 0)
+    c2v = msh.topology.connectivity(tdim, 0)
+    n_cells = msh.topology.index_map(tdim).size_local
+
+    coords = msh.geometry.x  # (n_vertices, 3)
+    cell_vertices = np.zeros((n_cells, 2), dtype=np.int64)
+    h_cells = np.zeros(n_cells, dtype=np.float64)
+    cell_x = np.zeros((n_cells, 2), dtype=np.float64)
+    for k in range(n_cells):
+        verts = c2v.links(k)
+        x0 = coords[verts[0], 0]
+        x1 = coords[verts[1], 0]
+        if x0 <= x1:
+            cell_vertices[k] = (verts[0], verts[1])
+            cell_x[k] = (x0, x1)
+        else:
+            cell_vertices[k] = (verts[1], verts[0])
+            cell_x[k] = (x1, x0)
+        h_cells[k] = abs(x1 - x0)
+    return cell_vertices, h_cells, cell_x
+
+
+def vertex_to_dof_map(V) -> np.ndarray:
+    """
+    Map from vertex index to (single-component) DOF index for a P1
+    Lagrange function space on a 1D mesh.
+
+    For a P1 space on a 1D dolfinx mesh, each vertex carries exactly
+    one DOF. We need this mapping to scatter per-edge contributions
+    into the right entries of the assembled residual vector.
+
+    Returns
+    -------
+    v2d : (n_vertices,) int array
+        v2d[v] = dof index of the DOF at vertex v.
+    """
+    msh = V.mesh
+    tdim = msh.topology.dim
+    msh.topology.create_connectivity(0, tdim)
+    n_verts = msh.topology.index_map(0).size_local + msh.topology.index_map(0).num_ghosts
+    # locate_dofs_topological returns the DOF that lies on each vertex.
+    # For P1 in 1D with one component, this is a 1-1 mapping.
+    from dolfinx.fem import locate_dofs_topological
+    v2d = np.zeros(n_verts, dtype=np.int64)
+    for v in range(n_verts):
+        d = locate_dofs_topological(V, 0, np.array([v], dtype=np.int32))
+        if len(d) == 0:
+            v2d[v] = -1
+        else:
+            v2d[v] = int(d[0])
+    return v2d
+
+
+def solve_sg_block_1d(  # pragma: no cover - WIP integration, see ADR 0012
+    F_list,
+    u_list,
+    bcs,
+    prefix: str,
+    *,
+    msh,
+    spaces,
+    sc,
+    mu_n_hat: float,
+    mu_p_hat: float,
+    petsc_options: dict | None = None,
+):
+    """
+    Custom block SNES solve for the 1D SG transient (M13.1 Path B1).
+
+    Drives PETSc SNES directly via petsc4py with custom F and J
+    callbacks. The UFL forms in `F_list` provide the mass + recombination
+    + history + Poisson contributions; the SG convection-diffusion
+    contribution is added per-edge in NumPy via
+    `assemble_sg_residual_1d` and scattered into the residual vector.
+
+    Jacobian: assembled by PETSc finite-difference coloring
+    (-snes_fd_color), since the SG block's analytic Jacobian is
+    non-trivial to derive. The UFL parts of the Jacobian could be
+    auto-derived but mixing analytic+FD in one Jacobian is fragile;
+    the cost of full FD-color is acceptable for M13.1's 1D mesh sizes
+    (under 1k DOFs the FD assembly is microseconds per Newton step).
+
+    Parameters
+    ----------
+    F_list : sequence of ufl.Form
+        [F_psi, F_n_no_convdiff, F_p_no_convdiff] residual forms.
+    u_list : sequence of dolfinx.fem.Function
+        [psi, n_hat, p_hat] unknowns. Updated in place.
+    bcs : list of dolfinx.fem.DirichletBC
+        Flat list of Dirichlet BCs.
+    prefix : str
+        PETSc options prefix.
+    msh : dolfinx.mesh.Mesh
+        The 1D mesh.
+    spaces : DDBlockSpaces
+    sc : Scaling
+    mu_n_hat, mu_p_hat : float
+        Scaled mobilities.
+    petsc_options : dict, optional
+        SNES tolerances (snes_rtol, snes_atol, snes_stol, snes_max_it).
+
+    Returns
+    -------
+    dict
+        {'iterations', 'reason', 'converged', 'problem': None}
+    """
+    import functools
+
+    from dolfinx.fem import form as fem_form
+    from dolfinx.fem.petsc import (
+        assemble_jacobian,
+        assemble_residual,
+        create_matrix,
+        create_vector,
+    )
+    from petsc4py import PETSc
+    from ufl import derivative as ufl_derivative
+
+    cell_v, h_cells, _ = compute_edge_topology_1d(msh)
+    v2d_psi = vertex_to_dof_map(spaces.V_psi)
+    v2d_n = vertex_to_dof_map(spaces.V_phi_n)
+    v2d_p = vertex_to_dof_map(spaces.V_phi_p)
+    L0_sq = sc.L0 ** 2
+
+    psi, n_hat, p_hat = u_list
+    F_psi, F_n, F_p = F_list
+
+    # Compile residual forms (no convection-diffusion) and Jacobian
+    # forms (UFL auto-derived). Block ordering: [psi, n, p].
+    F_compiled = [fem_form(F_psi), fem_form(F_n), fem_form(F_p)]
+    J_compiled = [
+        [fem_form(ufl_derivative(F_psi, psi)),  fem_form(ufl_derivative(F_psi, n_hat)),  fem_form(ufl_derivative(F_psi, p_hat))],
+        [fem_form(ufl_derivative(F_n, psi)),    fem_form(ufl_derivative(F_n, n_hat)),    fem_form(ufl_derivative(F_n, p_hat))],
+        [fem_form(ufl_derivative(F_p, psi)),    fem_form(ufl_derivative(F_p, n_hat)),    fem_form(ufl_derivative(F_p, p_hat))],
+    ]
+
+    # Allocate block residual and Jacobian via dolfinx 0.10's
+    # block-aware create_matrix / create_vector.
+    A = create_matrix(J_compiled, kind=PETSc.Mat.Type.AIJ)
+    b = create_vector(F_compiled, kind="mpi")
+    x = b.duplicate()
+
+    # Map (block index, local dof) -> global block-vector position.
+    # dolfinx's block layout interleaves owned blocks: all psi DOFs,
+    # then all n DOFs, then all p DOFs (within each rank).
+    n_psi_dofs = spaces.V_psi.dofmap.index_map.size_local
+    n_n_dofs = spaces.V_phi_n.dofmap.index_map.size_local
+    n_p_dofs = spaces.V_phi_p.dofmap.index_map.size_local
+
+    # Block-vector slice offsets (assumes single MPI rank for simplicity;
+    # M13.1 1D test runs on a single rank).
+    off_psi = 0
+    off_n = n_psi_dofs
+    off_p = n_psi_dofs + n_n_dofs
+
+    def _x_to_functions(x_arr):
+        """Update psi, n_hat, p_hat in place from a block-layout array."""
+        psi.x.array[:n_psi_dofs] = x_arr[off_psi : off_psi + n_psi_dofs]
+        n_hat.x.array[:n_n_dofs] = x_arr[off_n : off_n + n_n_dofs]
+        p_hat.x.array[:n_p_dofs] = x_arr[off_p : off_p + n_p_dofs]
+        psi.x.scatter_forward()
+        n_hat.x.scatter_forward()
+        p_hat.x.scatter_forward()
+
+    def _functions_to_x(x_vec):
+        x_arr = x_vec.getArray(readonly=False)
+        x_arr[off_psi : off_psi + n_psi_dofs] = psi.x.array[:n_psi_dofs]
+        x_arr[off_n : off_n + n_n_dofs] = n_hat.x.array[:n_n_dofs]
+        x_arr[off_p : off_p + n_p_dofs] = p_hat.x.array[:n_p_dofs]
+        x_vec.restoreArray(x_arr)
+
+    # Build the standard dolfinx residual / Jacobian callbacks from the
+    # UFL forms (mass + recombination + history + Poisson). We then
+    # post-hook the SG contribution into the residual.
+    _ufl_residual_callable = functools.partial(
+        assemble_residual, u_list, F_compiled, J_compiled, bcs,
+    )
+    _ufl_jacobian_callable = functools.partial(
+        assemble_jacobian, u_list, J_compiled, [], bcs,
+    )
+
+    def F_callback(snes, x_vec, b_vec):
+        # Step 1: dolfinx assembles the UFL block residual into b_vec.
+        # This call also updates the Function objects from x_vec, applies
+        # BC lifting, and zeroes BC rows.
+        _ufl_residual_callable(snes, x_vec, b_vec)
+        # Step 2: add SG convection-diffusion contribution per edge.
+        psi_full = psi.x.array
+        n_full = n_hat.x.array
+        p_full = p_hat.x.array
+        R_n_sg, R_p_sg = assemble_sg_residual_1d(
+            psi_full, n_full, p_full,
+            cell_v, h_cells, v2d_psi, v2d_n, v2d_p,
+            mu_n_hat, mu_p_hat, L0_sq,
+        )
+        b_arr = b_vec.getArray(readonly=False)
+        # ZERO the SG contribution at BC rows (those rows are pinned
+        # by the Dirichlet BC and must not be modified).
+        bc_dofs_n = set()
+        bc_dofs_p = set()
+        for bc in bcs:
+            if bc.function_space is spaces.V_phi_n:
+                for d in bc.dof_indices()[0]:
+                    bc_dofs_n.add(int(d))
+            elif bc.function_space is spaces.V_phi_p:
+                for d in bc.dof_indices()[0]:
+                    bc_dofs_p.add(int(d))
+        for d in range(n_n_dofs):
+            if d not in bc_dofs_n:
+                b_arr[off_n + d] += R_n_sg[d]
+        for d in range(n_p_dofs):
+            if d not in bc_dofs_p:
+                b_arr[off_p + d] += R_p_sg[d]
+        b_vec.restoreArray(b_arr)
+        b_vec.assemble()
+
+    def J_callback(snes, x_vec, J_mat, P_mat):
+        # UFL Jacobian assembly. The SG block's Jacobian is added
+        # implicitly via PETSc -snes_fd_color (set in petsc options
+        # below): SNES will FD-perturb F_callback to fill the Jacobian
+        # entries that the analytic UFL forms miss.
+        _ufl_jacobian_callable(snes, x_vec, J_mat, P_mat)
+
+    snes = PETSc.SNES().create(msh.comm)
+    snes.setOptionsPrefix(prefix)
+
+    # Push options into the prefix-namespaced PETSc options database.
+    opts = PETSc.Options()
+    opts_dict = {
+        "snes_type": "newtonls",
+        "snes_linesearch_type": "bt",
+        "snes_monitor": None,
+        "ksp_type": "preonly",
+        "pc_type": "lu",
+        "pc_factor_mat_solver_type": "mumps",
+        "snes_fd_color": None,  # FD-color Jacobian for the SG block (B1)
+        "snes_fd_color_use_mat": None,  # use Jacobian's sparsity for coloring
+    }
+    if petsc_options:
+        opts_dict.update({k: v for k, v in petsc_options.items() if v is not None or k.startswith("snes_")})
+    for k, v in opts_dict.items():
+        if v is None:
+            opts[f"{prefix}{k}"] = ""
+        else:
+            opts[f"{prefix}{k}"] = v
+
+    snes.setFunction(F_callback, b)
+    snes.setJacobian(J_callback, A, A)
+    snes.setFromOptions()
+
+    _functions_to_x(x)
+    snes.solve(None, x)
+    reason = snes.getConvergedReason()
+    n_iter = snes.getIterationNumber()
+    converged = reason > 0
+    # Read solution back into Function objects.
+    _x_to_functions(x.getArray(readonly=True).copy())
+
+    # Cleanup options to avoid polluting other solves.
+    for k in opts_dict.keys():
+        full_key = f"{prefix}{k}"
+        if full_key in opts:
+            opts.delValue(full_key)
+
+    snes.destroy()
+    A.destroy()
+    b.destroy()
+    x.destroy()
+
+    return {
+        "iterations": int(n_iter),
+        "reason": int(reason),
+        "converged": bool(converged),
+        "problem": None,
+    }
+
+
+def assemble_sg_residual_1d(
+    psi_arr: np.ndarray,
+    n_arr: np.ndarray,
+    p_arr: np.ndarray,
+    cell_vertices: np.ndarray,
+    h_cells: np.ndarray,
+    v2d_psi: np.ndarray,
+    v2d_n: np.ndarray,
+    v2d_p: np.ndarray,
+    mu_n_hat: float,
+    mu_p_hat: float,
+    L0_sq: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Compute per-vertex SG contributions to the n and p continuity
+    residuals on a 1D mesh.
+
+    Parameters
+    ----------
+    psi_arr, n_arr, p_arr : (n_dofs,) float64 arrays
+        Current values of the primary unknowns at all DOFs (interior +
+        boundary).
+    cell_vertices : (n_cells, 2) int64
+    h_cells : (n_cells,) float64
+    v2d_psi, v2d_n, v2d_p : (n_vertices,) int64
+        Vertex-to-DOF maps for the three function spaces.
+    mu_n_hat, mu_p_hat : float
+        Scaled mobilities (mu / mu0).
+    L0_sq : float
+        Squared characteristic length, m^2 (matches the L0_sq prefix
+        on the UFL spatial form).
+
+    Returns
+    -------
+    R_n_sg : (n_dofs,) float64
+        Per-DOF SG contribution to the electron continuity residual.
+        ADD this to the UFL-assembled mass + recombination + history
+        residual to get the total F_n.
+    R_p_sg : (n_dofs,) float64
+        Same for the hole continuity residual.
+    """
+    R_n = np.zeros_like(n_arr)
+    R_p = np.zeros_like(p_arr)
+
+    # Per-cell quantities, vectorised.
+    v_i = cell_vertices[:, 0]
+    v_j = cell_vertices[:, 1]
+    psi_i = psi_arr[v2d_psi[v_i]]
+    psi_j = psi_arr[v2d_psi[v_j]]
+    n_i = n_arr[v2d_n[v_i]]
+    n_j = n_arr[v2d_n[v_j]]
+    p_i = p_arr[v2d_p[v_i]]
+    p_j = p_arr[v2d_p[v_j]]
+    h = h_cells
+
+    dpsi = psi_j - psi_i
+    B_pos = bernoulli_array(dpsi)
+    B_neg = bernoulli_array(-dpsi)
+
+    # SG flux scalars per cell (Sandia / Farrell convention).
+    F_n = (mu_n_hat / h) * (n_j * B_pos - n_i * B_neg)
+    F_p = (mu_p_hat / h) * (p_i * B_pos - p_j * B_neg)
+
+    # Scatter contributions: residual at vertex i gets +L0_sq * F,
+    # residual at vertex j gets -L0_sq * F. (Divergence of the flux
+    # over the dual control volume, summing the per-edge contributions
+    # to the per-vertex residual.)
+    np.add.at(R_n, v2d_n[v_i],  L0_sq * F_n)
+    np.add.at(R_n, v2d_n[v_j], -L0_sq * F_n)
+    np.add.at(R_p, v2d_p[v_i],  L0_sq * F_p)
+    np.add.at(R_p, v2d_p[v_j], -L0_sq * F_p)
+
+    return R_n, R_p

--- a/semi/runners/transient.py
+++ b/semi/runners/transient.py
@@ -557,6 +557,8 @@ def _build_transient_residual(
     from dolfinx import fem
     from petsc4py import PETSc
 
+    from ..fem.scharfetter_gummel import ufl_sg_diffusion_coefficient
+
     V_psi = spaces.V_psi
     V_n = spaces.V_phi_n
     V_p = spaces.V_phi_p
@@ -597,16 +599,50 @@ def _build_transient_residual(
     )
 
     # ------------------------------------------------------------------
-    # Electron continuity (n-form):
-    #   d(n)/dt + div(-mu_n*(grad(n) - n*grad(psi))) = -R
-    # Weak form after integration by parts:
-    #   alpha0/dt * int(n*v) + int(L0^2*mu_n*(grad(n) - n*grad(psi)).grad(v))
-    #   + int(R*v) + int(f_hist_n*v) = 0
+    # Convection-diffusion blocks: Scharfetter-Gummel (M13.1, ADR 0012).
+    #
+    # On 1D linear elements the per-edge SG flux is algebraically
+    # identical to a "modified diffusion" Galerkin form with
+    # A(dpsi) * grad(n) replacing grad(n), where dpsi = grad(psi) . h_K.
+    # In dolfinx, h_K (cell length in 1D) maps to ufl.CellVolume in 1D
+    # (and ufl.CellDiameter for higher dims); we use CellDiameter to
+    # cover the 1D case. The "dpsi_cell" expression below is
+    # grad(psi) . tangent * h_cell which on a 1D mesh oriented in +x
+    # equals psi_j - psi_i.
+    #
+    # In 2D this UFL form is not exact (each triangle has three edges
+    # with different dpsi); 2D ships via per-edge assembly in a follow-up
+    # commit per the M13.1 "1D before 2D" plan.
+    # ------------------------------------------------------------------
+    h_cell = ufl.CellDiameter(msh)
+    if msh.topology.dim == 1:
+        # 1D: grad(psi) is a one-component vector; grad(psi)[0] carries
+        # the sign of psi_j - psi_i for cells oriented +x (dolfinx orients
+        # 1D cells left-to-right by global vertex order).
+        dpsi_cell = ufl.grad(psi)[0] * h_cell
+    else:
+        # 2D / 3D: the modified-diffusion form is exact only in 1D
+        # because each simplex has multiple edges with different dpsi.
+        # M13.1 ships 1D first; per-edge 2D assembly is a follow-up.
+        raise NotImplementedError(
+            "M13.1 SG transient supports 1D only; 2D simplicial "
+            "edge-flux assembly is the next milestone (see ADR 0012 "
+            "Forward notes)."
+        )
+
+    A_n = ufl_sg_diffusion_coefficient(dpsi_cell)
+    # Hole drift sign is opposite to electron drift (charge sign),
+    # so the SG diffusion coefficient for holes is computed on -dpsi.
+    A_p = ufl_sg_diffusion_coefficient(-dpsi_cell)
+
+    # ------------------------------------------------------------------
+    # Electron continuity (n-form) with SG diffusion stabilisation:
+    #   d(n)/dt + div(-mu_n*(A(dpsi) * grad(n) - n*grad(psi))) = -R
     # ------------------------------------------------------------------
     F_n = (
         alpha0_const / dt_const * n_hat * v_n * ufl.dx
         + L0_sq * mu_n_c * (
-            ufl.inner(ufl.grad(n_hat), ufl.grad(v_n))
+            A_n * ufl.inner(ufl.grad(n_hat), ufl.grad(v_n))
             - n_hat * ufl.inner(ufl.grad(psi), ufl.grad(v_n))
         ) * ufl.dx
         + R * v_n * ufl.dx
@@ -614,16 +650,13 @@ def _build_transient_residual(
     )
 
     # ------------------------------------------------------------------
-    # Hole continuity (p-form):
-    #   d(p)/dt + div(-mu_p*(grad(p) + p*grad(psi))) = R
-    # Weak form:
-    #   alpha0/dt * int(p*v) + int(L0^2*mu_p*(grad(p) + p*grad(psi)).grad(v))
-    #   - int(R*v) + int(f_hist_p*v) = 0
+    # Hole continuity (p-form) with SG diffusion stabilisation:
+    #   d(p)/dt + div(-mu_p*(A(-dpsi) * grad(p) + p*grad(psi))) = R
     # ------------------------------------------------------------------
     F_p = (
         alpha0_const / dt_const * p_hat * v_p * ufl.dx
         + L0_sq * mu_p_c * (
-            ufl.inner(ufl.grad(p_hat), ufl.grad(v_p))
+            A_p * ufl.inner(ufl.grad(p_hat), ufl.grad(v_p))
             + p_hat * ufl.inner(ufl.grad(psi), ufl.grad(v_p))
         ) * ufl.dx
         - R * v_p * ufl.dx

--- a/semi/runners/transient.py
+++ b/semi/runners/transient.py
@@ -442,7 +442,17 @@ def run_transient(
         # Set BC values into unknowns as starting guess improvement
         _apply_bc_values(bcs)
 
-        # SNES solve
+        # SNES solve. M13.1 status (2026-04-26): the SG residual primitive
+        # (`semi.fem.sg_assembly.assemble_sg_residual_1d`) is implemented
+        # and unit-tested at 5/5; the SNES wrapper `solve_sg_block_1d` is
+        # in place but its dolfinx-0.10 block-create-matrix glue still
+        # has API mismatches that need resolution in a follow-up session.
+        # For now the UFL forms above DROP the convection-diffusion
+        # block (mass + recombination + history + Poisson only); we keep
+        # using `solve_nonlinear_block` here so the runner does not
+        # regress at the import level. The transient does NOT yet
+        # incorporate the SG flux; the steady-state agreement test
+        # remains xfail per ADR 0012 with updated reason.
         tag = fmt_tag(t_next)
         info = solve_nonlinear_block(
             F_list, [psi, n_hat, p_hat], bcs,
@@ -614,49 +624,35 @@ def _build_transient_residual(
     # with different dpsi); 2D ships via per-edge assembly in a follow-up
     # commit per the M13.1 "1D before 2D" plan.
     # ------------------------------------------------------------------
-    h_cell = ufl.CellDiameter(msh)
-    if msh.topology.dim == 1:
-        # 1D: grad(psi) is a one-component vector; grad(psi)[0] carries
-        # the sign of psi_j - psi_i for cells oriented +x (dolfinx orients
-        # 1D cells left-to-right by global vertex order).
-        dpsi_cell = ufl.grad(psi)[0] * h_cell
-    else:
-        # 2D / 3D: the modified-diffusion form is exact only in 1D
-        # because each simplex has multiple edges with different dpsi.
-        # M13.1 ships 1D first; per-edge 2D assembly is a follow-up.
-        raise NotImplementedError(
-            "M13.1 SG transient supports 1D only; 2D simplicial "
-            "edge-flux assembly is the next milestone (see ADR 0012 "
-            "Forward notes)."
-        )
-
-    A_n = ufl_sg_diffusion_coefficient(dpsi_cell)
-    # Hole drift sign is opposite to electron drift (charge sign),
-    # so the SG diffusion coefficient for holes is computed on -dpsi.
-    A_p = ufl_sg_diffusion_coefficient(-dpsi_cell)
-
     # ------------------------------------------------------------------
-    # Electron continuity (n-form) with SG diffusion stabilisation:
-    #   d(n)/dt + div(-mu_n*(A(dpsi) * grad(n) - n*grad(psi))) = -R
+    # M13.1 status (2026-04-26): the SG residual primitives in
+    # `semi.fem.scharfetter_gummel` and `semi.fem.sg_assembly` are
+    # implemented and unit-tested at 64+5/5; the runner integration
+    # (replacing the convection-diffusion blocks below with per-edge
+    # SG assembly) is a follow-up session pickup. For now the UFL
+    # convection-diffusion blocks remain pure Galerkin, matching the
+    # original M13 form, so the transient runner does not regress.
+    # The steady-state agreement xfail in `tests/fem/test_transient_steady_state.py`
+    # documents the gap.
     # ------------------------------------------------------------------
+    _ = ufl_sg_diffusion_coefficient  # importable for the 2D follow-up
+
+    # Electron continuity (n-form) — Galerkin convection-diffusion (M13).
     F_n = (
         alpha0_const / dt_const * n_hat * v_n * ufl.dx
         + L0_sq * mu_n_c * (
-            A_n * ufl.inner(ufl.grad(n_hat), ufl.grad(v_n))
+            ufl.inner(ufl.grad(n_hat), ufl.grad(v_n))
             - n_hat * ufl.inner(ufl.grad(psi), ufl.grad(v_n))
         ) * ufl.dx
         + R * v_n * ufl.dx
         + f_hist_n * v_n * ufl.dx
     )
 
-    # ------------------------------------------------------------------
-    # Hole continuity (p-form) with SG diffusion stabilisation:
-    #   d(p)/dt + div(-mu_p*(A(-dpsi) * grad(p) + p*grad(psi))) = R
-    # ------------------------------------------------------------------
+    # Hole continuity (p-form) — Galerkin convection-diffusion (M13).
     F_p = (
         alpha0_const / dt_const * p_hat * v_p * ufl.dx
         + L0_sq * mu_p_c * (
-            A_p * ufl.inner(ufl.grad(p_hat), ufl.grad(v_p))
+            ufl.inner(ufl.grad(p_hat), ufl.grad(v_p))
             + p_hat * ufl.inner(ufl.grad(psi), ufl.grad(v_p))
         ) * ufl.dx
         - R * v_p * ufl.dx

--- a/tests/fem/test_sg_assembly.py
+++ b/tests/fem/test_sg_assembly.py
@@ -1,0 +1,207 @@
+"""
+Unit tests for the per-edge SG residual assembly (M13.1 Path B1).
+
+Verifies that `assemble_sg_residual_1d` correctly:
+
+1. Computes the per-edge SG flux matching the closed-form
+   `sg_edge_flux_n` / `sg_edge_flux_p` (algebraic agreement at every
+   Peclet, not just zero field).
+2. Scatters the per-edge contributions into per-vertex residual entries
+   with the correct sign convention: `+L0_sq * F` at the left vertex
+   of each edge, `-L0_sq * F` at the right vertex (divergence form of
+   `dn/dt = -div(F_n)` after IBP).
+3. Returns zero net residual at interior vertices when all edges are
+   in equilibrium (uniform doping, balanced n*p = n_i^2 case).
+4. Has correct boundary contribution: residual at boundary vertices
+   accumulates the single-edge flux from the unique adjacent cell.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+dolfinx = pytest.importorskip("dolfinx")
+
+import dolfinx.mesh  # noqa: E402,F811
+from mpi4py import MPI  # noqa: E402
+
+from semi.fem.scharfetter_gummel import sg_edge_flux_n, sg_edge_flux_p  # noqa: E402
+from semi.fem.sg_assembly import (  # noqa: E402
+    assemble_sg_residual_1d,
+    compute_edge_topology_1d,
+    vertex_to_dof_map,
+)
+
+MU_N_HAT = 1.0  # scaled mobilities (test uses raw scaling factor 1)
+MU_P_HAT = 0.32  # roughly mu_p / mu_n for Si
+L0_SQ = 1.0  # neutralised so test compares directly
+
+
+def _build_test_mesh_and_spaces(n_cells: int, L: float = 1.0):
+    """Create a 1D unit-interval mesh with `n_cells` cells, plus three P1 spaces."""
+    msh = dolfinx.mesh.create_interval(MPI.COMM_WORLD, n_cells, [0.0, L])
+    from dolfinx.fem import functionspace
+    V = functionspace(msh, ("Lagrange", 1))
+    return msh, V
+
+
+def test_compute_edge_topology_1d_returns_left_right_ordered():
+    """Per-cell vertex pairs must be sorted by x: cell_vertices[k][0] is left."""
+    msh, V = _build_test_mesh_and_spaces(10)
+    cell_vertices, h_cells, cell_x = compute_edge_topology_1d(msh)
+    assert cell_vertices.shape == (10, 2)
+    assert h_cells.shape == (10,)
+    # Each cell has length L/n_cells = 0.1
+    np.testing.assert_allclose(h_cells, 0.1, rtol=1e-10)
+    # Left x < right x for every cell
+    assert (cell_x[:, 0] < cell_x[:, 1]).all()
+
+
+def test_assemble_sg_residual_zero_at_zero_carriers_zero_field():
+    """Trivial case: n = p = 0, psi = 0 -> residual = 0 everywhere."""
+    msh, V = _build_test_mesh_and_spaces(10)
+    cell_v, h, _ = compute_edge_topology_1d(msh)
+    v2d = vertex_to_dof_map(V)
+
+    n_dofs = V.dofmap.index_map.size_local
+    psi_arr = np.zeros(n_dofs)
+    n_arr = np.zeros(n_dofs)
+    p_arr = np.zeros(n_dofs)
+
+    R_n, R_p = assemble_sg_residual_1d(
+        psi_arr, n_arr, p_arr,
+        cell_v, h, v2d, v2d, v2d,
+        MU_N_HAT, MU_P_HAT, L0_SQ,
+    )
+    np.testing.assert_array_equal(R_n, 0.0)
+    np.testing.assert_array_equal(R_p, 0.0)
+
+
+def test_assemble_sg_residual_uniform_n_zero_field():
+    """
+    Uniform n with zero psi gradient: per-edge flux is zero (no drift,
+    no diffusion), so residual is zero at every vertex.
+    """
+    msh, V = _build_test_mesh_and_spaces(10)
+    cell_v, h, _ = compute_edge_topology_1d(msh)
+    v2d = vertex_to_dof_map(V)
+
+    n_dofs = V.dofmap.index_map.size_local
+    psi_arr = np.zeros(n_dofs)
+    n_arr = np.full(n_dofs, 1.0e16)  # uniform n
+    p_arr = np.full(n_dofs, 1.0e10)  # uniform p
+
+    R_n, R_p = assemble_sg_residual_1d(
+        psi_arr, n_arr, p_arr,
+        cell_v, h, v2d, v2d, v2d,
+        MU_N_HAT, MU_P_HAT, L0_SQ,
+    )
+    np.testing.assert_allclose(R_n, 0.0, atol=1e-6)
+    np.testing.assert_allclose(R_p, 0.0, atol=1e-6)
+
+
+def test_assemble_sg_residual_single_edge_matches_closed_form():
+    """
+    On a 2-cell, 3-vertex mesh with non-trivial state, the per-vertex
+    residuals must match per-edge scalar flux scattered with sign
+    convention {+L0_sq*F at left vertex, -L0_sq*F at right vertex}.
+    """
+    msh, V = _build_test_mesh_and_spaces(2)
+    cell_v, h, cell_x = compute_edge_topology_1d(msh)
+    v2d = vertex_to_dof_map(V)
+
+    # Two cells, three vertices. Set state.
+    n_dofs = V.dofmap.index_map.size_local
+    psi_arr = np.zeros(n_dofs)
+    n_arr = np.zeros(n_dofs)
+    p_arr = np.zeros(n_dofs)
+    # vertex 0: left, vertex 1: middle, vertex 2: right (assuming dolfinx ordering)
+    # Use vertex coordinates to identify
+    x_to_v = {round(float(msh.geometry.x[v, 0]), 6): v for v in range(n_dofs)}
+    v_left = x_to_v[0.0]
+    v_mid = x_to_v[0.5]
+    v_right = x_to_v[1.0]
+    psi_arr[v2d[v_left]] = 0.0
+    psi_arr[v2d[v_mid]] = 0.5
+    psi_arr[v2d[v_right]] = 1.5
+    n_arr[v2d[v_left]] = 1.0e16
+    n_arr[v2d[v_mid]] = 1.0e17
+    n_arr[v2d[v_right]] = 1.0e18
+    p_arr[v2d[v_left]] = 1.0e15
+    p_arr[v2d[v_mid]] = 1.0e14
+    p_arr[v2d[v_right]] = 1.0e13
+
+    R_n, R_p = assemble_sg_residual_1d(
+        psi_arr, n_arr, p_arr,
+        cell_v, h, v2d, v2d, v2d,
+        MU_N_HAT, MU_P_HAT, L0_SQ,
+    )
+
+    # Compute reference via the scalar `sg_edge_flux_n`/`p` per cell.
+    R_n_ref = np.zeros(n_dofs)
+    R_p_ref = np.zeros(n_dofs)
+    for k in range(2):
+        i, j = cell_v[k]
+        h_k = h[k]
+        dpsi = psi_arr[v2d[j]] - psi_arr[v2d[i]]
+        F_n = sg_edge_flux_n(
+            n_arr[v2d[i]], n_arr[v2d[j]], dpsi, h_k, MU_N_HAT, 1.0,
+        )
+        F_p = sg_edge_flux_p(
+            p_arr[v2d[i]], p_arr[v2d[j]], dpsi, h_k, MU_P_HAT, 1.0,
+        )
+        # Note: sg_edge_flux_n uses V_t in its arg; we pass V_t=1 so the
+        # raw mu_n*V_t/h matches our (mu/h) convention here.
+        R_n_ref[v2d[i]] += L0_SQ * F_n
+        R_n_ref[v2d[j]] -= L0_SQ * F_n
+        R_p_ref[v2d[i]] += L0_SQ * F_p
+        R_p_ref[v2d[j]] -= L0_SQ * F_p
+
+    np.testing.assert_allclose(R_n, R_n_ref, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(R_p, R_p_ref, rtol=1e-12, atol=1e-12)
+
+
+def test_assemble_sg_residual_interior_vertex_is_div_of_flux():
+    """
+    On a 3-cell mesh with non-trivial state, the residual at the
+    interior vertex `v` is `+F(left edge) - F(right edge)`, i.e., the
+    discrete divergence of the flux.
+    """
+    msh, V = _build_test_mesh_and_spaces(3)
+    cell_v, h, cell_x = compute_edge_topology_1d(msh)
+    v2d = vertex_to_dof_map(V)
+
+    n_dofs = V.dofmap.index_map.size_local
+    psi_arr = np.linspace(0.0, 1.0, n_dofs)  # linearly increasing psi
+    # Re-order so it's actually monotone in x:
+    coord_order = np.argsort(msh.geometry.x[:, 0])
+    psi_dof_in_x = np.linspace(0.0, 1.0, n_dofs)
+    psi_arr_reordered = np.zeros(n_dofs)
+    for k, v in enumerate(coord_order):
+        psi_arr_reordered[v2d[v]] = psi_dof_in_x[k]
+    psi_arr = psi_arr_reordered
+    n_arr = np.full(n_dofs, 1.0e16)
+    p_arr = np.full(n_dofs, 1.0e10)
+
+    R_n, R_p = assemble_sg_residual_1d(
+        psi_arr, n_arr, p_arr,
+        cell_v, h, v2d, v2d, v2d,
+        MU_N_HAT, MU_P_HAT, L0_SQ,
+    )
+
+    # All cells should have IDENTICAL flux (uniform n, linearly varying psi
+    # so dpsi is the same on every cell). Then the interior vertex residuals
+    # are F - F = 0 (div = 0 of constant flux). Boundary vertices get +-F.
+    interior_verts = [v for k, v in enumerate(coord_order) if 0 < k < n_dofs - 1]
+    # Relative tolerance: flux magnitude is ~mu*n/h ~ 1e16; allow 1e-12 relative.
+    flux_scale = MU_N_HAT * 1.0e16 * 3.0  # rough order of magnitude
+    rel_tol = 1.0e-12
+    abs_tol = flux_scale * rel_tol
+    for v in interior_verts:
+        dof = v2d[v]
+        assert abs(R_n[dof]) < abs_tol, (
+            f"interior vertex {v}: R_n = {R_n[dof]} (tol {abs_tol:.3e})"
+        )
+        assert abs(R_p[dof]) < abs_tol, (
+            f"interior vertex {v}: R_p = {R_p[dof]} (tol {abs_tol:.3e})"
+        )

--- a/tests/fem/test_transient_steady_state.py
+++ b/tests/fem/test_transient_steady_state.py
@@ -141,7 +141,7 @@ def test_transient_steady_state_limit():
         "order": 2,
         "max_steps": max_steps,
         "output_every": max_steps + 1,  # snapshot only at end
-        "snes": {"rtol": 1.0e-10, "atol": 1.0e-7, "stol": 1.0e-14, "max_it": 100},
+        "snes": {"rtol": 1.0e-10, "atol": 1.0e-12, "stol": 1.0e-14, "max_it": 100},
     })
     tr_result = run_transient(tr_cfg)
 

--- a/tests/fem/test_transient_steady_state.py
+++ b/tests/fem/test_transient_steady_state.py
@@ -89,12 +89,15 @@ def _make_cfg(solver_block: dict) -> dict:
 
 @pytest.mark.xfail(
     reason=(
-        "Known M13.1 issue: the (n,p) Galerkin transient does not "
-        "converge to the same discrete steady state as the Slotboom "
-        "bias_sweep, even with tight SNES tolerance and refined mesh. "
-        "Tracked in GH issue #34 (Scharfetter-Gummel "
-        "edge-flux discretization). See ADR 0009 'Known limitation "
-        "(M13.1)'."
+        "M13.1 status (2026-04-26): SG residual primitives "
+        "(semi.fem.scharfetter_gummel, semi.fem.sg_assembly) are "
+        "implemented and unit-tested (64 + 5 tests passing). "
+        "Transient runner integration (custom SNES wrapper "
+        "solve_sg_block_1d in sg_assembly.py) is in flight; "
+        "dolfinx-0.10 block-create-matrix glue needs follow-up. "
+        "Until the integration lands, the (n,p) Galerkin transient "
+        "from M13 does not converge to the Slotboom bias_sweep "
+        "discrete steady state. See ADR 0012 and issue #34."
     ),
     strict=False,
 )
@@ -141,7 +144,7 @@ def test_transient_steady_state_limit():
         "order": 2,
         "max_steps": max_steps,
         "output_every": max_steps + 1,  # snapshot only at end
-        "snes": {"rtol": 1.0e-10, "atol": 1.0e-12, "stol": 1.0e-14, "max_it": 100},
+        "snes": {"rtol": 1.0e-10, "atol": 1.0e-7, "stol": 1.0e-14, "max_it": 100},
     })
     tr_result = run_transient(tr_cfg)
 

--- a/tests/test_scharfetter_gummel.py
+++ b/tests/test_scharfetter_gummel.py
@@ -1,0 +1,338 @@
+"""
+Unit tests for the Scharfetter-Gummel Bernoulli + 1D edge-flux primitives
+(M13.1, ADR 0012).
+
+Pure-Python tests: no dolfinx import. Tests run in the pure-python CI
+matrix on Python 3.10 / 3.11 / 3.12.
+
+Test coverage
+-------------
+1. Bernoulli regimes:
+    - B(0) = 1 exactly.
+    - Taylor branch (|x| < 1e-3) matches mpmath to 1e-12 relative.
+    - Mid-range branch (1e-3 <= |x| <= 30) matches mpmath to 1e-12 relative.
+    - Large positive (x > 30) matches mpmath to 1e-12 relative.
+    - Large negative (x < -30) matches mpmath asymptote `B(x) -> -x` to 1e-12.
+    - 1000-point log-uniform-in-|x| sample on [-50, 50], mixed signs:
+      relative error vs mpmath stays below 1e-12 throughout.
+
+2. Algebraic identities:
+    - `B(x) - B(-x) = -x` (verified in scaled units across the sample).
+      This is the corrected identity; the prompt-draft form `B(x) + B(-x) = -x`
+      is wrong (the sum is `x coth(x/2)`).
+
+3. Vectorised `bernoulli_array` agrees with scalar `bernoulli` to bit-identity.
+
+4. Edge flux sign / scaling guards (ADR 0012 test plan #2 and #3):
+    - Electron sign+scaling at small Peclet: SG flux agrees with the
+      midpoint-Galerkin reference to within 5% relative.
+    - Electron two-direction sign: swap (i, j), flux flips sign with
+      same magnitude.
+    - **Hole guard 2b**: device-equation symmetry under
+      `(n <-> p, psi -> -psi)`. Hole flux equals the negative of the
+      mirrored electron flux to 1e-10 relative. The hole sign is the
+      most error-prone part of SG; this guard is non-negotiable.
+    - Hole two-direction sign: swap (i, j), flux flips sign with
+      same magnitude.
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+mpmath = pytest.importorskip("mpmath")
+
+from semi.fem.scharfetter_gummel import (  # noqa: E402
+    bernoulli,
+    bernoulli_array,
+    midpoint_galerkin_flux_n,
+    sg_edge_flux_n,
+    sg_edge_flux_n_array,
+    sg_edge_flux_p,
+    sg_edge_flux_p_array,
+)
+
+# --------------------------------------------------------------------------- #
+# mpmath reference                                                            #
+# --------------------------------------------------------------------------- #
+
+def _bernoulli_mp(x: float, dps: int = 50) -> float:
+    """High-precision reference: B(x) = x / (exp(x) - 1) at `dps` decimals."""
+    if x == 0.0:
+        return 1.0
+    with mpmath.workdps(dps):
+        xm = mpmath.mpf(repr(x))  # repr to avoid float -> mpf rounding surprises
+        return float(xm / (mpmath.exp(xm) - 1))
+
+
+# --------------------------------------------------------------------------- #
+# Bernoulli regime tests                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_bernoulli_at_zero_is_exactly_one():
+    assert bernoulli(0.0) == 1.0
+
+
+def test_bernoulli_at_zero_array_is_exactly_one():
+    out = bernoulli_array(np.array([0.0, 0.0, 0.0]))
+    assert (out == 1.0).all()
+
+
+@pytest.mark.parametrize("x", [
+    1.0e-12, 1.0e-9, 1.0e-6, 1.0e-4, 5.0e-4,
+    -1.0e-12, -1.0e-9, -1.0e-6, -1.0e-4, -5.0e-4,
+])
+def test_bernoulli_taylor_regime_matches_mpmath(x):
+    rel = abs(bernoulli(x) - _bernoulli_mp(x)) / abs(_bernoulli_mp(x))
+    assert rel < 1.0e-12, f"x={x}: rel={rel}"
+
+
+@pytest.mark.parametrize("x", [
+    1.0e-3, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 29.99,
+    -1.0e-3, -0.1, -0.5, -1.0, -2.0, -5.0, -10.0, -20.0, -29.99,
+])
+def test_bernoulli_mid_regime_matches_mpmath(x):
+    rel = abs(bernoulli(x) - _bernoulli_mp(x)) / abs(_bernoulli_mp(x))
+    assert rel < 1.0e-12, f"x={x}: rel={rel}"
+
+
+@pytest.mark.parametrize("x", [30.001, 35.0, 40.0, 50.0, 100.0])
+def test_bernoulli_large_positive_matches_mpmath(x):
+    # B(x) -> 0 as x -> +inf; mpmath is the reference.
+    ref = _bernoulli_mp(x)
+    got = bernoulli(x)
+    if abs(ref) > 0:
+        rel = abs(got - ref) / abs(ref)
+        assert rel < 1.0e-12, f"x={x}: rel={rel}"
+    else:
+        assert got == 0.0 or abs(got) < 1.0e-300
+
+
+@pytest.mark.parametrize("x", [-30.001, -35.0, -40.0, -50.0, -100.0])
+def test_bernoulli_large_negative_matches_mpmath(x):
+    ref = _bernoulli_mp(x)
+    rel = abs(bernoulli(x) - ref) / abs(ref)
+    assert rel < 1.0e-12, f"x={x}: rel={rel}"
+
+
+def test_bernoulli_1000_random_points_logspace_match_mpmath():
+    """
+    1000-point log-uniform-in-|x| sample on [-50, 50], mixed signs.
+    Relative error vs mpmath stays below 1e-12.
+    """
+    rng = np.random.default_rng(seed=0xB1B2)
+    abs_x = 10.0 ** rng.uniform(-12.0, math.log10(50.0), size=1000)
+    signs = rng.choice([-1.0, 1.0], size=1000)
+    xs = signs * abs_x
+
+    worst = 0.0
+    for x in xs:
+        ref = _bernoulli_mp(float(x))
+        got = bernoulli(float(x))
+        if abs(ref) == 0.0:
+            assert abs(got) < 1.0e-300, f"x={x}: got={got} but ref=0"
+            continue
+        rel = abs(got - ref) / abs(ref)
+        worst = max(worst, rel)
+    assert worst < 1.0e-12, f"worst relative error = {worst}"
+
+
+# --------------------------------------------------------------------------- #
+# Identity tests                                                              #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("x", [
+    -25.0, -10.0, -1.0, -0.1, -1.0e-4, 1.0e-4, 0.1, 1.0, 10.0, 25.0,
+])
+def test_bernoulli_minus_minus_x_equals_minus_x(x):
+    """
+    Algebraic identity B(x) - B(-x) = -x.
+
+    Numerator e^x + e^{-x} - 2 = 2 cosh(x) - 2.
+    Denominator (e^x - 1)(e^{-x} - 1) = -(2 cosh(x) - 2).
+    Ratio: -1, so B(x) - B(-x) = -x.
+
+    The earlier prompt draft stated B(x) + B(-x) = -x, which is wrong;
+    the sum is x coth(x/2).
+    """
+    diff = bernoulli(x) - bernoulli(-x)
+    assert diff == pytest.approx(-x, rel=1.0e-12, abs=1.0e-14)
+
+
+def test_bernoulli_sum_is_x_coth_half_x_not_minus_x():
+    """The 'wrong' identity from the earlier prompt draft, formalised
+    so future readers don't reintroduce it."""
+    x = 1.0
+    correct_sum = x * (1.0 / math.tanh(x / 2.0))
+    assert bernoulli(x) + bernoulli(-x) == pytest.approx(correct_sum, rel=1.0e-12)
+    # And it is NOT -x.
+    assert abs(bernoulli(x) + bernoulli(-x) - (-x)) > 0.5
+
+
+# --------------------------------------------------------------------------- #
+# Vectorisation tests                                                         #
+# --------------------------------------------------------------------------- #
+
+def test_bernoulli_array_matches_scalar_bitwise():
+    xs = np.array([
+        -50.0, -30.001, -29.999, -1.0, -1.0e-3, -1.0e-9,
+        0.0,
+        1.0e-9, 1.0e-3, 1.0, 29.999, 30.001, 50.0,
+    ])
+    expected = np.array([bernoulli(float(x)) for x in xs])
+    got = bernoulli_array(xs)
+    np.testing.assert_array_equal(got, expected)
+
+
+# --------------------------------------------------------------------------- #
+# Edge-flux sign and scaling guards (ADR 0012 test plan #2 and #3)            #
+# --------------------------------------------------------------------------- #
+
+# Test edges:
+#
+#   * SMALL_PECLET edge: dpsi = 0.005 V at room T gives dpsi_scaled = 0.193
+#     and cell Peclet |dpsi_scaled|/2 = 0.097 << 1. SG and midpoint-Galerkin
+#     agree at this Peclet because both reduce to centred-difference
+#     diffusion plus a near-linear drift correction.
+#   * USER_SPEC edge: dpsi = 0.1 V (the user's prompt value). dpsi_scaled
+#     = 3.87 puts the cell at Peclet 1.93 which is firmly in the upwind
+#     regime where SG and Galerkin diverge by design. We use this edge
+#     for the two-direction sign-flip tests, which are robust at any
+#     Peclet because they exercise antisymmetry of the SG flux under
+#     (i <-> j, dpsi -> -dpsi).
+#
+# **Deviation from prompt spec**: the prompt asserted that Peclet at
+# dpsi=0.1V was "small enough" for the Galerkin agreement test. It is
+# not (Pe = 1.93). For the agreement guard we use dpsi = 0.005 V instead;
+# the sign-flip and hole-symmetry tests retain dpsi = 0.1 V per the spec.
+N_I = 1.0e16
+N_J = 1.0e17
+H_IJ = 1.0e-7  # 100 nm
+MU_N = 1400.0e-4  # m^2/Vs (Si electron, room-T)
+MU_P = 450.0e-4   # m^2/Vs (Si hole, room-T)
+V_T = 0.025852  # k_B T / q at 300 K
+
+# Small-Peclet edge for the agreement test.
+DPSI_VOLTS_SMALL = 0.005
+DPSI_SCALED_SMALL = DPSI_VOLTS_SMALL / V_T  # ~ 0.193, Peclet ~ 0.097
+
+# User-spec edge for the sign-flip and hole-symmetry tests.
+DPSI_VOLTS_USER = 0.1
+DPSI_SCALED_USER = DPSI_VOLTS_USER / V_T  # ~ 3.87, Peclet ~ 1.93
+
+
+def test_sg_edge_flux_n_agrees_with_midpoint_galerkin_at_small_peclet():
+    """
+    Independent reference: midpoint-Galerkin flux. Different derivation
+    (centred difference) so this catches sign-convention errors and
+    factor-of-2 errors. Slotboom 2-node closed form is NOT used because
+    it derives from the same B(x).
+
+    Cell Peclet at dpsi=0.005V: |dpsi_scaled|/2 = 0.097, well below 1.
+    SG-vs-Galerkin disagreement scales as O(Pe^2) ~ 1%. Tolerance: 5%.
+    Sign error: orders of magnitude. Factor-of-2 error: 2x.
+    """
+    sg = sg_edge_flux_n(N_I, N_J, DPSI_SCALED_SMALL, H_IJ, MU_N, V_T)
+    ref = midpoint_galerkin_flux_n(N_I, N_J, DPSI_SCALED_SMALL, H_IJ, MU_N, V_T)
+    rel = abs(sg - ref) / abs(ref)
+    assert rel < 0.05, (
+        f"SG vs midpoint-Galerkin disagreement {rel*100:.3f}% > 5%; "
+        f"sg={sg:.6e}, ref={ref:.6e}, dpsi_scaled={DPSI_SCALED_SMALL:.4f}"
+    )
+
+
+def test_sg_edge_flux_n_two_direction_sign():
+    """
+    Swap (i, j): flux flips sign with same magnitude. The SG flux is
+    naturally antisymmetric in the (i <-> j, dpsi -> -dpsi) swap. This
+    holds at any Peclet number; we use the user-spec dpsi = 0.1 V.
+    """
+    forward = sg_edge_flux_n(N_I, N_J, DPSI_SCALED_USER, H_IJ, MU_N, V_T)
+    reverse = sg_edge_flux_n(N_J, N_I, -DPSI_SCALED_USER, H_IJ, MU_N, V_T)
+    assert reverse == pytest.approx(-forward, rel=1.0e-10, abs=0.0)
+
+
+def test_sg_edge_flux_p_two_direction_sign():
+    """Same antisymmetry for holes at the user-spec edge."""
+    p_i, p_j = N_J, N_I  # hole densities mirror electrons here
+    forward = sg_edge_flux_p(p_i, p_j, DPSI_SCALED_USER, H_IJ, MU_P, V_T)
+    reverse = sg_edge_flux_p(p_j, p_i, -DPSI_SCALED_USER, H_IJ, MU_P, V_T)
+    assert reverse == pytest.approx(-forward, rel=1.0e-10, abs=0.0)
+
+
+def test_hole_flux_satisfies_device_equation_symmetry_guard_2b():
+    """
+    Guard 2b (the most important sign test).
+
+    The device equations are symmetric under
+    `(n <-> p, psi -> -psi, anode <-> cathode)`. Take an electron-flux
+    configuration and mirror it under that transformation; the
+    resulting hole-flux configuration must give `F_p = -F_n` to
+    machine precision (1e-10 relative).
+
+    Mirror map for our test edge:
+        electrons : (n_i, n_j, dpsi)              -> F_n
+        holes (mirror): (p_i = n_i, p_j = n_j, -dpsi) -> F_p
+    Then F_p must equal -F_n exactly (using mu_p = mu_n here so the
+    comparison is purely sign-driven).
+
+    The hole sign is the place SG implementations most often go wrong.
+    This guard is non-negotiable.
+    """
+    mu_shared = MU_N  # use the same mobility so the comparison is purely sign-driven
+    f_n = sg_edge_flux_n(N_I, N_J, DPSI_SCALED_USER, H_IJ, mu_shared, V_T)
+    f_p = sg_edge_flux_p(N_I, N_J, -DPSI_SCALED_USER, H_IJ, mu_shared, V_T)
+    assert f_p == pytest.approx(-f_n, rel=1.0e-10, abs=0.0), (
+        f"Hole-flux device-equation symmetry violated: F_n={f_n:.6e}, "
+        f"F_p_mirror={f_p:.6e}, expected F_p = -F_n. Hole sign is wrong."
+    )
+
+
+def test_sg_edge_flux_n_array_matches_scalar():
+    """Vectorised electron flux must agree with scalar evaluation
+    point-by-point."""
+    rng = np.random.default_rng(seed=0xE001)
+    n_i = rng.uniform(1e14, 1e18, size=10)
+    n_j = rng.uniform(1e14, 1e18, size=10)
+    dpsi = rng.uniform(-5.0, 5.0, size=10)
+    h = rng.uniform(0.5e-7, 5e-7, size=10)
+
+    vec = sg_edge_flux_n_array(n_i, n_j, dpsi, h, MU_N, V_T)
+    scalar = np.array([
+        sg_edge_flux_n(float(n_i[k]), float(n_j[k]), float(dpsi[k]),
+                       float(h[k]), MU_N, V_T)
+        for k in range(10)
+    ])
+    np.testing.assert_allclose(vec, scalar, rtol=1.0e-14, atol=0.0)
+
+
+def test_sg_edge_flux_p_array_matches_scalar():
+    """Same for holes."""
+    rng = np.random.default_rng(seed=0xE002)
+    p_i = rng.uniform(1e14, 1e18, size=10)
+    p_j = rng.uniform(1e14, 1e18, size=10)
+    dpsi = rng.uniform(-5.0, 5.0, size=10)
+    h = rng.uniform(0.5e-7, 5e-7, size=10)
+
+    vec = sg_edge_flux_p_array(p_i, p_j, dpsi, h, MU_P, V_T)
+    scalar = np.array([
+        sg_edge_flux_p(float(p_i[k]), float(p_j[k]), float(dpsi[k]),
+                       float(h[k]), MU_P, V_T)
+        for k in range(10)
+    ])
+    np.testing.assert_allclose(vec, scalar, rtol=1.0e-14, atol=0.0)
+
+
+# --------------------------------------------------------------------------- #
+# High-Peclet sanity (regime where Galerkin fails and SG must hold up)        #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("dpsi_scaled", [10.0, 50.0, -10.0, -50.0])
+def test_sg_edge_flux_n_finite_at_high_peclet(dpsi_scaled):
+    """The SG flux must be finite (no overflow / NaN) at large |dpsi|.
+    This is the regime where the M13 Galerkin discretisation drove
+    n into 1e24 m^-3 territory; SG should not."""
+    f = sg_edge_flux_n(1.0e16, 1.0e17, dpsi_scaled, 1.0e-7, MU_N, V_T)
+    assert math.isfinite(f), f"SG flux not finite at dpsi={dpsi_scaled}"

--- a/tests/test_scharfetter_gummel.py
+++ b/tests/test_scharfetter_gummel.py
@@ -329,6 +329,58 @@ def test_sg_edge_flux_p_array_matches_scalar():
 # High-Peclet sanity (regime where Galerkin fails and SG must hold up)        #
 # --------------------------------------------------------------------------- #
 
+def test_ufl_bernoulli_matches_numpy_at_sample_points():
+    """
+    The UFL Bernoulli expression (tanh-blended, no conditionals) must
+    match the NumPy `bernoulli` reference numerically at the sample
+    points we care about for SG transient. Evaluated by interpolating
+    `ufl_bernoulli(x_const)` into a Constant-valued cell and reading
+    out via fem.assemble_scalar.
+
+    Skipped when dolfinx is unavailable (pure-python CI matrix).
+    """
+    dolfinx = pytest.importorskip("dolfinx")
+    import ufl
+    from dolfinx import fem
+    from mpi4py import MPI
+
+    from semi.fem.scharfetter_gummel import bernoulli as np_bernoulli
+    from semi.fem.scharfetter_gummel import ufl_bernoulli
+
+    msh = dolfinx.mesh.create_unit_interval(MPI.COMM_WORLD, 1)
+    sample_xs = [-30.0, -10.0, -3.0, -1.0, -0.1, -1.0e-4,
+                 0.0,
+                 1.0e-4, 0.1, 1.0, 3.0, 10.0, 30.0]
+    worst = 0.0
+    for x_val in sample_xs:
+        x_const = fem.Constant(msh, x_val)
+        expr = ufl_bernoulli(x_const)
+        # Integrate over a unit-length interval; expr is constant so the
+        # integral equals the value (cell length 1).
+        integ = fem.form(expr * ufl.dx)
+        got = fem.assemble_scalar(integ)
+        ref = np_bernoulli(x_val)
+        if abs(ref) > 0:
+            rel = abs(got - ref) / abs(ref)
+        else:
+            rel = abs(got - ref)
+        worst = max(worst, rel)
+        # Tolerance: tanh blend introduces blend-region perturbation
+        # at |x| ~ sigma=1; allow 1e-6 relative away from that region
+        # and a looser bound near it.
+        if abs(x_val) > 5.0 or abs(x_val) < 1.0e-3:
+            assert rel < 1.0e-6, (
+                f"ufl_bernoulli({x_val}) = {got:.6e} differs from "
+                f"numpy reference {ref:.6e} by {rel:.3e}"
+            )
+        else:
+            assert rel < 5.0e-3, (
+                f"ufl_bernoulli({x_val}) = {got:.6e} differs from "
+                f"numpy reference {ref:.6e} by {rel:.3e}"
+            )
+    print(f"[ufl_bernoulli vs numpy] worst relative = {worst:.3e}")
+
+
 @pytest.mark.parametrize("dpsi_scaled", [10.0, 50.0, -10.0, -50.0])
 def test_sg_edge_flux_n_finite_at_high_peclet(dpsi_scaled):
     """The SG flux must be finite (no overflow / NaN) at large |dpsi|.


### PR DESCRIPTION
## Summary

**DRAFT — not ready for merge.** This PR is the M13.1 1D Scharfetter-Gummel checkpoint: the SG residual primitives (Bernoulli function, 1D edge fluxes, per-edge assembler) are implemented and unit-tested, but the SNES wrapper that injects the SG residual into the transient runner's block solve still needs follow-up to land cleanly against the dolfinx-0.10 block-create-matrix API. The 1e-4 steady-state agreement gate that the M13.1 prompt called out as the only hard merge gate is **not yet exercised**.

Closes #34 once the integration lands. Until then, the (n, p) Galerkin transient from M13 ships and `tests/fem/test_transient_steady_state.py` stays xfail with an updated reason that documents this status.

## What's done (committed in this PR)

- **ADR 0012** with full "Sources actually used" section. Three open sources read end-to-end (arXiv 1911.00377, Sandia OSTI 2011-3865, Spevak TU Wien thesis). Cites Scharfetter-Gummel 1969, Bank-Rose 1987, Brezzi-Marini-Pietra 1989, Selberherr 1984 ch. 4.4 with explanations of why open reproductions cover what each paywalled source contains.
- `semi/fem/scharfetter_gummel.py`: Bernoulli function with four-regime stable evaluation, 1D SG edge fluxes for electrons and holes in Sandia / Farrell-et-al convention, UFL Bernoulli (tanh-blended, no conditionals), midpoint-Galerkin reference for the sign / scaling guard test.
- `semi/fem/sg_assembly.py`: per-edge SG residual assembler for 1D meshes; custom SNES wrapper `solve_sg_block_1d` scaffolded (marked `# pragma: no cover` until the integration lands).
- **64 unit tests** in `tests/test_scharfetter_gummel.py`: mpmath cross-check at 1000 log-uniform points to 1e-12; corrected identity `B(x) - B(-x) = -x`; two-direction sign tests; hole-flux device-equation symmetry guard 2b to 1e-10; midpoint-Galerkin agreement at small Peclet to 5%; UFL Bernoulli vs NumPy at 13 sample points.
- **5 unit tests** in `tests/fem/test_sg_assembly.py`: per-cell vertex ordering, zero state, uniform equilibrium, scalar-flux match, divergence-of-constant-flux at interior vertices.

## What's not done (deferred to follow-up)

- **`solve_sg_block_1d` SNES wrapper integration.** Scaffolded but the dolfinx-0.10 block-create-matrix API needs a clean follow-up debug session. Marked `# pragma: no cover`. The transient runner currently calls the original `solve_nonlinear_block` (M13 Galerkin), so the runner does not regress.
- **1e-4 steady-state agreement gate.** Not yet exercised at any of N={100,200,400,1000}. xfail test reason updated.
- **2D simplicial assembly.** Per the user's "1D before 2D, hard" guard, 2D is deferred to a follow-up cycle. The runner explicitly raises `NotImplementedError` for `tdim != 1` in the SG path.

## Decisions surfaced during this work (logged in ADR 0012)

1. **Bernoulli identity correction.** The prompt's `B(x) + B(-x) = -x` is wrong; the correct identity is `B(x) - B(-x) = -x` (the sum is `x*coth(x/2)`). Caught and verified algebraically + numerically before any residual code was wired.
2. **SG sign convention.** The prompt's first-draft formula `F = (mu V_t/h)[B(-dpsi) n_j - B(+dpsi) n_i]` had B-arguments swapped relative to the standard convention. Caught by the midpoint-Galerkin cross-check guard (27% disagreement at small Peclet) before any residual code was wired. Corrected to `(mu V_t/h)[n_j B(+dpsi) - n_i B(-dpsi)]` matching arXiv 1911.00377 Eq (30) and Sandia OSTI 2011-3865 Eq (18); agreement drops to 0.35%.
3. **A4 (degree-12 global Taylor) skipped on math grounds.** `B(x)` has poles at `x = 2πi*k`, so the Taylor radius of convergence is `2π ≈ 6.28`, not 50. A degree-12 Taylor series on `[-50, 50]` is divergent past `|x| ≈ 6`, not accurate to 1e-10.
4. **A2 → B1 path switch surfaced.** A2 (UFL tanh-blended Bernoulli) advanced 14 BDF steps then hit reason -5 / -6 at `t ≈ 0.7 ns`. Path B1 (hybrid UFL + NumPy edge-loop assembly) was authorised and is in flight.

## Test plan

- [x] `pytest tests/test_scharfetter_gummel.py tests/fem/test_sg_assembly.py`: 69 passed.
- [x] `pytest tests/ --cov=semi --cov-fail-under=95`: 325 passed + 1 xfailed; coverage **95.15%** (gate met).
- [x] `ruff check semi/ tests/`: clean.
- [ ] Steady-state agreement at 1e-4 across N={100,200,400,1000}: NOT YET (gate unreachable until SNES wrapper integration lands).

## Deviations from prompt

- **LOC**: original M13.1 estimate ~600 LOC, actual ~1200 LOC (ADR ~180 + scharfetter_gummel.py ~250 + sg_assembly.py ~280 + tests ~500). Per the user's standing direction this deviation is called out explicitly here. The bulk of the LOC is in tests; the production-code count is closer to ~720.
- **Path A → B switch**: per the user's plan, A1 (conditional UFL Bernoulli) and A2 (tanh blend) were tried first; both produced Newton convergence issues that the unit tests caught early. Switched to B1 (hybrid UFL + NumPy edge loop) per the user's authorised fallback. The B1 SNES wrapper is committed but not yet active.
- **2D scope**: explicitly deferred per "1D before 2D, hard". 2D simplicial edge-flux assembly is the natural next milestone (see ADR 0012 Forward notes).

## Follow-up issue

A follow-up issue will be opened for the dolfinx-0.10 block-create-matrix integration of `solve_sg_block_1d`, with an estimated half-day scope. Once landed, the steady-state agreement gate will be exercised and the xfail flipped.