### PR TITLE
docs: post-M15 roadmap refresh (Phase 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,50 @@ shipped with the M15 GPU linear-solver work in v0.15.0 below.
 
 ## [Unreleased]
 
+### Documentation
+
+- **Post-M15 roadmap refresh.** PLAN, IMPROVEMENT_GUIDE, and ROADMAP
+  rewritten to encode the post-M15 priorities derived from an
+  external code review. Each Tier 1 physics model in the M16
+  umbrella (Caughey-Thomas, Lombardi, Auger, Fermi-Dirac, Schottky,
+  BBT and TAT) now has an explicit acceptance test with a numerical
+  threshold or analytical reference. New milestones added:
+  - **M14.3 Housekeeping** (between M14.2 and M15): re-render the
+    GitHub README, tighten the `mosfet_2d` verifier with a Pao-Sah
+    analytical reference, implement XDMF mesh ingest, strict-mode
+    the input schema with an `additionalProperties: false` major
+    bump, and remove the dead-on-active-path Scharfetter-Gummel
+    primitives in `semi/fem/sg_assembly.py`.
+  - **M16.1 through M16.7** (physics completeness, one PR each):
+    Caughey-Thomas mobility, Lombardi surface mobility, Auger
+    recombination, Fermi-Dirac statistics (gated), Schottky
+    contacts, BBT and TAT tunneling, time-varying transient
+    contact voltage.
+  - **M19 3D MOSFET capstone**: Pao-Sah-with-velocity-saturation
+    analytical reference within 25% on linear-regime I_D, run on
+    both CPU-MUMPS and GPU-AMGX backends to demonstrate M15
+    acceptance on a real device.
+  - **M19.1 MPI parallel benchmark**: collective-communication
+    audit of the runners, `mosfet_3d` under `mpiexec -n {1, 2, 4}`.
+  - **M20 HTTP server hardening**: API-key middleware, per-key rate
+    limiting, admin endpoint to issue and revoke keys.
+- Added per-milestone starter prompts for the next two PRs:
+  [`docs/M14_3_STARTER_PROMPT.md`](docs/M14_3_STARTER_PROMPT.md)
+  and [`docs/M16_1_STARTER_PROMPT.md`](docs/M16_1_STARTER_PROMPT.md).
+  The shape mirrors `docs/M9_STARTER_PROMPT.md` and
+  `docs/M15_STARTER_PROMPT.md`.
+- Added an "Honest gap" section to
+  [`docs/ROADMAP.md`](docs/ROADMAP.md) calling out the three
+  remaining weaknesses a reviewer should hit first: thin 3D
+  semiconductor coverage, Boltzmann-only carrier statistics, and
+  no contact / tunneling physics.
+- Moved the M14.2.x cartesian-2D MOSCAP and rigorous gate-driven
+  HF C-V backlog into [`docs/ROADMAP.md`](docs/ROADMAP.md)
+  § Deferred with a note that they are superseded for practical
+  purposes by M16.4 (Fermi-Dirac) and M19 (3D MOSFET).
+- No engine code changed; coverage gate untouched; no version bump
+  (the next bump ships with M14.3).
+
 ### Added
 - Axisymmetric (cylindrical) coordinate system support (**schema 1.3.0**).
   New top-level `coordinate_system` field accepts `"cartesian"`

--- a/PLAN.md
+++ b/PLAN.md
@@ -50,6 +50,21 @@ matches bias_sweep at deep steady state. SG flux primitives ship in
 `test_transient_steady_state_limit` and BDF rate tests are now active
 and passing.
 
+The post-M15 roadmap was refreshed in the doc-only PR on branch
+`dev/roadmap-refresh-post-m15` (this PR). The refresh encodes the
+findings of an external code review into PLAN, ROADMAP, and
+IMPROVEMENT_GUIDE: the GitHub-rendered README is stale, the 3D coverage
+is thin, the `mosfet_2d` verifier has no analytical reference, the M16
+and M17 entries were sketches not contracts, and the production-
+hardening items (strict schema, XDMF ingest, dead SG primitives, HTTP
+auth) were uncollected. The backlog now contains an explicit
+acceptance test with a numerical threshold or analytical reference for
+every Tier 1 physics model (Caughey-Thomas, Lombardi, Auger,
+Fermi-Dirac, Schottky, BBT/TAT) plus a 3D MOSFET capstone (M19), an
+MPI parallel benchmark (M19.1), and HTTP server hardening (M20). Two
+new milestone starter prompts (M14.3, M16.1) ship in this PR so the
+next contributor can pick up immediately.
+
 The capability matrix (verified in CI) is authoritative: see `README.md`
 §Status or `docs/ROADMAP.md`.
 
@@ -100,24 +115,60 @@ M15 through M18. Summary:
 
 ## Next task
 
-**Owner picks one** of: (a) M14.2.x cartesian-2D MOSCAP / rigorous HF
-C-V follow-ups; (b) Physics validation suite Phase 2 (Sze /
-Nicollian-Brews external comparisons, case 06); (c) M16.1 (first
-physics-completeness slice: Caughey-Thomas mobility). All three are
-tracked in [`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md)
-and [`docs/ROADMAP.md`](docs/ROADMAP.md).
+**M14.3 Housekeeping PR** on branch `dev/m14.3-housekeeping`. Picked
+up via [`docs/M14_3_STARTER_PROMPT.md`](docs/M14_3_STARTER_PROMPT.md);
+acceptance tests in [`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md)
+§ M14.3. Five-deliverable scope:
+
+1. Re-render the GitHub `README.md` so the landing page matches `main`
+   (the on-disk copy is correct; the `github.com` cache, fork shadow,
+   or rendered view is stale at v0.1.0 framing).
+2. Tighten the `mosfet_2d` verifier with a Pao-Sah / square-law
+   analytical reference in the linear regime and a documented 20%
+   tolerance window.
+3. Implement the XDMF branch in `semi/mesh.py::_build_from_file` and
+   round-trip the resistor benchmark from `box.xdmf` within 1e-12
+   relative R.
+4. Strict-mode the input schema (`additionalProperties: false`
+   everywhere), bump the schema major to v2.0.0, ship `schemas/input.v2.json`
+   alongside v1, and migrate every benchmark JSON.
+5. Delete `semi/fem/sg_assembly.py` (~792 LOC dead-on-active-path)
+   and raise the coverage gate from 92 to 95.
+
+After M14.3 lands, M16.1 (Caughey-Thomas field-dependent mobility) is
+the next physics-completeness slice; starter prompt at
+[`docs/M16_1_STARTER_PROMPT.md`](docs/M16_1_STARTER_PROMPT.md).
 
 ## Backlog
 
 Items deferred behind the next task. Order is informational, not
 binding; the owner picks one explicitly when the next task ships.
 
+- **M14.2.x cartesian-2D MOSCAP / rigorous HF C-V follow-ups.**
+  Tracked in `docs/ROADMAP.md` §Deferred. Superseded for practical
+  purposes by M16.4 (Fermi-Dirac, which the rigorous HF C-V
+  formulation depends on at high doping) and M19 (3D MOSFET, which
+  exercises the same multi-region infrastructure with a more
+  important device).
 - **Physics validation suite, Phase 2.** External validation against
   Sze and Nicollian-Brews. Phase 1 is complete: cases 01-04 pass
   internal-consistency checks (audit case 03 confirms `mos_cv` and
   `mos_cap_ac` byte-identity); case 02/05 sign-convention findings
-  were resolved in PR #62 (M14 sign fix); case 06 deferred. Audit
-  suite is CI-gated via the `docker-fem-audit` job.
+  were resolved in PR #62 (M14 sign fix); case 06 (transient FFT vs
+  AC sweep) is deferred and is the M16.7 deliverable. Audit suite is
+  CI-gated via the `docker-fem-audit` job.
+- **M16.2 Lombardi surface mobility, M16.3 Auger, M16.4 Fermi-Dirac,
+  M16.5 Schottky contacts, M16.6 BBT/TAT tunneling.** Each its own
+  PR with explicit acceptance tests in
+  [`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md).
+- **M19 3D MOSFET benchmark.** Capstone after M16.1, depends on
+  M14.3 for stable XDMF / gmsh ingest.
+- **M19.1 MPI parallel benchmark.** Verify and where needed fix
+  collective communication in the runners; `mosfet_3d` under
+  `mpiexec -n 4`.
+- **M20 HTTP server hardening.** API-key middleware, per-key rate
+  limiting, admin endpoint to issue/revoke keys. Required before
+  multi-tenant deployment.
 
 ## Roadmap
 
@@ -225,6 +276,23 @@ affect any verifier or benchmark result.
 ## Completed work log
 
 Append-only. Newest entries on top.
+
+- **Phase 0 roadmap refresh (2026-05-01):** Doc-only PR on branch
+  `dev/roadmap-refresh-post-m15`. PLAN, ROADMAP, and IMPROVEMENT_GUIDE
+  rewritten to encode the post-M15 priorities derived from an external
+  code review. Each Tier 1 physics model in M16 (Caughey-Thomas,
+  Lombardi, Auger, Fermi-Dirac, Schottky, BBT/TAT) now has an explicit
+  acceptance test with a numerical threshold or analytical reference;
+  new milestones M14.3 (housekeeping), M19 (3D MOSFET capstone), M19.1
+  (MPI parallel benchmark), and M20 (HTTP server hardening) added; the
+  M14.2.x backlog moved into ROADMAP.md §Deferred with a note that it
+  is superseded by M16.4 / M19. Two ready-to-paste starter prompts
+  shipped: `docs/M14_3_STARTER_PROMPT.md` and
+  `docs/M16_1_STARTER_PROMPT.md`. ROADMAP.md grew an "Honest gap"
+  section calling out the three remaining weaknesses (3D semiconductor
+  device benchmarks, post-Boltzmann statistics, contact / tunneling
+  physics). No engine code changed; coverage gate untouched; CI ran
+  only the pure-Python and lint jobs because no FEM file moved.
 
 - **M15 GPU linear-solver path (2026-05-15):** Schema 1.4.0 adds
   `solver.backend` (`cpu-mumps` default, plus `gpu-amgx`, `gpu-hypre`,

--- a/docs/IMPROVEMENT_GUIDE.md
+++ b/docs/IMPROVEMENT_GUIDE.md
@@ -11,15 +11,16 @@ input, its acceptance test, and its dependency on prior milestones.
 
 ---
 
-## 1. Honest current state (as of v0.14.1)
+## 1. Honest current state (as of v0.15.0)
 
 What exists and works:
 
 - `semi/` package with a five-layer architecture; Layer 3 (pure-Python
   core) has no dolfinx dependency and is independently testable.
-- JSON schema 1.3.0 (Draft-07, enforced via `jsonschema`) covering
+- JSON schema 1.4.0 (Draft-07, enforced via `jsonschema`) covering
   mesh, regions, doping, contacts, physics, solver, output, plus the
-  top-level `coordinate_system` field added in M14.2.
+  top-level `coordinate_system` field added in M14.2 and the
+  `solver.backend` / `solver.compute` fields added in M15.
 - Builtin meshes in 1D/2D/3D plus gmsh `.msh` loader with physical
   groups.
 - Equilibrium Poisson, coupled drift-diffusion in Slotboom form, SRH
@@ -63,28 +64,57 @@ What exists and works:
   UI-facing annotations, every benchmark validates, the major-version
   gate refuses mismatched majors (M11).
 - 2D MOSFET with Gaussian n+ source/drain implants on the multi-region
-  Poisson + Slotboom DD stack (M12).
+  Poisson + Slotboom DD stack (M12). Verifier is qualitative (M14.3
+  tightens it with a Pao-Sah / square-law analytical reference).
+- GPU linear-solver path via PETSc CUDA / HIP, AMGX or hypre BoomerAMG
+  preconditioning (M15). Schema 1.4.0 adds `solver.backend` and
+  `solver.compute`; manifest 1.1.0 adds KSP iters and linear-solve
+  wall time; `semi/compute.py` runtime probe and dynamic
+  `GET /capabilities` endpoint.
 
 What does *not* exist:
 
-- **No GPU linear solve.** Every solve is MUMPS LU on CPU via PETSc.
-  Above ~200k DOFs this is the wall. M15 closes the gap.
 - **No field-dependent mobility, Auger, Fermi-Dirac, Schottky
   contacts, or tunneling.** COMSOL Semiconductor has all of these.
-  M16, one PR per model.
+  M16.1 through M16.7, one PR per model, each with an explicit
+  numerical acceptance threshold.
+- **No real 3D semiconductor device.** The 3D coverage today is the
+  doped resistor (M7) and a pure-Poisson box (M15 acceptance test).
+  No 3D MOSFET / FinFET / planar transistor. M19 closes this with a
+  3D MOSFET benchmark on a gmsh-sourced unstructured mesh.
 - **No heterojunctions.** Position-dependent χ and Eg are not yet
-  supported. M17 (depends on M16.4 Fermi-Dirac).
+  supported. M17 (depends on M16.4 Fermi-Dirac because heterojunctions
+  break the nondegenerate approximation at the barrier).
 - **No Cartesian-2D MOSCAP variant** and no rigorous gate-driven HF
-  C-V method. Tracked as M14.2.x in
-  [`PLAN.md`](../PLAN.md) §Backlog and `docs/ROADMAP.md`.
-- **No `GET /capabilities` endpoint.** UI integration item; M15 will
-  close it because GPU availability is itself a capability.
+  C-V method. Tracked in [`docs/ROADMAP.md`](ROADMAP.md) §Deferred;
+  superseded for practical purposes by M16.4 (which the rigorous HF
+  C-V depends on at high doping) and M19 (3D MOSFET, which exercises
+  the same multi-region infrastructure on a more important device).
+- **No MPI parallel orchestration in the runners.** dolfinx supports
+  MPI natively; bias-sweep, postprocess, and IV recording in
+  `semi/runners/` and `semi/postprocess.py` need a collective-
+  communication audit before mosfet_3d at ~1M DOFs is practical.
+  M19.1.
+- **No HTTP server hardening.** `kronos_server/app.py` carries a
+  `# TODO(M10+): add auth, rate limiting, API keys before any public
+  deployment`. M20.
+- **Five small production-hardening gaps** scattered across the
+  codebase: `additionalProperties: false` is not enforced on the
+  input schema; `semi/mesh.py::_build_from_file` raises
+  `NotImplementedError` for the XDMF branch; the transient runner
+  accepts no `V(t)` (closes audit case 06); ~792 LOC of dead-on-
+  active-path Scharfetter-Gummel primitives in `semi/fem/sg_assembly.py`
+  remain in the tree. M14.3 closes the first three plus the dead-LOC
+  removal in one housekeeping PR before M16 physics work starts.
 
 Bottom line: the numerics are sound, the engine is addressable from
-outside Python, results are consumable without a dolfinx install, and
-the schema is versioned and richly annotated. The remaining work is
-scaling the linear solver (M15) and adding the physics models
-engineers actually use daily (M16+).
+outside Python, results are consumable without a dolfinx install, the
+schema is versioned and richly annotated, and the GPU linear-solve
+lever is in place. The remaining work is closing the housekeeping
+gaps (M14.3), filling out the Tier 1 physics catalogue (M16.1
+through M16.7), shipping a real 3D semiconductor device (M19),
+hardening the HTTP server for multi-tenant deployment (M20), and
+extending to heterojunctions (M17).
 
 ---
 
@@ -249,33 +279,112 @@ matches `bias_sweep` within 1e-4 relative error and the
 
 ### M14 — AC small-signal analysis
 
-**Status: Done (2026-04-26).** Linearised
+**Status: Done (2026-04-26, v0.14.0).** Linearised
 `(J + jωM) δu = -dF/dV δV` in real 2x2 block form (PETSc-real build);
 `rc_ac_sweep` benchmark matches analytical depletion C within 0.4%
-over [1 Hz, 1 MHz]; ADR 0011 with sign-convention errata. Full
-deliverable, acceptance tests, and scope preserved in §10.
+over [1 Hz, 1 MHz]; ADR 0011 with sign-convention errata. See
+[CHANGELOG.md](../CHANGELOG.md) `[0.14.0]` entry. Full deliverable,
+acceptance tests, and scope preserved in §10.
 
 ---
 
 ### M14.1 — AC differential capacitance for MOSCAP
 
-**Status: Done (2026-04-26).** `semi/runners/mos_cap_ac.py` returns
-dQ/dV directly from `Im(Y) / (2πf)`, replacing the noisier
+**Status: Done (2026-04-26, PR #38).** `semi/runners/mos_cap_ac.py`
+returns dQ/dV directly from `Im(Y) / (2πf)`, replacing the noisier
 `numpy.gradient(Q, V)` of `mos_cv` for the `mos_2d` C-V verifier;
 audit case 03 confirms byte-identity with `mos_cv` Q_gate at all 42
-gate voltages.
+gate voltages. See [CHANGELOG.md](../CHANGELOG.md) `[0.14.0]` /
+`[Unreleased]` entries.
 
 ---
 
 ### M14.2 — Axisymmetric (cylindrical) 2D MOSCAP
 
-**Status: Done (2026-04-30).** Top-level `coordinate_system` field
-(schema 1.3.0, `cartesian` default or `axisymmetric`) with cross-
-field validation; r-weighted Poisson and Slotboom drift-diffusion on
-the meridian half-plane (`semi/physics/axisymmetric.py`); pure-Python
-MOSCAP analytical helpers (`semi/cv.py`); `benchmarks/moscap_axisym_2d/`
-reproduces Hu Fig. 5-18; runner dispatch in `mos_cap_ac.py` r-weights
-the charge and sensitivity forms (PRs #64, #65).
+**Status: Done (2026-04-30, PRs #64, #65).** Top-level
+`coordinate_system` field (schema 1.3.0, `cartesian` default or
+`axisymmetric`) with cross-field validation; r-weighted Poisson and
+Slotboom drift-diffusion on the meridian half-plane
+(`semi/physics/axisymmetric.py`); pure-Python MOSCAP analytical
+helpers (`semi/cv.py`); `benchmarks/moscap_axisym_2d/` reproduces
+Hu Fig. 5-18; runner dispatch in `mos_cap_ac.py` r-weights the
+charge and sensitivity forms. See [CHANGELOG.md](../CHANGELOG.md)
+`[Unreleased]` entry. The Cartesian-2D MOSCAP variant and rigorous
+gate-driven HF C-V method (M14.2.x) are now in
+[`docs/ROADMAP.md`](ROADMAP.md) §Deferred; superseded for practical
+purposes by M16.4 and M19.
+
+---
+
+### M14.3: Housekeeping (cheap closes)
+
+**Why.** Five small production-hardening gaps are scattered across the
+codebase: the GitHub-rendered `README.md` does not match `main` (the
+landing page still shows v0.1.0 framing); the `mosfet_2d` verifier is
+qualitative with no analytical reference; `semi/mesh.py::_build_from_file`
+raises `NotImplementedError` for the XDMF branch; the input schema
+does not enforce `additionalProperties: false`; and ~792 LOC of dead-
+on-active-path Scharfetter-Gummel primitives in
+`semi/fem/sg_assembly.py` are not on any code path. Closing them in
+one PR removes the noise floor before M16 physics work starts.
+
+**Deliverable.**
+
+- Re-render the GitHub `README.md` so the `github.com` landing page
+  matches `main`. The on-disk copy is correct; the visible page is
+  stale. Investigate whether a fork is shadowing the remote, or
+  whether GitHub's render cache is the issue, and force-push or
+  file a support request as appropriate.
+- Tighten the `mosfet_2d` verifier in
+  [`scripts/run_benchmark.py`](../scripts/run_benchmark.py). Add a
+  Pao-Sah or square-law analytical reference in the linear regime
+  (`V_DS = 0.05 V`, `V_GS in [V_T + 0.2, V_T + 0.6] V`) with a 20%
+  tolerance window. Document the choice in
+  [`benchmarks/mosfet_2d/README.md`](../benchmarks/mosfet_2d/README.md)
+  with a derivation paragraph; document the verifier window choice
+  in [`docs/PHYSICS.md`](PHYSICS.md) Section 6.
+- Implement XDMF mesh ingest in
+  [`semi/mesh.py::_build_from_file`](../semi/mesh.py). Wire
+  `dolfinx.io.XDMFFile.read_mesh` and propagate cell tags via
+  `read_meshtags`. Acceptance: round-trip a `box.msh` -> `box.xdmf`
+  via meshio and verify the resistor benchmark produces the same R
+  within 1e-12 relative.
+- Strict-mode the input schema. Set `additionalProperties: false`
+  on every object node in [`schemas/input.v1.json`](../schemas/input.v1.json)
+  and bump the schema major to v2.0.0. Ship
+  [`schemas/input.v2.json`](../schemas/input.v2.json) alongside v1,
+  keep the engine accepting both for one minor cycle, log a
+  deprecation warning on v1, and migrate every benchmark JSON to
+  v2.0.0. Update `SCHEMA_SUPPORTED_MINOR` and
+  `ENGINE_SUPPORTED_SCHEMA_MAJOR` in
+  [`semi/schema.py`](../semi/schema.py).
+- Delete [`semi/fem/sg_assembly.py`](../semi/fem/sg_assembly.py)
+  (~792 LOC) and remove its dedicated test
+  `tests/fem/test_sg_assembly.py`. Add a one-line note in ADR 0012's
+  status section that the SG primitives are reachable in git history
+  if M13.2 ever revives them. Raise the coverage gate in
+  [`pyproject.toml`](../pyproject.toml) from 92 to 95 (back to the
+  M5-era number) once the file is gone.
+
+**Acceptance tests.**
+
+1. The GitHub-rendered README at the top of the repository page
+   shows v0.15.0 status and the M1-M15 capability matrix.
+2. `python scripts/run_benchmark.py mosfet_2d` exits 0 with the new
+   analytical-reference verifier passing inside the
+   [V_T + 0.2, V_T + 0.6] V window at the documented 20% tolerance.
+3. The resistor benchmark loaded from `box.xdmf` (newly-supported
+   ingest path) produces R within 1e-12 relative of the same
+   benchmark loaded from `box.msh`.
+4. Every benchmark JSON in `benchmarks/` validates as
+   `schema_version: "2.0.0"` with `additionalProperties: false`
+   active; an intentional typo (`"voltag"` for `"voltage"`) is
+   rejected with a clear error message that names the offending
+   field.
+5. `semi/fem/sg_assembly.py` and its dedicated test are gone, the
+   coverage gate in `pyproject.toml` is 95, and CI is green.
+
+**Dependencies.** None; M14.3 only consolidates known small fixes.
 
 ---
 
@@ -332,65 +441,356 @@ GPU yet — dolfinx-cuda is experimental and moving fast.
 
 ---
 
-### M16 — Physics completeness pass
+### M16: Physics completeness pass (umbrella)
 
-**Why:** To mimic COMSOL Semiconductor properly we need the models engineers
-actually use daily.
+**Why.** To mimic COMSOL Semiconductor properly we need the models
+engineers actually use daily. The umbrella M16 work is broken into
+seven sub-milestones, each shipped as its own PR with an explicit
+acceptance test and an analytical or external reference. Do them in
+the order below; M16.4 (Fermi-Dirac) is a hard prerequisite for both
+M16.6 (BBT tunneling, where the density of states matters) and M17
+(heterojunctions, where the barrier breaks the nondegenerate
+approximation).
 
-**Deliverable (do these in order, each a separate PR):**
+**Deliverable.** Seven sub-milestones, each its own PR. See M16.1
+through M16.7 below.
 
-1. **Caughey-Thomas field-dependent mobility.** Closed-form velocity-saturation
-   model. ~200 LOC.
-2. **Lombardi surface-mobility model.** Needed for realistic MOSFET I-V in
-   the inversion regime. ~300 LOC.
-3. **Auger recombination.** `R_Auger = (C_n n + C_p p)(np - n_i^2)`.
-   ~100 LOC.
-4. **Fermi-Dirac statistics.** Replace `exp(±psi)` with Fermi integrals
-   (use Blakemore approximation for speed, full FDI for validation). Gate
-   with a `statistics: "fermi-dirac"` schema option; Boltzmann remains the
-   default. ~400 LOC.
-5. **Schottky contacts.** Thermionic-emission boundary condition. ~300 LOC.
-6. **Band-to-band (Kane) and trap-assisted (Hurkx) tunneling.** Required for
-   any useful diode or floating-gate simulation. ~600 LOC.
+**Acceptance tests.** Each sub-milestone has its own gate; the
+umbrella M16 is "done" when all seven are merged and every existing
+benchmark with the default (constant mobility, Boltzmann statistics,
+SRH-only recombination) is bit-identical to v0.15.0.
 
-Each ships with its own benchmark and verifier.
+**Dependencies.** M9 (artifact writer), M11 (schema versioning),
+M14.3 (strict-mode schema must be in place before any new schema
+field is added; the v1-vs-v2 acceptance also exercises every
+benchmark JSON).
 
-**Acceptance tests:** one analytical-or-SPICE comparison per model.
+---
 
-**Estimated scope:** 2–4 days per item. Don't batch; one PR per model.
+### M16.1: Caughey-Thomas field-dependent mobility
 
-**Dependencies:** M9, M11.
+**Why.** Velocity saturation is the entry-level field-dependent
+mobility model and is required for any quantitative MOSFET I-V at
+fields above ~10 kV/cm. Without it, the M14.3 mosfet_2d verifier
+passes only in the deeply-linear regime; with it, we can extend the
+verifier window into saturation and start running 3D MOSFET
+benchmarks meaningfully.
+
+**Deliverable.**
+
+- New file `semi/physics/mobility.py` with `caughey_thomas_mu(mu0, F_par, ...)`
+  UFL builder. Closed-form, no new unknowns. Schema entry
+  `physics.mobility.model: "constant" | "caughey_thomas"` with parameters
+  `vsat_n`, `vsat_p`, `beta_n`, `beta_p`. Defaults bake in the standard
+  Si values (vsat ~ 1e7 cm/s, beta_n = 2, beta_p = 1).
+- Wire the new mobility into
+  [`semi/physics/drift_diffusion.py`](../semi/physics/drift_diffusion.py)
+  and [`semi/runners/bias_sweep.py`](../semi/runners/bias_sweep.py)
+  behind the schema dispatch. The `constant` branch is bit-identical
+  to pre-M16.1.
+- MMS verifier `tests/fem/test_mms_caughey_thomas.py`: extend the
+  existing MMS-DD harness to include a manufactured solution where
+  the mobility depends on the gradient. Acceptance L2 rate >= 1.99,
+  H1 rate >= 0.99 at the finest pair.
+- New benchmark `benchmarks/diode_velsat_1d/`: 1D pn diode at
+  `V_F in [0.5, 0.9] V` comparing constant-mu and caughey-thomas
+  forward I-V; verifier asserts the two diverge by >5% at 0.9 V and
+  converge to within 1% at 0.5 V.
+
+**Acceptance tests.**
+
+1. `python scripts/run_verification.py mms_dd` includes the
+   caughey_thomas variant and reports L2 rate >= 1.99 at the finest
+   pair.
+2. `python scripts/run_benchmark.py diode_velsat_1d` exits 0 with the
+   divergence-vs-convergence verifier passing.
+3. Every existing benchmark with `physics.mobility.model: "constant"`
+   (which is the schema default) produces results bit-identical to
+   v0.15.0.
+
+**Dependencies.** M14.3 (need the strict-mode schema and the
+tightened mosfet_2d verifier in place first; otherwise the new
+mobility schema field collides with a v1 schema bump and the
+mosfet_2d verifier has nothing analytical to compare velocity
+saturation against).
+
+---
+
+### M16.2: Lombardi surface mobility
+
+**Why.** Inversion-layer mobility in MOSFETs is dominated by surface
+scattering, which Caughey-Thomas does not capture. Required for
+quantitative MOSFET I-V in the inversion regime.
+
+**Deliverable.** Lombardi composite (Coulomb + phonon + surface
+roughness) added to `semi/physics/mobility.py`. Schema entry
+`physics.mobility.model: "lombardi"`. Benchmark:
+[`benchmarks/mosfet_2d`](../benchmarks/mosfet_2d) re-run with
+lombardi mobility, verifier threshold tightened from 20% to 10% in
+the inversion-strong-field region.
+
+**Acceptance tests.**
+
+1. MMS rate >= 1.99 L2 with a manufactured surface-distance field.
+2. Re-run mosfet_2d in the [V_T + 0.4, V_T + 1.0] V window with
+   lombardi mobility, get within 10% of the analytical Sah-Pao
+   reference.
+
+**Dependencies.** M16.1.
+
+---
+
+### M16.3: Auger recombination
+
+**Why.** High-injection diode and BJT modeling are wrong without
+Auger. Cheap (~100 LOC) and benchmarkable on a 1D diode.
+
+**Deliverable.** `R_Auger = (C_n * n + C_p * p) * (np - n_i^2)` added
+to [`semi/physics/recombination.py`](../semi/physics/recombination.py).
+Schema: `physics.recombination.auger: bool` and `C_n`, `C_p`
+parameters. Benchmark: 1D high-injection diode (N=1e15, V_F = 0.9 V)
+where SRH alone underpredicts recombination current by >20% and
+SRH+Auger matches an analytical high-injection long-diode reference.
+
+**Acceptance tests.**
+
+1. With `auger=false`, every existing benchmark produces results
+   bit-identical to v0.15.0.
+2. New benchmark `benchmarks/diode_auger_1d` shows the SRH-only-vs-
+   SRH+Auger divergence at >20% and the latter matches analytical
+   within 5%.
+
+**Dependencies.** M14.3.
+
+---
+
+### M16.4: Fermi-Dirac statistics (gated)
+
+**Why.** Boltzmann breaks above ~1e19 cm^-3, which is the source/drain
+extension regime of every modern MOSFET. Required for quantitative
+I-V at modern technology nodes and a hard prerequisite for M17
+heterojunctions.
+
+**Deliverable.** Blakemore approximation in
+`semi/physics/statistics.py` for the production path; full Fermi-Dirac
+integral via `scipy.special.fdk` for the verification reference.
+Schema: `physics.statistics: "boltzmann" | "fermi_dirac"`, default
+`boltzmann`. Replace `exp(+/- psi)` calls in
+[`semi/physics/poisson.py`](../semi/physics/poisson.py) and the
+Slotboom builders with dispatched calls.
+
+**Acceptance tests.**
+
+1. With `statistics: "boltzmann"`, every existing benchmark is
+   bit-identical to v0.15.0.
+2. New benchmark `benchmarks/diode_fermi_dirac_1d/` (1D pn,
+   `N_D = 1e20 cm^-3` in n+ region) where boltzmann and FD diverge by
+   >15% on V_bi and the FD result matches a stand-alone scipy-driven
+   reference within 1e-3.
+3. MMS rate >= 1.99 L2 on a manufactured solution that pushes the
+   Boltzmann-validity boundary.
+
+**Dependencies.** M14.3, M16.1.
+
+---
+
+### M16.5: Schottky contacts
+
+**Why.** Diode-on-Si and any metal-semiconductor interface is
+unmodellable without thermionic-emission boundary conditions.
+
+**Deliverable.** New contact `type: "schottky"` with parameter
+`barrier_height_eV`. Builder in [`semi/bcs.py`](../semi/bcs.py) adds a
+Robin-style boundary form to the continuity rows; ohmic and gate
+contacts unchanged. Benchmark: 1D Schottky diode with Pt-on-n-Si
+contact vs thermionic-emission analytical I-V.
+
+**Acceptance tests.**
+
+1. New benchmark `benchmarks/schottky_1d` matches the thermionic-
+   emission analytical I-V within 10% from V_F = 0.1 V to 0.5 V.
+2. Existing ohmic-contact benchmarks are bit-identical.
+
+**Dependencies.** M14.3.
+
+---
+
+### M16.6: Tunneling (BBT and TAT)
+
+**Why.** Required for any non-toy diode (Zener, Esaki, GIDL) and
+floating-gate flash modeling. The largest single physics addition in
+M16; do this last in M16.
+
+**Deliverable.** Kane band-to-band model and Hurkx trap-assisted
+model, both as UFL generation/recombination kernels added to
+[`semi/physics/recombination.py`](../semi/physics/recombination.py).
+Schema flags `physics.tunneling: {bbt: bool, tat: bool}` plus model
+parameters.
+
+**Acceptance tests.**
+
+1. New benchmark `benchmarks/zener_1d` shows reverse-bias breakdown
+   current matching a Kane analytical reference within 20% from
+   V_R = 4 V to 8 V on a heavily-doped (1e19) abrupt junction.
+2. Existing benchmarks bit-identical with both flags off.
+
+**Dependencies.** M14.3, M16.4 (BBT depends on the FD-corrected
+density of states).
+
+---
+
+### M19: 3D MOSFET benchmark (capstone after M16.1)
+
+This is a new milestone, not a rename of an existing one. Slotted
+between M16 and M17.
+
+**Why.** The single biggest visible gap relative to "mimics COMSOL
+Semiconductor". Exercises the multi-region MOSFET infrastructure in
+3D, the M15 GPU linear-solver path on a real device (not just on
+Poisson), and the M16.1 Caughey-Thomas mobility under non-trivial
+fields.
+
+**Deliverable.**
+
+- New benchmark `benchmarks/mosfet_3d/`: 3D n-channel MOSFET on a
+  gmsh-sourced unstructured tetrahedral mesh, ~200k DOFs to start
+  (scalable to ~1M for the GPU acceptance run). Channel length
+  L = 250 nm, width W = 1 um, oxide t_ox = 5 nm. Gaussian n+
+  source/drain implants, p-type body 1e16 cm^-3.
+- Verifier compares I_D vs V_GS in linear (`V_DS = 0.05 V`) and
+  saturation (`V_DS = 1.0 V`) regimes against the
+  Pao-Sah-with-velocity-saturation analytical reference within 25%
+  (looser than 2D because of the corner effects).
+- Run on both `cpu-mumps` and `gpu-amgx` backends to demonstrate M15
+  acceptance on a real device, not just on Poisson.
+
+**Acceptance tests.**
+
+1. `python scripts/run_benchmark.py mosfet_3d` exits 0 in both
+   CPU-MUMPS and GPU-AMGX runs.
+2. Linear-regime I_D within 25% of the Pao-Sah analytical reference
+   at three V_GS values.
+3. Saturation-regime I_DSAT within 30% of the velocity-saturation
+   reference.
+4. CPU/GPU wall-clock ratio for the linear solve >=5x at the
+   ~500k-DOF mesh refinement, on the nightly GPU runner.
+
+**Dependencies.** M16.1 (need Caughey-Thomas before saturation has
+any meaning), M14.3 (need XDMF or gmsh ingest stable).
+
+---
+
+### M16.7: Time-varying transient contact voltage
+
+**Why.** Closes audit case 06 (transient FFT vs AC sweep) which is
+currently `pytest.skip`. Enables switching-transient and ringing
+simulation, which is the second-most-asked-for transient feature
+after turn-on.
+
+**Deliverable.** Extend
+[`semi/runners/transient.py`](../semi/runners/transient.py) to accept
+a per-step contact voltage from a callable or a JSON-supplied table.
+Schema:
+`contacts[].voltage_t: {type: "table", times, values}` or
+`{type: "step", t0, v0, v1}`. Update audit case 06 to active.
+
+**Acceptance tests.**
+
+1. Audit case 06 passes: transient FFT of I(t) at a small-signal
+   V(t) sinusoid agrees with `run_ac_sweep` Y(omega) at the same
+   frequency within 5%.
+2. Existing transient benchmarks bit-identical.
+
+**Dependencies.** M14.3.
+
+---
+
+### M19.1: MPI parallel benchmark
+
+**Why.** dolfinx supports MPI natively; the runner orchestration
+does not. Above ~1M DOFs (well within reach of the M15 GPU path and
+the M19 3D MOSFET) MPI is the next bottleneck after the linear
+solver.
+
+**Deliverable.** Verify and where needed fix collective communication
+in [`semi/runners/bias_sweep.py`](../semi/runners/bias_sweep.py) and
+[`semi/postprocess.py`](../semi/postprocess.py) for IV recording. Add
+a CI matrix entry that runs `benchmarks/mosfet_3d` under
+`mpiexec -n 4`.
+
+**Acceptance tests.**
+
+1. mosfet_3d under `mpiexec -n {1,2,4}` produces the same I_D within
+   1e-8 relative.
+2. Wall-clock scaling: n=4 vs n=1 speedup >=2.5x on the ~500k-DOF
+   mesh.
+
+**Dependencies.** M19.
 
 ---
 
 ### M17 — Heterojunction / position-dependent band structure
 
-**Why:** AlGaAs/GaAs, InGaAs/InP, SiGe/Si — none of this works without
+**Why.** AlGaAs/GaAs, InGaAs/InP, SiGe/Si: none of this works without
 position-varying electron affinity `chi(x)` and bandgap `Eg(x)`.
+Required for HEMT and HBT modeling, both of which are core COMSOL
+Semiconductor capabilities.
 
-**Deliverable:** extend the material model and Poisson/continuity kernels
-to read `chi` and `Eg` as cellwise DG0 fields. Benchmark: AlGaAs/GaAs HEMT
-or SiGe HBT.
+**Deliverable.** Extend the material model and the Poisson and
+continuity kernels to read `chi` and `Eg` as cellwise DG0 fields.
+Schema: per-region `material_overrides: {chi_eV, Eg_eV}` plus a
+`heterojunction: true` switch on the region join. Benchmark: an
+AlGaAs/GaAs HEMT or a SiGe HBT with a published reference solution.
 
-**Estimated scope:** 4 days.
+**Acceptance tests.**
 
-**Dependencies:** M9, M16.4 (Fermi-Dirac, because heterojunctions break the
-nondegenerate approximation at the barrier).
+1. New benchmark `benchmarks/hemt_2d` (AlGaAs/GaAs) reproduces the
+   2DEG sheet density at the heterojunction within 15% of a published
+   self-consistent Poisson-Schrodinger reference.
+2. With a single-material override (chi and Eg constant in space),
+   every existing benchmark is bit-identical to v0.15.0.
+3. MMS rate >= 1.99 L2 on a manufactured solution with a smooth
+   chi(x) and Eg(x) variation.
+
+**Dependencies.** M16.4 (Fermi-Dirac, because heterojunctions break
+the nondegenerate approximation at the barrier).
 
 ---
 
 ### M18 — UI: first cut
 
-**Why:** At this point the engine has everything; the UI is what turns this
-into a product.
+**Why.** At this point the engine has everything; the UI is what
+turns this into a product.
 
-**Not in scope of this repo.** Mentioned here so the engine team knows what
-invariants the UI relies on.
+**Not in scope of this repo.** Mentioned here so the engine team
+knows what invariants the UI relies on.
 
-Recommended stack: React + TypeScript, three.js for 3D mesh visualization,
-vtk.js or plotly for field rendering, JSONForms for schema-driven device
-setup. The UI is a separate repo that consumes this engine's JSON schema
-and HTTP API.
+Recommended stack: React + TypeScript, three.js for 3D mesh
+visualization, vtk.js or plotly for field rendering, JSONForms for
+schema-driven device setup. The UI is a separate repo that consumes
+this engine's JSON schema and HTTP API.
+
+---
+
+### M20: HTTP server hardening
+
+**Why.** [`kronos_server/app.py`](../kronos_server/app.py) carries a
+`# TODO(M10+): add auth, rate limiting, API keys before any public
+deployment`. Required before this can be hosted multi-tenant.
+
+**Deliverable.** API-key middleware, per-key rate limiter (in-memory
+token bucket; Redis backend optional), basic admin endpoint to
+issue/revoke keys. Update OpenAPI to reflect the Authorization
+requirement.
+
+**Acceptance tests.**
+
+1. Unauthenticated `POST /solve` returns 401.
+2. Authenticated `POST /solve` is rate-limited to a configurable RPS
+   per key with a 429 response on overrun.
+3. Existing `/health` and `/ready` endpoints remain auth-free.
+
+**Dependencies.** None.
 
 ---
 
@@ -519,6 +919,17 @@ The engine is ready for a UI when all of these are green:
 - **2026-05-15**, mark §4 M15 Done (v0.15.0); the GPU linear-solver
   path landed with schema 1.4.0 (`solver.backend`, `solver.compute`)
   and manifest 1.1.0 (KSP iters and linear-solve wall time fields).
+- **2026-05-01**, post-M15 roadmap refresh: §1 updated to v0.15.0,
+  M14/M14.1/M14.2 status badges grew CHANGELOG anchors, M14.3
+  housekeeping milestone added between M14.2 and M15, M16 umbrella
+  rewritten and broken into seven sub-milestones M16.1 through M16.7
+  each with explicit four-subsection Why / Deliverable / Acceptance /
+  Dependencies blocks, M17 rewritten in the same shape, three new
+  milestones M19 (3D MOSFET capstone), M19.1 (MPI parallel
+  benchmark), and M20 (HTTP server hardening) added with full
+  acceptance tests. Two new starter prompts shipped:
+  [M14_3_STARTER_PROMPT.md](M14_3_STARTER_PROMPT.md) and
+  [M16_1_STARTER_PROMPT.md](M16_1_STARTER_PROMPT.md).
 
 ---
 

--- a/docs/M14_3_STARTER_PROMPT.md
+++ b/docs/M14_3_STARTER_PROMPT.md
@@ -1,0 +1,382 @@
+# M14.3 starter prompt: Housekeeping (cheap closes)
+
+Paste-ready prompt for Claude in VS Code. Mirrors the convention of
+`docs/M9_STARTER_PROMPT.md` and `docs/M15_STARTER_PROMPT.md`. Pick this
+up on a fresh branch `dev/m14.3-housekeeping`. Do not bundle with any
+other milestone work.
+
+---
+
+You are working in `kronos-semi` at v0.15.0. Your assignment is
+**M14.3: Housekeeping (cheap closes)**, the bridge PR between M15
+(GPU linear-solver path) and M16.1 (Caughey-Thomas mobility, the
+first physics-completeness slice).
+
+This prompt does not restate the M14.3 deliverable, the acceptance
+tests, or the rationale; those live in `docs/IMPROVEMENT_GUIDE.md`
+§ M14.3. Read the guide first; this prompt only tells you the order
+in which to execute and which invariants must remain load-bearing.
+
+## Required reading (do not skip; ~30 minutes)
+
+Per `CONTRIBUTING.md` "Before you start", in order:
+
+1. `PLAN.md` in full. Confirm `main` is at v0.15.0 and that no other
+   PR is in flight on `dev/m14.3-*`. The "Next task" section names
+   M14.3; if it does not, stop and align with the maintainer before
+   continuing.
+2. `docs/IMPROVEMENT_GUIDE.md` § M14.3 (the milestone definition,
+   including the Why / Deliverable / Acceptance / Dependencies block)
+   and § 1 (Honest current state, for the v0.15.0 baseline).
+3. `docs/ROADMAP.md` § Capability matrix and § Honest gap. M14.3 is
+   listed as Planned.
+4. `docs/ARCHITECTURE.md` for the five-layer rule. M14.3 touches the
+   schema (Layer 2), the FEM mesh ingest (Layer 4), and the
+   benchmark / verifier (Layer 5). Layer 3 (pure-Python core) and
+   Layer 4 physics kernels stay untouched.
+5. `docs/adr/0001`, `0002`, `0006`, `0011`, `0012`. ADR 0006
+   (V&V strategy) and ADR 0012 (SG primitives status) are directly
+   relevant: the Pao-Sah verifier is a new analytical check, and the
+   SG primitives go away in this PR.
+6. `docs/PHYSICS.md` Section 6 (MOS reference). The new mosfet_2d
+   verifier window choice belongs here.
+
+## Conventions (project rules, not suggestions)
+
+- **JSON is the contract.** Every shipped feature must be expressible
+  in `schemas/input.v1.json` (and v2.0.0 from this PR onward),
+  validated by `semi/schema.py`, and exercised by at least one
+  benchmark JSON.
+- **Schema versioning is binding.** This PR ships a major bump
+  (v1 to v2) because flipping `additionalProperties: false` is a
+  schema-breaking change. Both schemas must be present in the tree,
+  the engine must accept both for one minor cycle, and v1 inputs
+  must log a deprecation warning.
+- **Five layers, enforced.** The pure-Python core
+  (`semi/constants.py`, `semi/materials.py`, `semi/scaling.py`,
+  `semi/doping.py`, `semi/schema.py`, `semi/cv.py`,
+  `semi/timestepping.py`, `semi/bcs.py`, `semi/results.py`,
+  `semi/diode_analytical.py`, `semi/continuation.py`,
+  `semi/compute.py`) does not import dolfinx, ufl, petsc4py, or
+  mpi4py at module scope. The XDMF branch in `semi/mesh.py` is
+  Layer 4; imports go inside the function body.
+- **Every new analytical model needs a benchmark.** The Pao-Sah
+  reference for mosfet_2d is the new analytical model; its place in
+  the verifier is the benchmark.
+- **One milestone, one PR.** Do not bundle M14.3 with M16.1 or any
+  other physics work.
+- **No em dashes in prose or code comments.** Use commas, periods,
+  parentheses, or colons.
+- **Physics-style variable names are allowed.** `N_A`, `V_t`,
+  `psi_L`, `eps_Si`, etc. PEP 8 N rules are off globally in ruff.
+- **Coverage gate ends this PR at 95.** It enters this PR at 92;
+  the SG-removal step plus the new XDMF / Pao-Sah / strict-schema
+  unit tests should restore it. Do not lower the gate; if the
+  gate drops below 95, add unit tests rather than relax the
+  threshold.
+
+## Five phases, one commit per phase
+
+Do not bundle. After each phase, run `ruff check semi/ tests/` and
+`pytest tests/`. Do not advance with red tests.
+
+---
+
+### Phase A: GitHub-rendered README (the visible problem)
+
+No code. The `README.md` in this tree is correct; the GitHub landing
+page is stale. Investigate and fix.
+
+1. View the README at `https://github.com/rwalkerlewis/kronos-semi`
+   in a browser (incognito to bypass any local cache). Confirm the
+   landing page does not match `main`.
+2. Diagnose the cause. Three plausible explanations:
+   - A fork is shadowing the repo at the user/org level (rare).
+   - GitHub's render cache is stuck (common after a long-running
+     branch was force-pushed; fixed by editing `README.md` with a
+     trivial whitespace change and pushing).
+   - The displayed README is a `default-branch` mismatch (the
+     `main` branch is the default but the rendered page is reading
+     a different branch).
+3. Apply the smallest fix that closes the visible problem. If a
+   trivial whitespace push refreshes the cache, do that. If the
+   default-branch setting is wrong, fix it via the GitHub web UI
+   and document in the PR description. If a fork shadows the repo,
+   file a GitHub support request and link it from the PR; do not
+   block the rest of M14.3 on it.
+4. Take a screenshot of the corrected landing page; attach it to
+   the PR description as evidence.
+
+**Acceptance test 1**: the GitHub-rendered README at the top of the
+repository page shows v0.15.0 status and the M1-M15 capability
+matrix.
+
+**Commit message:** `docs: refresh GitHub-rendered README landing page (M14.3)`
+
+---
+
+### Phase B: tighten the mosfet_2d verifier with a Pao-Sah reference
+
+Bring the `mosfet_2d` benchmark from a qualitative check to an
+analytical-reference check. The Pao-Sah square-law model is the
+correct linear-regime reference at low V_DS.
+
+1. Add a Pao-Sah / square-law analytical reference to
+   `scripts/run_benchmark.py`'s `verify_mosfet_2d`:
+   - Linear-regime current
+     `I_D = (W/L) * mu_n * C_ox * (V_GS - V_T) * V_DS` for
+     `V_GS > V_T`, `V_DS << V_GS - V_T`.
+   - Use the existing `semi/cv.py` MOSCAP analytical helpers for
+     `V_T`; if they do not export the helper you need, extend
+     `semi/cv.py` (Layer 3, pure-Python; no dolfinx imports).
+2. Pick the verifier window: `V_DS = 0.05 V`, `V_GS in [V_T + 0.2, V_T + 0.6] V`.
+   Tolerance: 20%.
+3. Document the choice in `benchmarks/mosfet_2d/README.md` with a
+   one-paragraph derivation. The window edges are: lower bound
+   so we are above subthreshold (Boltzmann tail does not dominate);
+   upper bound so velocity-saturation is still negligible
+   (M16.1 will widen the window once Caughey-Thomas ships).
+4. Document the verifier window choice in `docs/PHYSICS.md`
+   Section 6 (the existing MOS reference). One short paragraph
+   plus the equation; cross-reference the README.
+5. Add a new pure-Python unit test in `tests/test_mosfet_2d_verifier.py`
+   that mocks the IV result and asserts the verifier passes when
+   the simulated I_D is within 20% and fails when outside.
+
+**Acceptance test 2**: `python scripts/run_benchmark.py mosfet_2d`
+exits 0 with the new analytical-reference verifier passing inside
+the [V_T + 0.2, V_T + 0.6] V window at the documented 20%
+tolerance.
+
+**Commit message:** `feat(benchmark): mosfet_2d Pao-Sah analytical verifier (M14.3)`
+
+---
+
+### Phase C: implement XDMF mesh ingest
+
+Wire the existing `NotImplementedError` branch in
+`semi/mesh.py::_build_from_file`.
+
+1. In `semi/mesh.py::_build_from_file`, add the XDMF branch:
+   - Use `dolfinx.io.XDMFFile.read_mesh(comm, "r", path)` to load
+     the mesh.
+   - Use `XDMFFile.read_meshtags(...)` to load cell tags and facet
+     tags. Propagate them as `cell_tags` and `facet_tags` matching
+     the gmsh `.msh` branch.
+   - Imports inside the function body, not at module scope.
+2. Test: `tests/fem/test_mesh_xdmf.py` round-trips the resistor
+   benchmark mesh through `box.msh` -> `box.xdmf` via meshio.
+   Compute R from each load path; assert
+   `abs(R_xdmf - R_msh) / R_msh < 1e-12`.
+3. Update `docs/schema/reference.md` to note that
+   `mesh.source: "file"` accepts both `.msh` and `.xdmf`.
+
+**Acceptance test 3**: the resistor benchmark loaded from
+`box.xdmf` produces R within 1e-12 relative of the same benchmark
+loaded from `box.msh`.
+
+**Commit message:** `feat(mesh): XDMF mesh ingest with cell-tag propagation (M14.3)`
+
+---
+
+### Phase D: strict-mode the input schema (v1 -> v2 major bump)
+
+This is the largest single change in M14.3 and the only one that
+breaks v1 compatibility. Do it with care; both v1 and v2 must coexist
+for one minor cycle.
+
+1. Copy `schemas/input.v1.json` to `schemas/input.v2.json`. In v2:
+   - Set `additionalProperties: false` on every object node.
+   - Bump `schema_version` constraint: `"const": "2.0.0"` (or a
+     pattern that accepts only 2.x.y).
+2. Keep `schemas/input.v1.json` unchanged for one minor cycle.
+3. Update `semi/schema.py`:
+   - `ENGINE_SUPPORTED_SCHEMA_MAJOR` now lists both 1 and 2 (or
+     accepts a range).
+   - Validation dispatches on `schema_version` major; v1 inputs log
+     a `DeprecationWarning` ("Schema v1 is deprecated; migrate to
+     v2.0.0") and continue.
+   - `SCHEMA_SUPPORTED_MINOR` resets to 0 for the v2 line.
+4. Migrate every benchmark JSON in `benchmarks/` to v2.0.0:
+   - Bump `schema_version` to `"2.0.0"`.
+   - Verify each one validates as strict v2 (no extra properties).
+   - Fix any latent typos or unused fields the strict gate
+     surfaces.
+5. Add a unit test `tests/test_schema_strict.py`:
+   - Every benchmark JSON validates as strict v2.
+   - An intentional typo (`"voltag"` instead of `"voltage"`) in a
+     contact entry is rejected with a clear error message that
+     names the offending field.
+   - A v1 input loads with a `DeprecationWarning`.
+6. Update `docs/schema/reference.md` to document the v1 / v2
+   coexistence and the deprecation timeline.
+
+**Acceptance test 4**: every benchmark JSON in `benchmarks/`
+validates as `schema_version: "2.0.0"` with `additionalProperties:
+false` active; an intentional typo (`"voltag"` for `"voltage"`) is
+rejected with a clear error message that names the offending field.
+
+**Commit message:** `feat(schema): strict-mode v2.0.0 with additionalProperties false (M14.3)`
+
+---
+
+### Phase E: remove dead Scharfetter-Gummel primitives
+
+ADR 0012 documented the SG primitives' status; M13.1 closed in
+v0.14.1 with the Slotboom transient (ADR 0014) leaving the SG
+primitives unreachable on the active code path. Delete them.
+
+1. Delete `semi/fem/sg_assembly.py` (~792 LOC).
+2. Delete `tests/fem/test_sg_assembly.py` if present (the
+   dedicated SG test).
+3. Confirm via grep that no other module imports
+   `semi.fem.sg_assembly` or its public symbols. If any test or
+   runner still references it, that is a sign the file is not
+   actually dead; stop and reconcile with the maintainer before
+   deletion.
+4. Add a one-line note in ADR 0012's status section:
+   "Reachable in git history at commit `<sha-of-deletion>` if
+   M13.2 ever revives the SG flux path."
+5. Raise the coverage gate in `pyproject.toml` from 92 to 95
+   (back to the M5-era number).
+6. Run `pytest --cov=semi --cov-fail-under=95` to confirm the
+   gate holds. If it does not, the deletion exposed a real
+   coverage gap; add unit tests rather than relax the gate.
+
+**Acceptance test 5**: `semi/fem/sg_assembly.py` and its
+dedicated test are gone, the coverage gate in `pyproject.toml`
+is 95, and CI is green.
+
+**Commit message:** `chore(fem): remove dead SG primitives; raise coverage gate to 95 (M14.3)`
+
+---
+
+## Phase F: close out
+
+1. `PLAN.md`:
+   - Move M14.3 from "Next task" to "Completed work log" with the
+     PR number, deliverables, schema major bump, and acceptance-test
+     results.
+   - Set "Next task" to **M16.1 Caughey-Thomas field-dependent
+     mobility** with a pointer to `docs/M16_1_STARTER_PROMPT.md`.
+   - Refresh "Current state" with the new package version
+     (bump 0.15.0 to 0.16.0; this PR ships the schema major bump,
+     so the package version follows).
+2. `docs/IMPROVEMENT_GUIDE.md`:
+   - Mark M14.3 Done in § 4 with a one-line summary and a CHANGELOG
+     anchor.
+   - Append a § 9 changelog entry.
+3. `docs/ROADMAP.md`:
+   - Update the M14.3 row in the capability matrix from Planned
+     to shipped with the per-deliverable verifier summary.
+4. `CHANGELOG.md`:
+   - New `[0.16.0]` entry with the M14.3 line items.
+5. Push every commit to origin immediately. The maintainer's
+   convention is one push per commit (not at the end of the
+   branch); include the SHA, log line, and `git status` snapshot in
+   each gate report.
+
+**Commit message:** `docs: close out M14.3 (PLAN, IMPROVEMENT_GUIDE, ROADMAP, CHANGELOG)`
+
+---
+
+## Invariants checklist (re-verify before each commit)
+
+- [ ] No em dashes in any new prose or code comment touched by this
+      PR. Use commas, parentheses, or colons.
+- [ ] Pure-Python core remains dolfinx-free.
+- [ ] CPU-MUMPS path (default) is bit-identical to v0.15.0 on every
+      benchmark; new schema dispatch in v2.0.0 does not change the
+      assembled forms.
+- [ ] `make_scaling_from_config` still on every solve path.
+- [ ] No PETSc / UFL types leak into `kronos_server` public API.
+- [ ] Schema major bumped (v1 to v2) per the schema-versioning
+      invariant; both schemas coexist for one minor cycle; v1 inputs
+      log a `DeprecationWarning` and still solve.
+- [ ] No new ADR introduced unless an invariant is broken; the
+      `additionalProperties: false` flip is a schema major bump
+      already covered by the existing schema-versioning invariant
+      and does not require a new ADR.
+- [ ] Coverage gate holds at 95 after the SG removal.
+
+## Anti-goals
+
+- Do not start M16.1 in this PR. The Caughey-Thomas mobility is its
+  own PR.
+- Do not change anything in `semi/physics/*`, `semi/bcs.py`,
+  `semi/scaling.py`, or `semi/runners/*` (other than the schema
+  dispatch wiring).
+- Do not delete the SG primitives' git history. Removing the file
+  is enough; the history is the recovery path if M13.2 ever
+  revives it.
+- Do not raise the coverage gate above 95 in this PR. That is a
+  separate decision.
+- Do not bundle this PR with the M14.2.x backlog or with anything
+  in M16. Those are separate PRs.
+
+## Stop conditions
+
+You are done with this prompt when:
+
+1. The M14.3 PR is opened on branch `dev/m14.3-housekeeping`.
+2. All five acceptance tests in `docs/IMPROVEMENT_GUIDE.md`
+   § M14.3 are green in CI.
+3. PLAN.md, IMPROVEMENT_GUIDE.md, ROADMAP.md, and CHANGELOG.md
+   reflect the close-out.
+4. The package version has bumped 0.15.0 to 0.16.0 in
+   `pyproject.toml` and `semi/__init__.py`.
+5. The schema files `schemas/input.v1.json` and
+   `schemas/input.v2.json` both exist; v1 logs a deprecation
+   warning; every benchmark JSON is at v2.0.0.
+6. `semi/fem/sg_assembly.py` is gone, the coverage gate is 95,
+   and CI is green.
+
+## PR description template
+
+```
+## Summary
+
+Housekeeping PR (M14.3) closing five small production-hardening
+gaps before M16 physics work starts. Doc-only effects on PLAN /
+IMPROVEMENT_GUIDE / ROADMAP / CHANGELOG; engine effects bounded
+to the schema dispatch, the XDMF branch in semi/mesh.py, and the
+mosfet_2d verifier in scripts/run_benchmark.py.
+
+Schema major bump v1 to v2 (additionalProperties: false). Both
+schemas coexist; v1 inputs log a DeprecationWarning.
+
+Closes:
+- GitHub-rendered README staleness (Phase A)
+- mosfet_2d qualitative verifier (Phase B)
+- semi/mesh.py XDMF NotImplementedError (Phase C)
+- input schema additionalProperties: false enforcement (Phase D)
+- semi/fem/sg_assembly.py dead-on-active-path (Phase E)
+
+## Acceptance tests
+
+(All five are in docs/IMPROVEMENT_GUIDE.md § M14.3.)
+
+- [x] A1: GitHub-rendered README at v0.15.0
+- [x] A2: scripts/run_benchmark.py mosfet_2d Pao-Sah verifier
+- [x] A3: resistor benchmark from box.xdmf vs box.msh within 1e-12
+- [x] A4: every benchmark JSON validates as v2.0.0; typo rejected
+- [x] A5: SG primitives gone; coverage gate 95; CI green
+
+## Test plan
+
+- [ ] ruff check semi/ tests/
+- [ ] pytest tests/
+- [ ] pytest --cov=semi --cov-fail-under=95
+- [ ] python scripts/run_verification.py all
+- [ ] docker compose run --rm benchmark mosfet_2d
+- [ ] docker compose run --rm benchmark resistor_3d (msh and xdmf)
+```
+
+## Hand-off
+
+When M14.3 lands and is reviewed, the next pickup is M16.1
+(Caughey-Thomas field-dependent mobility). Paste
+`docs/M16_1_STARTER_PROMPT.md` into a fresh Claude Code session on
+branch `dev/m16.1-caughey-thomas`. Phase 2 of the post-M15 roadmap
+refresh is a separate PR; it does not start until M14.3 is
+merged.

--- a/docs/M16_1_STARTER_PROMPT.md
+++ b/docs/M16_1_STARTER_PROMPT.md
@@ -1,0 +1,398 @@
+# M16.1 starter prompt: Caughey-Thomas field-dependent mobility
+
+Paste-ready prompt for Claude in VS Code. Mirrors the convention of
+`docs/M9_STARTER_PROMPT.md`, `docs/M15_STARTER_PROMPT.md`, and
+`docs/M14_3_STARTER_PROMPT.md`. Pick this up on a fresh branch
+`dev/m16.1-caughey-thomas` after M14.3 has merged. Do not bundle
+with any other milestone work.
+
+---
+
+You are working in `kronos-semi` at v0.16.0 (post-M14.3). Your
+assignment is **M16.1: Caughey-Thomas field-dependent mobility**, the
+first physics-completeness slice of the M16 umbrella.
+
+This prompt does not restate the M16.1 deliverable, the acceptance
+tests, or the rationale; those live in `docs/IMPROVEMENT_GUIDE.md`
+§ M16.1. Read the guide first; this prompt only tells you the order
+in which to execute and which invariants must remain load-bearing.
+
+## Required reading (do not skip; ~45 minutes)
+
+Per `CONTRIBUTING.md` "Before you start", in order:
+
+1. `PLAN.md` in full. Confirm `main` is at v0.16.0 (post-M14.3) and
+   that no other PR is in flight on `dev/m16.1-*`. The "Next task"
+   section names M16.1; if it does not, stop and align with the
+   maintainer before continuing.
+2. `docs/IMPROVEMENT_GUIDE.md` § M16 (the umbrella context),
+   § M16.1 (the milestone definition with Why / Deliverable /
+   Acceptance / Dependencies), and § 1 (Honest current state).
+3. `docs/ROADMAP.md` § Capability matrix, § Honest gap, and the
+   M16.1 row.
+4. `docs/ARCHITECTURE.md` for the five-layer rule. M16.1 touches
+   physics (Layer 4), the schema (Layer 2), and the benchmark
+   (Layer 5). Layer 3 (pure-Python core) and the BC layer are not
+   touched.
+5. `docs/PHYSICS.md` for the scaled drift-diffusion derivation.
+   The Caughey-Thomas mobility is a coefficient on the scaled
+   continuity flux; understand which scale absorbs the field
+   dependence.
+6. `docs/adr/0001`, `0002`, `0004` (Slotboom variables for DD;
+   M16.1 must remain in Slotboom form), `0006` (V&V strategy;
+   M16.1 needs an MMS verifier), `0007` (BC interface; do not
+   touch).
+7. `docs/mms_dd_derivation.md` for the existing MMS-DD harness; the
+   Caughey-Thomas variant extends it with a gradient-dependent
+   mobility.
+
+## Conventions (project rules, not suggestions)
+
+- **JSON is the contract.** The new schema entries
+  `physics.mobility.model: "constant" | "caughey_thomas"` and the
+  parameters `vsat_n`, `vsat_p`, `beta_n`, `beta_p` must be
+  expressible in `schemas/input.v2.json` (M14.3 has bumped to v2),
+  validated by `semi/schema.py`, and exercised by at least one
+  benchmark JSON.
+- **Schema versioning is binding.** This is an additive minor bump
+  v2.0.0 to v2.1.0; v2.0.0 inputs (no `physics.mobility` block)
+  must continue to validate and produce bit-identical results.
+  Update `SCHEMA_SUPPORTED_MINOR` in `semi/schema.py`.
+- **Five layers, enforced.** The new `semi/physics/mobility.py` is
+  Layer 4 (FEM); imports for `dolfinx`, `ufl`, `petsc4py` go
+  inside function bodies, not at module scope. The mobility
+  parameters live in the JSON schema (Layer 1) and the schema
+  loader (Layer 2); pure Python.
+- **Slotboom variables for DD.** ADR 0004 is locked. The
+  Caughey-Thomas mobility multiplies the Slotboom flux; do not
+  re-derive the continuity rows in primary-density form.
+- **Every new physics module needs an MMS verifier.** ADR 0006.
+  No exceptions. Acceptance L2 rate >= 1.99 and H1 rate >= 0.99 at
+  the finest pair, gated in `scripts/run_verification.py mms_dd`.
+- **Every new analytical model needs a benchmark.** The
+  `diode_velsat_1d` benchmark is the analytical anchor.
+- **One milestone, one PR.** Do not bundle M16.1 with M16.2 or any
+  other physics work.
+- **No em dashes in prose or code comments.** Use commas, periods,
+  parentheses, or colons.
+- **Physics-style variable names are allowed.** `mu_n0`, `vsat_n`,
+  `beta_n`, `F_par`, etc.
+- **Coverage gate is 95 on `semi/`.** The new mobility module must
+  carry pure-Python unit tests for the closed-form math; the FEM
+  wiring is covered by the MMS test and the benchmark.
+
+## Five phases, one commit per phase
+
+Do not bundle. After each phase, run `ruff check semi/ tests/` and
+`pytest tests/`. Do not advance with red tests.
+
+---
+
+### Phase A: schema surface for the mobility dispatch
+
+Pure-Python only. No FEM behavior change.
+
+1. Bump `schemas/input.v2.json` minor: 2.0.0 to 2.1.0. Confirm the
+   major-version gate in `semi/schema.py` still accepts 2.1.0;
+   bump `SCHEMA_SUPPORTED_MINOR` accordingly.
+2. Add to `physics`:
+   ```jsonc
+   "mobility": {
+     "type": "object",
+     "additionalProperties": false,
+     "properties": {
+       "model": {
+         "enum": ["constant", "caughey_thomas"],
+         "default": "constant",
+         "description": "Mobility model dispatch. constant is the V&V reference and the v0.15.0 baseline; caughey_thomas adds closed-form velocity saturation."
+       },
+       "vsat_n": {"type": "number", "default": 1.0e7,
+                  "description": "Electron saturation velocity (cm/s). Default is the standard Si value."},
+       "vsat_p": {"type": "number", "default": 8.0e6,
+                  "description": "Hole saturation velocity (cm/s)."},
+       "beta_n": {"type": "number", "default": 2.0,
+                  "description": "Electron Caughey-Thomas exponent."},
+       "beta_p": {"type": "number", "default": 1.0,
+                  "description": "Hole Caughey-Thomas exponent."}
+     }
+   }
+   ```
+3. Default-fill: an input with no `physics.mobility` block produces
+   an exact bit-equivalent solve to v0.16.0 (which is bit-equivalent
+   to v0.15.0 plus the M14.3 housekeeping closures).
+4. Pure-Python tests in `tests/test_mobility_schema.py`:
+   - Every existing benchmark JSON validates unchanged against
+     v2.1.0.
+   - `physics.mobility.model: "caughey_thomas"` validates with
+     defaults.
+   - An unknown model name (`"foo"`) is rejected.
+   - An extra property under `physics.mobility` (strict mode) is
+     rejected.
+
+**Commit message:** `feat(schema): physics.mobility dispatch (schema 2.1.0); constant default unchanged (M16.1)`
+
+**Acceptance:** all existing tests pass; new tests pass; no FEM
+behavior change is observable on any benchmark.
+
+---
+
+### Phase B: the mobility builder
+
+The closed-form Caughey-Thomas expression as a UFL builder. Layer 4;
+imports inside function bodies.
+
+1. New module `semi/physics/mobility.py`. Public API:
+   ```python
+   def caughey_thomas_mu(mu0, F_par, vsat, beta):
+       """
+       Caughey-Thomas field-dependent mobility:
+           mu(F) = mu0 / (1 + (mu0 * F_par / vsat)**beta)**(1/beta)
+       Inputs are UFL expressions or Constants in scaled units;
+       returns a UFL expression in the same scaled units.
+       """
+   def constant_mu(mu0):
+       """Identity wrapper; returns mu0 unchanged."""
+   def build_mobility(physics_cfg, mu0_n, mu0_p, F_par_n, F_par_p):
+       """Dispatch on physics.mobility.model and return (mu_n, mu_p) UFL expressions."""
+   ```
+2. `F_par` is the magnitude of the field component parallel to
+   the current vector. For drift-diffusion in Slotboom form, the
+   carrier-specific parallel field magnitude is what
+   Caughey-Thomas wants; document the sign convention and the
+   absolute-value choice in a docstring.
+3. Pure-Python unit tests in
+   `tests/test_mobility_closed_form.py`:
+   - Limit `F_par -> 0`: `mu(F) -> mu0` to within 1e-12.
+   - Limit `F_par -> inf`: `mu(F) * F_par -> vsat` to within 1%.
+   - `beta = 2`, intermediate field: matches the closed form by
+     hand calculation at three sample points.
+
+**Commit message:** `feat(physics): Caughey-Thomas mobility UFL builder (M16.1)`
+
+**Acceptance:** new tests pass; no FEM behavior change.
+
+---
+
+### Phase C: wire the builder into the runners
+
+Add the dispatch hook in the drift-diffusion form builder and the
+bias-sweep runner. Touch only what is needed.
+
+1. `semi/physics/drift_diffusion.py`: thread the mobility dispatch
+   through `build_dd_block_residual` and the multi-region variant.
+   The `constant` branch is bit-identical; the
+   `caughey_thomas` branch substitutes
+   `caughey_thomas_mu(mu0, F_par, vsat, beta)` for `mu0` in the
+   continuity flux.
+2. `semi/runners/bias_sweep.py`: at runner setup, build
+   `(mu_n, mu_p)` via `semi.physics.mobility.build_mobility` and
+   pass them to the DD form builder.
+3. The other runners (equilibrium, mos_cv, mos_cap_ac, transient,
+   ac_sweep) do not need touching for this PR; the equilibrium and
+   MOSCAP runners do not have continuity rows under bias, and the
+   transient and AC runners can adopt mobility dispatch in a
+   follow-up.
+4. Existing benchmarks: with `physics.mobility.model: "constant"`
+   (the default), every benchmark must produce results
+   bit-identical to v0.16.0. Run the V&V suite and the benchmark
+   matrix to confirm.
+
+**Commit message:** `feat(runners): wire Caughey-Thomas mobility into bias_sweep and DD form (M16.1)`
+
+**Acceptance:** every existing benchmark with the default
+mobility produces bit-identical numerics to v0.16.0; CI green.
+
+---
+
+### Phase D: MMS verifier with a gradient-dependent mobility
+
+ADR 0006 mandates an MMS verifier for every new physics module.
+Extend the existing MMS-DD harness.
+
+1. New file `tests/fem/test_mms_caughey_thomas.py`:
+   - Manufactured solution: `psi_e = sin(k*x)`, `phi_n_e = a*sin(k*x)`,
+     `phi_p_e = b*sin(k*x)` (or the existing MMS-DD reference if it
+     fits). The mobility depends on `|grad(phi_n_e)|` and
+     `|grad(phi_p_e)|` so the gradient is non-trivial.
+   - Forcing terms in UFL (do not form `ufl.div(ufl.grad(...))`
+     directly; the constant prefactor on a coarse mesh can collapse
+     to numerical zero).
+   - Mesh sweep with N in [50, 100, 200, 400].
+   - Acceptance: finest-pair L2 rate >= 1.99 and H1 rate >= 0.99 on
+     each block (psi, phi_n, phi_p).
+2. Extend `semi/verification/mms_dd.py` to expose the new variant
+   so `python scripts/run_verification.py mms_dd` includes it.
+3. Update `docs/PHYSICS.md` § Verification & Validation with a
+   one-paragraph note on the new MMS variant and the rate gate.
+4. Update `docs/mms_dd_derivation.md` with the manufactured-source
+   derivation for the Caughey-Thomas variant.
+
+**Commit message:** `feat(verification): MMS-DD Caughey-Thomas variant (M16.1)`
+
+**Acceptance test 1**: `python scripts/run_verification.py mms_dd`
+includes the caughey_thomas variant and reports L2 rate >= 1.99 at
+the finest pair.
+
+---
+
+### Phase E: the diode_velsat_1d benchmark
+
+The analytical anchor: a 1D pn diode where Caughey-Thomas and
+constant mobility predict measurably different I-V at high field
+and converge at low field.
+
+1. New directory `benchmarks/diode_velsat_1d/`:
+   - `diode_velsat.json`: 1D pn diode at V_F in [0.5, 0.9] V, otherwise
+     identical to `pn_1d_bias`. Two configs (or one config with a
+     parametric switch): `physics.mobility.model: "constant"` and
+     `physics.mobility.model: "caughey_thomas"`.
+   - `README.md`: device description, analytical reasoning for the
+     >5% divergence at V = 0.9 V and the <1% convergence at V = 0.5 V.
+2. New verifier in `scripts/run_benchmark.py`:
+   `verify_diode_velsat_1d`:
+   - Run the constant-mu sweep, run the caughey-thomas sweep.
+   - Assert `|I_CT(0.9) - I_const(0.9)| / I_const(0.9) > 0.05`.
+   - Assert `|I_CT(0.5) - I_const(0.5)| / I_const(0.5) < 0.01`.
+3. Wire the new benchmark into CI: add a step in
+   `.github/workflows/ci.yml` (or the docker-fem job) that runs
+   `python scripts/run_benchmark.py diode_velsat_1d`.
+4. Notebook (optional but recommended for parity with shipped
+   benchmarks): `notebooks/06_diode_velsat_1d.ipynb` showing the
+   two I-V curves and the divergence plot.
+
+**Commit message:** `feat(benchmark): diode_velsat_1d Caughey-Thomas vs constant mobility (M16.1)`
+
+**Acceptance test 2**: `python scripts/run_benchmark.py
+diode_velsat_1d` exits 0 with the divergence-vs-convergence
+verifier passing.
+
+---
+
+## Phase F: close out
+
+1. `PLAN.md`:
+   - Move M16.1 from "Next task" to "Completed work log" with the
+     PR number, deliverables, schema minor bump, and acceptance-test
+     results.
+   - Set "Next task" to **M16.2 Lombardi surface mobility** with a
+     pointer to the (yet-to-be-authored) M16.2 starter prompt.
+   - Refresh "Current state" with the new package version (bump
+     0.16.0 to 0.17.0 for the schema minor and the new physics
+     model).
+2. `docs/IMPROVEMENT_GUIDE.md`:
+   - Mark M16.1 Done in § 4 with a one-line summary and a CHANGELOG
+     anchor.
+   - Append a § 9 changelog entry.
+3. `docs/ROADMAP.md`:
+   - Update the M16.1 row in the capability matrix from Planned to
+     shipped.
+4. `CHANGELOG.md`:
+   - New `[0.17.0]` entry with the M16.1 line items.
+5. Push every commit to origin immediately. Include the SHA, log
+   line, and `git status` snapshot in each gate report.
+
+**Commit message:** `docs: close out M16.1 (PLAN, IMPROVEMENT_GUIDE, ROADMAP, CHANGELOG)`
+
+---
+
+## Invariants checklist (re-verify before each commit)
+
+- [ ] No em dashes in any new prose or code comment touched by this
+      PR.
+- [ ] Pure-Python core remains dolfinx-free.
+- [ ] Constant-mobility path is bit-identical to v0.16.0 on every
+      benchmark.
+- [ ] Slotboom primary unknowns retained; no SUPG / streamline
+      diffusion (ADR 0004).
+- [ ] `make_scaling_from_config` still on every solve path.
+- [ ] No PETSc / UFL types leak into `kronos_server` public API.
+- [ ] Schema bumped per minor (2.0.0 to 2.1.0); v2.0.0 inputs still
+      validate.
+- [ ] MMS rate gate L2 >= 1.99 and H1 >= 0.99 active in
+      `scripts/run_verification.py`.
+- [ ] Coverage gate holds at 95.
+
+## Anti-goals
+
+- Do not start M16.2 (Lombardi) in this PR. Surface mobility is its
+  own PR with its own MMS variant.
+- Do not change anything in `semi/bcs.py`, `semi/scaling.py`, or
+  `semi/runners/equilibrium.py`. The mobility dispatch goes through
+  the bias_sweep runner and the DD form builder.
+- Do not introduce a `mu_n` / `mu_p` field as a new primary unknown.
+  Caughey-Thomas is closed-form; it does not add unknowns.
+- Do not lower the MMS rate gate to "passes on the coarse mesh".
+  The gate is L2 >= 1.99 and H1 >= 0.99 at the finest pair, every
+  block. If a rate degrades, the implementation has a bug.
+- Do not bundle this PR with the M14.2.x backlog or with M16.2
+  through M16.7. Those are separate PRs.
+
+## Stop conditions
+
+You are done with this prompt when:
+
+1. The M16.1 PR is opened on branch `dev/m16.1-caughey-thomas`.
+2. Both acceptance tests in `docs/IMPROVEMENT_GUIDE.md` § M16.1
+   are green in CI.
+3. Acceptance test 3 (every existing benchmark with constant
+   mobility produces bit-identical results to v0.16.0) is gated by
+   the existing benchmark CI matrix; confirm in the PR description
+   that the matrix passed.
+4. PLAN.md, IMPROVEMENT_GUIDE.md, ROADMAP.md, and CHANGELOG.md
+   reflect the close-out.
+5. The package version has bumped 0.16.0 to 0.17.0 in
+   `pyproject.toml` and `semi/__init__.py`.
+
+## PR description template
+
+```
+## Summary
+
+M16.1: Caughey-Thomas field-dependent mobility, the first
+physics-completeness slice of the M16 umbrella. Closed-form,
+no new unknowns, no change to Slotboom primary form.
+
+Schema additive minor bump v2.0.0 to v2.1.0
+(physics.mobility.model dispatch, default "constant"). Constant
+branch is bit-identical to v0.16.0.
+
+New benchmark: diode_velsat_1d demonstrates the >5% divergence
+at V_F = 0.9 V and <1% convergence at V_F = 0.5 V between
+constant and Caughey-Thomas mobility on a 1D pn diode.
+
+New MMS variant: gradient-dependent mobility manufactured
+solution. Finest-pair L2 rate >= 1.99 and H1 rate >= 0.99 on
+each block.
+
+## Acceptance tests
+
+(Both are in docs/IMPROVEMENT_GUIDE.md § M16.1.)
+
+- [x] A1: scripts/run_verification.py mms_dd caughey_thomas
+      variant L2 >= 1.99 finest-pair
+- [x] A2: scripts/run_benchmark.py diode_velsat_1d divergence
+      and convergence verifier passes
+- [x] A3: every existing benchmark with constant mobility is
+      bit-identical to v0.16.0
+
+## Test plan
+
+- [ ] ruff check semi/ tests/
+- [ ] pytest tests/
+- [ ] pytest --cov=semi --cov-fail-under=95
+- [ ] python scripts/run_verification.py all
+- [ ] docker compose run --rm benchmark diode_velsat_1d
+- [ ] docker compose run --rm benchmark mosfet_2d
+      (Pao-Sah, M14.3 verifier; constant mu still passes)
+- [ ] docker compose run --rm benchmark pn_1d_bias
+      (constant mu, bit-identical)
+```
+
+## Hand-off
+
+When M16.1 lands and is reviewed, the next pickup is M16.2
+(Lombardi surface mobility), authored at the time by the
+contributor in the same shape as this prompt. Subsequent
+milestones (M16.3 through M16.7, M19, M19.1, M20) each ship as
+their own PR with their own starter prompt; the shape is
+established by `docs/M14_3_STARTER_PROMPT.md` and this file.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,9 +4,11 @@ kronos-semi is a FEniCSx-based finite-element semiconductor device simulator tha
 
 ## Capability matrix
 
-All milestones M1 through M14.2 have shipped as of v0.14.1. The table
+All milestones M1 through M15 have shipped as of v0.15.0. The table
 below is the current state; see the Delivery history section for
-per-milestone details.
+per-milestone details. Planned milestones (M14.3, M16, M19, M20)
+have explicit acceptance tests in
+[`docs/IMPROVEMENT_GUIDE.md`](IMPROVEMENT_GUIDE.md).
 
 | Capability | Dimensions | Status | Verifier |
 |---|---|---|---|
@@ -22,14 +24,53 @@ per-milestone details.
 | Result artifact writer + manifest (M9) | n/a | shipped | semi-run CLI; manifest.v1.json schema |
 | HTTP server POST /solve, GET /runs/{id} (M10) | n/a | shipped | integration tests; WebSocket progress |
 | Schema versioning + UI-facing companion (M11) | n/a | shipped | schema_version gate; SCHEMA_SUPPORTED_MINOR |
-| Mesh input beyond axis-aligned boxes (M12) | 2D | shipped | MOSFET 2D verifier within ±20% |
+| Mesh input beyond axis-aligned boxes (M12) | 2D | shipped | MOSFET 2D verifier within ±20% (qualitative) |
 | Transient solver BDF1/BDF2 Slotboom (M13/M13.1) | 1D | shipped | steady-state-limit + BDF rate + pn_1d_turnon (5%) |
 | AC small-signal analysis (M14) | 1D / 2D | shipped | RC benchmark within 0.4% of analytical C_dep |
 | Differential capacitance via AC admittance (M14.1) | 2D | shipped | mos_cap_ac vs mos_cv on Q_gate (byte-identical) |
 | Axisymmetric (cylindrical) 2D MOSCAP (M14.2) | 2D | shipped | schema 1.3.0; LF/HF C-V vs Hu Fig. 5-18 analytical |
+| GPU linear-solver path (M15) | n/a | shipped | schema 1.4.0; pn_1d psi within 1e-8 vs CPU; >=5x linear-solve speedup at 500k DOFs |
 | Test suite | pure + FEM | shipped | 328+ tests, coverage >= 92% (CI gate) |
 | V&V | 10 studies | shipped | 62/62 PASS |
 | CI | pure-python + lint + docker-fem (parallelized) | shipped | green on main |
+| Housekeeping (strict schema, XDMF ingest, Pao-Sah mosfet_2d, dead SG removal) (M14.3) | n/a | Planned | per-deliverable acceptance in IMPROVEMENT_GUIDE.md |
+| Caughey-Thomas field-dependent mobility (M16.1) | 1D / 2D / 3D | Planned | MMS L2 >= 1.99; diode_velsat_1d divergence-vs-convergence verifier |
+| Lombardi surface mobility (M16.2) | 2D / 3D | Planned | mosfet_2d Sah-Pao within 10% in inversion strong-field window |
+| Auger recombination (M16.3) | 1D / 2D | Planned | diode_auger_1d analytical match within 5% at high injection |
+| Fermi-Dirac statistics (M16.4) | 1D / 2D | Planned | diode_fermi_dirac_1d FD vs scipy reference within 1e-3 |
+| Schottky contacts (M16.5) | 1D / 2D | Planned | schottky_1d thermionic-emission within 10% from V_F = 0.1 to 0.5 V |
+| BBT and TAT tunneling (M16.6) | 1D | Planned | zener_1d Kane reverse-bias breakdown within 20% from V_R = 4 to 8 V |
+| Time-varying transient contact voltage (M16.7) | 1D / 2D | Planned | audit case 06 transient FFT vs AC sweep agreement within 5% |
+| Heterojunctions (M17) | 2D | Planned | hemt_2d 2DEG sheet density within 15% of self-consistent reference |
+| 3D MOSFET benchmark (M19) | 3D | Planned | Pao-Sah within 25% (linear); velsat within 30% (saturation); >=5x GPU speedup at 500k DOFs |
+| MPI parallel benchmark (M19.1) | 3D | Planned | mosfet_3d under mpiexec -n {1,2,4} same I_D within 1e-8; n=4 vs n=1 speedup >=2.5x |
+| HTTP server hardening (M20) | n/a | Planned | unauthenticated POST /solve returns 401; authenticated rate-limited 429 on overrun |
+
+## Honest gap
+
+Three things the engine still does not do well, called out at the top
+of this document so a reviewer hits them first instead of digging
+through the milestone history.
+
+The 3D semiconductor coverage is thin. The shipped 3D benchmarks are
+the doped resistor (M7) and a pure-Poisson box (the M15 GPU
+acceptance test). There is no real 3D semiconductor device. M19
+closes this gap with a 3D MOSFET benchmark on a gmsh-sourced
+unstructured mesh, run on both CPU-MUMPS and GPU-AMGX backends; M19
+depends on M16.1 (Caughey-Thomas mobility) so saturation has any
+meaning.
+
+The physics catalogue is incomplete in three ways that matter for any
+quantitative TCAD comparison: (1) carrier statistics are Boltzmann
+throughout, which is wrong above ~1e19 cm^-3 (every modern MOSFET
+source/drain extension); (2) contacts are ohmic or ideal-gate only,
+with no Schottky thermionic-emission or thermionic-field-emission
+boundary conditions; (3) recombination is SRH only, with no Auger,
+no band-to-band tunneling, and no trap-assisted tunneling. M16.1
+through M16.7 each ship one of these as its own PR with a numerical
+acceptance test against an analytical or external reference; the
+order is dictated by physical dependencies (Fermi-Dirac before BBT,
+Caughey-Thomas before Lombardi).
 
 ## Scope vs. COMSOL Semiconductor Module
 
@@ -51,14 +92,29 @@ analysis and axisymmetric (cylindrical) 2D devices:
 - Differential capacitance via AC admittance (M14.1)
 - Axisymmetric (cylindrical) 2D devices, MOSCAP LF/HF C-V (M14.2)
 
-**Explicitly out of scope (post-submission stretch goals, M15–M17 planned):**
+**Explicitly out of scope today (M14.3 housekeeping, M16 physics
+completeness, M17 heterojunctions, M19 3D MOSFET, M19.1 MPI, M20
+server hardening planned):**
+
+- Strict-mode input schema with `additionalProperties: false`,
+  XDMF mesh ingest, Pao-Sah analytical reference for the
+  `mosfet_2d` verifier, dead Scharfetter-Gummel primitives
+  (M14.3 housekeeping)
 - Caughey-Thomas / Lombardi field-dependent mobility (M16.1, M16.2)
 - Auger and radiative recombination (M16.3)
-- Fermi-Dirac statistics — Boltzmann throughout (M16.4)
-- Band-to-band / trap-assisted tunneling (M16.6)
-- Heterojunctions (M17)
+- Fermi-Dirac statistics: Boltzmann throughout, valid below ~1e19
+  cm^-3 (M16.4)
 - Schottky contacts (M16.5)
-- Full FinFET / 3D transistor geometries (depends on M15 GPU)
+- Band-to-band / trap-assisted tunneling (M16.6)
+- Time-varying transient contact voltage (M16.7; closes audit
+  case 06)
+- Heterojunctions, position-dependent chi(x) and Eg(x) (M17;
+  depends on M16.4)
+- 3D MOSFET on a gmsh-sourced unstructured mesh (M19; depends on
+  M16.1 and M14.3)
+- MPI parallel orchestration in the runners (M19.1; depends on
+  M19)
+- HTTP server auth, rate limiting, API keys (M20)
 
 ## JSON input contract
 
@@ -670,15 +726,49 @@ contributors and reviewers know the intended direction.
     inversion regimes.
 - **Dependencies:** M14.1.
 
+## Deferred
+
+These items remain in-tree as named follow-ups but are not on the
+critical path. They are documented here, with the milestone that
+supersedes them, so that a reviewer scanning for "what is left of
+M14.2" finds the answer in one place.
+
+- **M14.2.x: Cartesian-2D MOSCAP variant and rigorous gate-driven
+  HF C-V method.** Originally tracked in
+  [`PLAN.md`](../PLAN.md) §Backlog and on the README capability
+  matrix. Superseded for practical purposes by M16.4 (Fermi-Dirac;
+  the rigorous HF C-V formulation depends on FD-corrected statistics
+  at the high doping that makes HF dispersion physically meaningful)
+  and M19 (3D MOSFET; the same multi-region MOSCAP infrastructure
+  exercised on a more important device than a 2D MOSCAP variant).
+  If a contributor still wants to ship the Cartesian-2D MOSCAP
+  variant in isolation, the work is bounded (~2 days) and can be
+  picked up after M14.3 lands; the rigorous HF C-V should not be
+  attempted before M16.4.
+- **Physics validation suite, Phase 2 (Sze, Nicollian-Brews).**
+  Phase 1 is closed. Case 06 (transient FFT vs AC sweep) is the
+  M16.7 deliverable; the rest (cases 01-05) are
+  internal-consistency checks that pass and were never load-bearing
+  on external references.
+
 ## Forward-looking
 
-See `PLAN.md` for the active "Next task" and milestone progression.
-See `docs/IMPROVEMENT_GUIDE.md` for the full milestone specs for M15
-(GPU / solver acceleration), M16 (physics additions: field-dependent
-mobility, Fermi-Dirac, additional recombination), and M17
-(heterojunctions).
+See [`PLAN.md`](../PLAN.md) for the active "Next task" and milestone
+progression. See
+[`docs/IMPROVEMENT_GUIDE.md`](IMPROVEMENT_GUIDE.md) for the full
+milestone specs:
 
-This file (`ROADMAP.md`) is the "what does this project do" document
-and is updated when milestones merge. `PLAN.md` tracks active work.
-`IMPROVEMENT_GUIDE.md` defines the acceptance criteria for future
-milestones.
+- M14.3: housekeeping (the next shipping PR, picked up via
+  [`docs/M14_3_STARTER_PROMPT.md`](M14_3_STARTER_PROMPT.md)).
+- M16.1 through M16.7: physics-completeness sub-milestones, each its
+  own PR. M16.1 (Caughey-Thomas) starts via
+  [`docs/M16_1_STARTER_PROMPT.md`](M16_1_STARTER_PROMPT.md).
+- M17: heterojunctions (depends on M16.4).
+- M19: 3D MOSFET capstone (depends on M16.1, M14.3).
+- M19.1: MPI parallel orchestration (depends on M19).
+- M20: HTTP server hardening (independent).
+
+This file (`ROADMAP.md`) is the "what does this project do"
+document and is updated when milestones merge. `PLAN.md` tracks
+active work. `IMPROVEMENT_GUIDE.md` defines the acceptance criteria
+for future milestones.


### PR DESCRIPTION
## Summary

Doc-only PR. Encodes the post-M15 priorities derived from an external
code review into PLAN, IMPROVEMENT_GUIDE, ROADMAP, and CHANGELOG, and
ships two ready-to-paste per-milestone starter prompts so the next
contributor can pick up M14.3 or M16.1 with full self-gating.

The external review identified five weaknesses on `main` after M15
shipped:

1. The repo's GitHub-rendered `README.md` does not match `main` (the
   landing page still shows v0.1.0 framing). The on-disk copy is
   correct.
