### PR TITLE
docs: strike M14.3 README re-render deliverable (false positive from PR #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,12 +71,12 @@ shipped with the M15 GPU linear-solver work in v0.15.0 below.
   umbrella (Caughey-Thomas, Lombardi, Auger, Fermi-Dirac, Schottky,
   BBT and TAT) now has an explicit acceptance test with a numerical
   threshold or analytical reference. New milestones added:
-  - **M14.3 Housekeeping** (between M14.2 and M15): re-render the
-    GitHub README, tighten the `mosfet_2d` verifier with a Pao-Sah
-    analytical reference, implement XDMF mesh ingest, strict-mode
-    the input schema with an `additionalProperties: false` major
-    bump, and remove the dead-on-active-path Scharfetter-Gummel
-    primitives in `semi/fem/sg_assembly.py`.
+  - **M14.3 Housekeeping** (between M14.2 and M15): tighten the
+    `mosfet_2d` verifier with a Pao-Sah analytical reference,
+    implement XDMF mesh ingest, strict-mode the input schema with
+    an `additionalProperties: false` major bump, and remove the
+    dead-on-active-path Scharfetter-Gummel primitives in
+    `semi/fem/sg_assembly.py`.
   - **M16.1 through M16.7** (physics completeness, one PR each):
     Caughey-Thomas mobility, Lombardi surface mobility, Auger
     recombination, Fermi-Dirac statistics (gated), Schottky
@@ -106,6 +106,11 @@ shipped with the M15 GPU linear-solver work in v0.15.0 below.
   purposes by M16.4 (Fermi-Dirac) and M19 (3D MOSFET).
 - No engine code changed; coverage gate untouched; no version bump
   (the next bump ships with M14.3).
+- Struck the M14.3 GitHub-rendered README re-render deliverable
+  from IMPROVEMENT_GUIDE, the M14.3 starter prompt, and PLAN. The
+  original observation that motivated it was a cached-render
+  artifact in the external reviewer's tooling; on-disk and
+  on-github.com READMEs have matched main since v0.8.0.
 
 ### Added
 - Axisymmetric (cylindrical) coordinate system support (**schema 1.3.0**).

--- a/PLAN.md
+++ b/PLAN.md
@@ -53,11 +53,10 @@ and passing.
 The post-M15 roadmap was refreshed in the doc-only PR on branch
 `dev/roadmap-refresh-post-m15` (this PR). The refresh encodes the
 findings of an external code review into PLAN, ROADMAP, and
-IMPROVEMENT_GUIDE: the GitHub-rendered README is stale, the 3D coverage
-is thin, the `mosfet_2d` verifier has no analytical reference, the M16
-and M17 entries were sketches not contracts, and the production-
-hardening items (strict schema, XDMF ingest, dead SG primitives, HTTP
-auth) were uncollected. The backlog now contains an explicit
+IMPROVEMENT_GUIDE: the 3D coverage is thin, the `mosfet_2d` verifier
+has no analytical reference, the M16 and M17 entries were sketches
+not contracts, and the production-hardening items (strict schema,
+XDMF ingest, dead SG primitives, HTTP auth) were uncollected. The backlog now contains an explicit
 acceptance test with a numerical threshold or analytical reference for
 every Tier 1 physics model (Caughey-Thomas, Lombardi, Auger,
 Fermi-Dirac, Schottky, BBT/TAT) plus a 3D MOSFET capstone (M19), an
@@ -118,21 +117,18 @@ M15 through M18. Summary:
 **M14.3 Housekeeping PR** on branch `dev/m14.3-housekeeping`. Picked
 up via [`docs/M14_3_STARTER_PROMPT.md`](docs/M14_3_STARTER_PROMPT.md);
 acceptance tests in [`docs/IMPROVEMENT_GUIDE.md`](docs/IMPROVEMENT_GUIDE.md)
-§ M14.3. Five-deliverable scope:
+§ M14.3. Four-deliverable scope:
 
-1. Re-render the GitHub `README.md` so the landing page matches `main`
-   (the on-disk copy is correct; the `github.com` cache, fork shadow,
-   or rendered view is stale at v0.1.0 framing).
-2. Tighten the `mosfet_2d` verifier with a Pao-Sah / square-law
+1. Tighten the `mosfet_2d` verifier with a Pao-Sah / square-law
    analytical reference in the linear regime and a documented 20%
    tolerance window.
-3. Implement the XDMF branch in `semi/mesh.py::_build_from_file` and
+2. Implement the XDMF branch in `semi/mesh.py::_build_from_file` and
    round-trip the resistor benchmark from `box.xdmf` within 1e-12
    relative R.
-4. Strict-mode the input schema (`additionalProperties: false`
+3. Strict-mode the input schema (`additionalProperties: false`
    everywhere), bump the schema major to v2.0.0, ship `schemas/input.v2.json`
    alongside v1, and migrate every benchmark JSON.
-5. Delete `semi/fem/sg_assembly.py` (~792 LOC dead-on-active-path)
+4. Delete `semi/fem/sg_assembly.py` (~792 LOC dead-on-active-path)
    and raise the coverage gate from 92 to 95.
 
 After M14.3 lands, M16.1 (Caughey-Thomas field-dependent mobility) is

--- a/docs/IMPROVEMENT_GUIDE.md
+++ b/docs/IMPROVEMENT_GUIDE.md
@@ -318,23 +318,17 @@ purposes by M16.4 and M19.
 
 ### M14.3: Housekeeping (cheap closes)
 
-**Why.** Five small production-hardening gaps are scattered across the
-codebase: the GitHub-rendered `README.md` does not match `main` (the
-landing page still shows v0.1.0 framing); the `mosfet_2d` verifier is
-qualitative with no analytical reference; `semi/mesh.py::_build_from_file`
-raises `NotImplementedError` for the XDMF branch; the input schema
-does not enforce `additionalProperties: false`; and ~792 LOC of dead-
-on-active-path Scharfetter-Gummel primitives in
-`semi/fem/sg_assembly.py` are not on any code path. Closing them in
-one PR removes the noise floor before M16 physics work starts.
+**Why.** Four small production-hardening gaps are scattered across the
+codebase: the `mosfet_2d` verifier is qualitative with no analytical
+reference; `semi/mesh.py::_build_from_file` raises `NotImplementedError`
+for the XDMF branch; the input schema does not enforce
+`additionalProperties: false`; and ~792 LOC of dead-on-active-path
+Scharfetter-Gummel primitives in `semi/fem/sg_assembly.py` are not on
+any code path. Closing them in one PR removes the noise floor before
+M16 physics work starts.
 
 **Deliverable.**
 
-- Re-render the GitHub `README.md` so the `github.com` landing page
-  matches `main`. The on-disk copy is correct; the visible page is
-  stale. Investigate whether a fork is shadowing the remote, or
-  whether GitHub's render cache is the issue, and force-push or
-  file a support request as appropriate.
 - Tighten the `mosfet_2d` verifier in
   [`scripts/run_benchmark.py`](../scripts/run_benchmark.py). Add a
   Pao-Sah or square-law analytical reference in the linear regime
@@ -368,20 +362,18 @@ one PR removes the noise floor before M16 physics work starts.
 
 **Acceptance tests.**
 
-1. The GitHub-rendered README at the top of the repository page
-   shows v0.15.0 status and the M1-M15 capability matrix.
-2. `python scripts/run_benchmark.py mosfet_2d` exits 0 with the new
+1. `python scripts/run_benchmark.py mosfet_2d` exits 0 with the new
    analytical-reference verifier passing inside the
    [V_T + 0.2, V_T + 0.6] V window at the documented 20% tolerance.
-3. The resistor benchmark loaded from `box.xdmf` (newly-supported
+2. The resistor benchmark loaded from `box.xdmf` (newly-supported
    ingest path) produces R within 1e-12 relative of the same
    benchmark loaded from `box.msh`.
-4. Every benchmark JSON in `benchmarks/` validates as
+3. Every benchmark JSON in `benchmarks/` validates as
    `schema_version: "2.0.0"` with `additionalProperties: false`
    active; an intentional typo (`"voltag"` for `"voltage"`) is
    rejected with a clear error message that names the offending
    field.
-5. `semi/fem/sg_assembly.py` and its dedicated test are gone, the
+4. `semi/fem/sg_assembly.py` and its dedicated test are gone, the
    coverage gate in `pyproject.toml` is 95, and CI is green.
 
 **Dependencies.** None; M14.3 only consolidates known small fixes.

--- a/docs/M14_3_STARTER_PROMPT.md
+++ b/docs/M14_3_STARTER_PROMPT.md
@@ -17,6 +17,12 @@ tests, or the rationale; those live in `docs/IMPROVEMENT_GUIDE.md`
 § M14.3. Read the guide first; this prompt only tells you the order
 in which to execute and which invariants must remain load-bearing.
 
+> **Note:** Phase A was struck after PR #68 landed (the original
+> observation was a cached-render artifact in the external
+> reviewer's tooling, not real staleness; see CHANGELOG `[Unreleased]`
+> for the full retraction). The original phase lettering (B, C, D, E)
+> is preserved below for traceability with PR #68's history.
+
 ## Required reading (do not skip; ~30 minutes)
 
 Per `CONTRIBUTING.md` "Before you start", in order:
@@ -75,43 +81,10 @@ Per `CONTRIBUTING.md` "Before you start", in order:
   gate drops below 95, add unit tests rather than relax the
   threshold.
 
-## Five phases, one commit per phase
+## Four phases, one commit per phase
 
 Do not bundle. After each phase, run `ruff check semi/ tests/` and
 `pytest tests/`. Do not advance with red tests.
-
----
-
-### Phase A: GitHub-rendered README (the visible problem)
-
-No code. The `README.md` in this tree is correct; the GitHub landing
-page is stale. Investigate and fix.
-
-1. View the README at `https://github.com/rwalkerlewis/kronos-semi`
-   in a browser (incognito to bypass any local cache). Confirm the
-   landing page does not match `main`.
-2. Diagnose the cause. Three plausible explanations:
-   - A fork is shadowing the repo at the user/org level (rare).
-   - GitHub's render cache is stuck (common after a long-running
-     branch was force-pushed; fixed by editing `README.md` with a
-     trivial whitespace change and pushing).
-   - The displayed README is a `default-branch` mismatch (the
-     `main` branch is the default but the rendered page is reading
-     a different branch).
-3. Apply the smallest fix that closes the visible problem. If a
-   trivial whitespace push refreshes the cache, do that. If the
-   default-branch setting is wrong, fix it via the GitHub web UI
-   and document in the PR description. If a fork shadows the repo,
-   file a GitHub support request and link it from the PR; do not
-   block the rest of M14.3 on it.
-4. Take a screenshot of the corrected landing page; attach it to
-   the PR description as evidence.
-
-**Acceptance test 1**: the GitHub-rendered README at the top of the
-repository page shows v0.15.0 status and the M1-M15 capability
-matrix.
-
-**Commit message:** `docs: refresh GitHub-rendered README landing page (M14.3)`
 
 ---
 
@@ -319,7 +292,7 @@ is 95, and CI is green.
 You are done with this prompt when:
 
 1. The M14.3 PR is opened on branch `dev/m14.3-housekeeping`.
-2. All five acceptance tests in `docs/IMPROVEMENT_GUIDE.md`
+2. All four acceptance tests in `docs/IMPROVEMENT_GUIDE.md`
    § M14.3 are green in CI.
 3. PLAN.md, IMPROVEMENT_GUIDE.md, ROADMAP.md, and CHANGELOG.md
    reflect the close-out.
@@ -336,7 +309,7 @@ You are done with this prompt when:
 ```
 ## Summary
 
-Housekeeping PR (M14.3) closing five small production-hardening
+Housekeeping PR (M14.3) closing four small production-hardening
 gaps before M16 physics work starts. Doc-only effects on PLAN /
 IMPROVEMENT_GUIDE / ROADMAP / CHANGELOG; engine effects bounded
 to the schema dispatch, the XDMF branch in semi/mesh.py, and the
@@ -346,7 +319,6 @@ Schema major bump v1 to v2 (additionalProperties: false). Both
 schemas coexist; v1 inputs log a DeprecationWarning.
 
 Closes:
-- GitHub-rendered README staleness (Phase A)
 - mosfet_2d qualitative verifier (Phase B)
 - semi/mesh.py XDMF NotImplementedError (Phase C)
 - input schema additionalProperties: false enforcement (Phase D)
@@ -354,13 +326,12 @@ Closes:
 
 ## Acceptance tests
 
-(All five are in docs/IMPROVEMENT_GUIDE.md § M14.3.)
+(All four are in docs/IMPROVEMENT_GUIDE.md § M14.3.)
 
-- [x] A1: GitHub-rendered README at v0.15.0
-- [x] A2: scripts/run_benchmark.py mosfet_2d Pao-Sah verifier
-- [x] A3: resistor benchmark from box.xdmf vs box.msh within 1e-12
-- [x] A4: every benchmark JSON validates as v2.0.0; typo rejected
-- [x] A5: SG primitives gone; coverage gate 95; CI green
+- [x] A1: scripts/run_benchmark.py mosfet_2d Pao-Sah verifier
+- [x] A2: resistor benchmark from box.xdmf vs box.msh within 1e-12
+- [x] A3: every benchmark JSON validates as v2.0.0; typo rejected
+- [x] A4: SG primitives gone; coverage gate 95; CI green
 
 ## Test plan
 


### PR DESCRIPTION
## Summary

Doc-only PR removing the M14.3 GitHub-rendered README re-render
deliverable that landed in PR #68's roadmap refresh. The original
observation was a stale rendering artifact in the external
reviewer's tooling, not real staleness on github.com. The on-disk
README and the github.com-rendered README both match `main` and
have been current since v0.8.0 — the deliverable describes work
that does not exist.

## Changes

- `docs/IMPROVEMENT_GUIDE.md` § M14.3: dropped the README clause
  from the "Why" paragraph (five gaps to four), removed the
  "Re-render the GitHub `README.md`..." bullet from "Deliverable",
  and removed acceptance test 1 (renumbered the remaining four).
- `docs/M14_3_STARTER_PROMPT.md`: deleted Phase A (GitHub-rendered
  README, the visible problem) including its acceptance-test-1
  block and commit-message line. Original phase lettering (B, C, D,
  E) preserved for traceability with PR #68; "Five phases" updated
  to "Four phases"; PR description template and stop conditions
  re-aligned (A1-A4 instead of A1-A5).
- `PLAN.md` § Next task: "Five-deliverable scope" -> "Four-deliverable
  scope"; dropped the README re-render summary line; removed the
  README-stale clause from the post-M15 refresh paragraph.
- `CHANGELOG.md` `[Unreleased]`: dropped the README re-render
  mention from the M14.3 housekeeping description and appended a
  retraction bullet citing the cached-render-artifact root cause
  and the v0.8.0-onward parity.

## Sanity checks

- [x] `ruff check semi/ tests/` — All checks passed
- [x] `pytest tests/` (in dev container) — 334 passed, 5 skipped, 6 deselected
- [x] `python tests/check_analytical_math.py` — All sanity checks complete
- [x] `grep -n "GitHub-rendered README\|github-rendered README\|render the GitHub" docs/IMPROVEMENT_GUIDE.md docs/M14_3_STARTER_PROMPT.md PLAN.md` — empty (the only remaining hit repo-wide is the retraction bullet in `CHANGELOG.md`, which is intentional)

## Out-of-scope finding

None. The fifth grep target (`re-render the GitHub`) survived only
in the changelog retraction bullet itself and in the `[Unreleased]`
M14.3 description, which I updated for consistency since it would
otherwise self-contradict the new retraction line.

## Hand-off

After this lands, M14.3 itself is the next PR in flight, picked up
from the corrected `docs/M14_3_STARTER_PROMPT.md`. The starter
prompt now opens with a `> Note:` callout referencing this strike
so the next contributor knows the original lettering (B, C, D, E)
is intentional rather than a renumbering bug.