2. The 3D coverage is the doped resistor and a pure-Poisson box; no
   real 3D semiconductor device.
3. The 2D MOSFET (`benchmarks/mosfet_2d`) has a qualitative verifier
   with no analytical reference.
4. The IMPROVEMENT_GUIDE's M16 / M17 entries were sketches, not
   contracts. Each Tier 1 physics model needed an explicit acceptance
   test with numbers.
5. Production-hardening gaps (`additionalProperties: false` not
   enforced; HTTP `# TODO` for auth; XDMF mesh ingest is
   `NotImplementedError`; transient runner accepts no `V(t)`; ~792
   LOC of dead Scharfetter-Gummel primitives in `semi/fem/`) were
   scattered across CHANGELOG, code comments, and audit-suite skips.

This PR encodes the response to all five into the planning docs:

- **M14.3 (new):** the housekeeping PR that closes 1, 3, parts of 5
  (XDMF ingest, strict schema, dead SG removal) cheaply before M16
  physics work starts.
- **M16.1 through M16.7 (rewritten / added):** each Tier 1 physics
  model gets its own milestone with Why / Deliverable / Acceptance /
  Dependencies and a numerical or analytical acceptance test. M16.7
  (time-varying transient `V(t)`) closes the audit case 06 skip.
- **M19 (new):** 3D MOSFET capstone, the visible answer to weakness 2.
- **M19.1 (new):** MPI parallel benchmark, dependency of M19 at scale.
- **M20 (new):** HTTP server hardening, closes the `# TODO(M10+)`.
- **M17 (rewritten):** four-subsection format with concrete benchmark
  and MMS acceptance.
- **ROADMAP.md** gained an "Honest gap" section calling out the three
  remaining weaknesses a reviewer should hit first; M14.2.x moved to
  a new "Deferred" section with a note it is superseded by M16.4
  and M19.

No engine code changed; coverage gate untouched; CI runs only the
pure-Python and lint jobs because no FEM file moved.

## Files changed

- `PLAN.md`: "Next task" now names M14.3 explicitly; backlog
  rewritten; Phase 0 entry appended to "Completed work log"; current
  state mentions the roadmap refresh.
- `docs/IMPROVEMENT_GUIDE.md`: §1 refreshed to v0.15.0; M14 / M14.1 /
  M14.2 status badges grew CHANGELOG anchors; new milestones M14.3,
  M16.1-M16.7, M19, M19.1, M20 each with the four-subsection format;
  M17 rewritten in the same shape; §9 changelog appended.
- `docs/ROADMAP.md`: capability matrix updated with Planned rows for
  the new milestones; new "Honest gap" section; new "Deferred"
  section for M14.2.x; "Scope vs COMSOL" out-of-scope list updated.
- `docs/M14_3_STARTER_PROMPT.md` (new): ready-to-paste prompt for
  the next PR, in the shape of `M9_STARTER_PROMPT.md` and
  `M15_STARTER_PROMPT.md`.
- `docs/M16_1_STARTER_PROMPT.md` (new): ready-to-paste prompt for
  the first physics-completeness PR.
- `CHANGELOG.md`: `[Unreleased]` gains a Documentation subsection
  summarizing the refresh; no version bump.

## Acceptance tests (Section 0.6)

- [x] `ruff check semi/ tests/` green
- [x] `pytest tests/` green: 295 passed, 26 skipped, 6 deselected
- [x] `python tests/check_analytical_math.py` green
- [x] em-dash check on text I added: 0 em dashes introduced
- [ ] em-dash grep across all of `docs/`, `PLAN.md`, `CHANGELOG.md`,
      `README.md` returns nothing: **241 pre-existing em dashes
      remain** (see Questions for review below)

## Test plan

- [x] All sanity checks above
- [ ] Reviewer to confirm the IMPROVEMENT_GUIDE acceptance tests
      match the spec in the originating prompt
- [ ] Reviewer to confirm the M14.3 starter prompt is a clean
      handoff (any contributor or agent can pick it up cold)

### Questions for review

1. **Pre-existing em dashes.** Invariant 8 (`PLAN.md`) forbids em
   dashes, but `grep -rn '—' docs/ PLAN.md CHANGELOG.md README.md`
   returns 241 hits, all pre-existing in surrounding prose and in
   the convention used by every section heading in
   `IMPROVEMENT_GUIDE.md` § 4 (`### M14 — AC small-signal analysis`,
   etc). I avoided em dashes in all new prose (verified via
   `git diff main`). The strict acceptance from the originating
   prompt is "the em-dash grep must return nothing"; cleaning up
   the 241 hits is out of scope for Phase 0 ("Phase 0 stays small or
   it never ships"). Should the cleanup ride with M14.3 (which
   already touches `README.md` and `docs/PHYSICS.md`), or should it
   be its own bookkeeping PR?

2. **README.md not touched.** The originating prompt lists weakness
   1 (GitHub-rendered README staleness) as part of the M14.3
   deliverable, not Phase 0. I left `README.md` unchanged in this
   PR; M14.3 owns the fix. There is also an untracked
   `prompts/cleanup-readme-and-branches.md` on `main` which is a
   separate worker prompt; I left it untracked because it pre-dates
   this PR.

3. **Schema major bump deferred to M14.3.** The originating prompt
   places the v1 to v2 schema bump (with `additionalProperties:
   false`) under M14.3. Phase 0 does not touch any schema file,
   `semi/schema.py`, or any benchmark JSON; the bump is described
   in `IMPROVEMENT_GUIDE.md` § M14.3 and in
   `docs/M14_3_STARTER_PROMPT.md`.

External review summary: encoded as five M14.3 deliverables plus
the new M16 sub-milestones; the reviewer's pointer is in
`docs/IMPROVEMENT_GUIDE.md` § 1 (Honest current state) and
`docs/ROADMAP.md` § Honest gap.